### PR TITLE
feat: Add Wallhaven API key management via environment variable

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2934,8 +2934,10 @@
     "no-wallpaper": "No wallpaper found.",
     "panel": {
       "apikey": {
+        "env-active": "API key is managed by the NOCTALIA_WALLHAVEN_API_KEY environment variable.",
         "help": "An API key is required to access NSFW content.",
         "label": "API Key",
+        "managed-by-env": "Managed by environment variable",
         "placeholder": "Enter your Wallhaven API Key"
       },
       "apply-all-monitors": {

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2934,10 +2934,9 @@
     "no-wallpaper": "No wallpaper found.",
     "panel": {
       "apikey": {
-        "env-active": "API key is managed by the NOCTALIA_WALLHAVEN_API_KEY environment variable.",
         "help": "An API key is required to access NSFW content.",
         "label": "API Key",
-        "managed-by-env": "Managed by environment variable",
+        "managed-by-env": "Managed via NOCTALIA_WALLHAVEN_API_KEY environment variable.",
         "placeholder": "Enter your Wallhaven API Key"
       },
       "apply-all-monitors": {

--- a/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
+++ b/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
@@ -131,9 +131,7 @@ Popup {
         id: apiKeyInput
         Layout.fillWidth: true
         enabled: !WallhavenService.apiKeyManagedByEnv
-        placeholderText: WallhavenService.apiKeyManagedByEnv
-          ? I18n.tr("wallpaper.panel.apikey.managed-by-env")
-          : I18n.tr("wallpaper.panel.apikey.placeholder")
+        placeholderText: WallhavenService.apiKeyManagedByEnv ? I18n.tr("wallpaper.panel.apikey.managed-by-env") : I18n.tr("wallpaper.panel.apikey.placeholder")
         text: WallhavenService.apiKeyManagedByEnv ? "" : (Settings.data.wallpaper.wallhavenApiKey || "")
 
         // Fix for password echo mode
@@ -151,10 +149,8 @@ Popup {
       }
 
       NText {
-        text: WallhavenService.apiKeyManagedByEnv
-          ? I18n.tr("wallpaper.panel.apikey.env-active")
-          : I18n.tr("wallpaper.panel.apikey.help")
-        color: WallhavenService.apiKeyManagedByEnv ? Color.mPrimary : Color.mOnSurfaceVariant
+        text: I18n.tr("wallpaper.panel.apikey.help")
+        color: Color.mOnSurfaceVariant
         pointSize: Style.fontSizeS
         wrapMode: Text.WordWrap
         Layout.fillWidth: true

--- a/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
+++ b/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
@@ -11,7 +11,15 @@ Popup {
 
   property ShellScreen screen
 
-  width: Math.max(440, Math.round(contentColumn.implicitWidth + (Style.marginL * 2)))
+  // Measure the ENV placeholder text at current font settings
+  TextMetrics {
+    id: envPlaceholderMetrics
+    text: I18n.tr("wallpaper.panel.apikey.managed-by-env")
+    font.pointSize: Style.fontSizeM
+  }
+
+  // Dynamic width: use measured ENV placeholder width + input padding, or fallback to 440
+  width: Math.max(440, Math.round(envPlaceholderMetrics.width + (Style.marginL * 4)), Math.round(contentColumn.implicitWidth + (Style.marginL * 2)))
   height: Math.round(contentColumn.implicitHeight + (Style.marginL * 2))
   padding: Style.marginL
   modal: true

--- a/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
+++ b/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
@@ -130,8 +130,11 @@ Popup {
       NTextInput {
         id: apiKeyInput
         Layout.fillWidth: true
-        placeholderText: I18n.tr("wallpaper.panel.apikey.placeholder")
-        text: Settings.data.wallpaper.wallhavenApiKey || ""
+        enabled: !WallhavenService.apiKeyManagedByEnv
+        placeholderText: WallhavenService.apiKeyManagedByEnv
+          ? I18n.tr("wallpaper.panel.apikey.managed-by-env")
+          : I18n.tr("wallpaper.panel.apikey.placeholder")
+        text: WallhavenService.apiKeyManagedByEnv ? "" : (Settings.data.wallpaper.wallhavenApiKey || "")
 
         // Fix for password echo mode
         Component.onCompleted: {
@@ -141,13 +144,17 @@ Popup {
         }
 
         onEditingFinished: {
-          Settings.data.wallpaper.wallhavenApiKey = text;
+          if (!WallhavenService.apiKeyManagedByEnv) {
+            Settings.data.wallpaper.wallhavenApiKey = text;
+          }
         }
       }
 
       NText {
-        text: I18n.tr("wallpaper.panel.apikey.help")
-        color: Color.mOnSurfaceVariant
+        text: WallhavenService.apiKeyManagedByEnv
+          ? I18n.tr("wallpaper.panel.apikey.env-active")
+          : I18n.tr("wallpaper.panel.apikey.help")
+        color: WallhavenService.apiKeyManagedByEnv ? Color.mPrimary : Color.mOnSurfaceVariant
         pointSize: Style.fontSizeS
         wrapMode: Text.WordWrap
         Layout.fillWidth: true
@@ -295,8 +302,8 @@ Popup {
             nsfwToggle.checked = purityRow.getPurityValue(2);
           }
           function onWallhavenApiKeyChanged() {
-            // If API key is removed, disable NSFW
-            if (!Settings.data.wallpaper.wallhavenApiKey && nsfwToggle.checked) {
+            // If API key is removed (and no ENV key), disable NSFW
+            if (!WallhavenService.apiKey && nsfwToggle.checked) {
               nsfwToggle.toggled(false);
             }
           }
@@ -410,7 +417,7 @@ Popup {
         Item {
           Layout.preferredWidth: nsfwCheckboxRow.implicitWidth
           Layout.preferredHeight: nsfwCheckboxRow.implicitHeight
-          visible: Settings.data.wallpaper.wallhavenApiKey !== ""
+          visible: WallhavenService.apiKey !== ""
 
           RowLayout {
             id: nsfwCheckboxRow

--- a/Services/UI/WallhavenService.qml
+++ b/Services/UI/WallhavenService.qml
@@ -28,7 +28,10 @@ Singleton {
   property string resolutions: "" // e.g., "1920x1080,1920x1200"
   property string ratios: "" // e.g., "16x9,16x10"
   property string colors: "" // Color hex codes
-  property string apiKey: "" // User API key for NSFW access
+  // API Key Priority: Environment Variable > Local Settings
+  readonly property string envApiKey: Quickshell.env("NOCTALIA_WALLHAVEN_API_KEY") || ""
+  readonly property string apiKey: envApiKey !== "" ? envApiKey : (Settings.data.wallpaper.wallhavenApiKey || "")
+  readonly property bool apiKeyManagedByEnv: envApiKey !== ""
 
   // Signals
   signal searchCompleted(var results, var meta)
@@ -62,7 +65,9 @@ Singleton {
     }
 
     params.push("categories=" + categories);
-    params.push("purity=" + purity);
+    // Safety: Force SFW if no purity selected to prevent API error
+    var safePurity = (purity === "000") ? "100" : purity;
+    params.push("purity=" + safePurity);
     params.push("sorting=" + sorting);
     params.push("order=" + order);
 


### PR DESCRIPTION
## Motivation
This allows for the Wallhaven API key to be set as an environment variable by the compositor, avoiding storage of it in the settings.json file. If someone wants to include their settings.json in a dotfiles git repository, it's much easier to do it this way to avoid publishing the API key. 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
I tested by removing the key from my settings and then defining an environment variable in a secrets file that was sourced by Hyprland. I tested all purity settings and they worked as expected.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1322" height="989" alt="image" src="https://github.com/user-attachments/assets/b1cd12e2-921c-4ffe-b123-edb125ea3273" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
