### PR TITLE
fix: Retain current page when re-initializing or switching to Wallhaven wallpaper source.

### DIFF
--- a/Modules/Panels/Wallpaper/WallpaperPanel.qml
+++ b/Modules/Panels/Wallpaper/WallpaperPanel.qml
@@ -494,9 +494,10 @@ SmartPanel {
                               panelContent.updateWallhavenResolution();
 
                               // If the view is already initialized, trigger a new search when switching to it
+                              // Preserve current page when switching back to Wallhaven source
                               if (wallhavenView && wallhavenView.initialized && !WallhavenService.fetching) {
                                 wallhavenView.loading = true;
-                                WallhavenService.search(Settings.data.wallpaper.wallhavenQuery || "", 1);
+                                WallhavenService.search(Settings.data.wallpaper.wallhavenQuery || "", WallhavenService.currentPage);
                               }
                             }
                           }
@@ -1048,8 +1049,9 @@ SmartPanel {
         }
 
         // Now check if we can actually search (fetching check is in WallhavenService.search)
+        // Use persisted currentPage to maintain state across window reopening
         loading = true;
-        WallhavenService.search(Settings.data.wallpaper.wallhavenQuery || "", 1);
+        WallhavenService.search(Settings.data.wallpaper.wallhavenQuery || "", WallhavenService.currentPage);
       }
     }
 


### PR DESCRIPTION
## Motivation
This prevents the browse page in the wallpaper chooser from resetting back to page 1 unless you click the refresh button or change the search query. On single monitor setups, it's often beneficial to close the wallpaper chooser temporarily to see what a wallpaper looks like, but doing that when you're on page 72 of the results and having it reset back to page 1 every time it's reopened after viewing the current wallpaper can get pretty frustrating.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated