### PR TITLE
feat(media): add basic implementation for progress fill on media widget

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3784,6 +3784,10 @@
           "description": "Show Num Lock state",
           "label": "Show Num Lock"
         },
+        "show-progress": {
+          "description": "Fill the widget background to show playback progress",
+          "label": "Show Playback Progress"
+        },
         "show-scroll-lock": {
           "description": "Show Scroll Lock state",
           "label": "Show Scroll Lock"

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -415,12 +415,6 @@ namespace {
     return LayerShellAnchor::Top | LayerShellAnchor::Left | LayerShellAnchor::Right;
   }
 
-  ColorSpec withOpacity(const ColorSpec& color, float opacity) {
-    ColorSpec out = color;
-    out.alpha = std::clamp(out.alpha * std::clamp(opacity, 0.0F, 1.0F), 0.0F, 1.0F);
-    return out;
-  }
-
   // Hover highlight: peak fill alpha of the widget-foreground tint, and the cross-axis inset
   // (logical px, content-scaled) of per-member pills inside capsule groups.
   constexpr float kWidgetHoverFillAlpha = 0.1F;
@@ -1009,7 +1003,7 @@ namespace {
           hasVisibleContent = hasVisibleContent || widget->root()->visible();
           hasCapsuleContent = hasCapsuleContent || widget->shouldShowBarCapsule();
         }
-        const bool hasPaintedFill = resolveColorSpec(withOpacity(run.spec.fill, run.spec.opacity)).a > 0.0F;
+        const bool hasPaintedFill = resolveColorSpec(scaleAlpha(run.spec.fill, run.spec.opacity)).a > 0.0F;
         const bool hasPaintedBorder = run.spec.border.has_value() && resolveColorSpec(*run.spec.border).a > 0.0F;
         run.hasPaintedCapsuleBackground = hasCapsuleContent && (hasPaintedFill || hasPaintedBorder);
 
@@ -2577,7 +2571,7 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
     shell.addChild(
         ui::box({
             .out = &boxPtr,
-            .fill = withOpacity(widget.widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.0F),
+            .fill = scaleAlpha(widget.widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.0F),
             .visible = false,
             .configure = [](Box& box) { box.setZIndex(-1); },
         })
@@ -2687,7 +2681,7 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
       Box* bgPtr = nullptr;
       auto capsuleBg = ui::box({
           .out = &bgPtr,
-          .fill = withOpacity(cap.fill, cap.opacity),
+          .fill = scaleAlpha(cap.fill, cap.opacity),
           .configure = [&cap, scale](Box& bg) {
             if (cap.border.has_value()) {
               bg.setBorder(*cap.border, Style::borderWidth * scale);
@@ -2778,7 +2772,7 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
       Box* bgPtr = nullptr;
       auto capsuleBg = ui::box({
           .out = &bgPtr,
-          .fill = withOpacity(cap.fill, cap.opacity),
+          .fill = scaleAlpha(cap.fill, cap.opacity),
           .configure = [&cap, scale](Box& bg) {
             if (cap.border.has_value()) {
               bg.setBorder(*cap.border, Style::borderWidth * scale);
@@ -2920,7 +2914,7 @@ void Bar::animateWidgetHoverHighlight(BarInstance& instance, Widget& widget, boo
       [&widget, box, fill](float progress) {
         widget.setBarHoverProgress(progress);
         box->setVisible(progress > 0.001F);
-        box->setFill(withOpacity(fill, kWidgetHoverFillAlpha * progress));
+        box->setFill(scaleAlpha(fill, kWidgetHoverFillAlpha * progress));
       },
       {}, box
   );

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -24,11 +24,6 @@ namespace {
   constexpr float kGraphicTerminalHeight = 7.0F;
   constexpr float kGraphicCornerRadius = 3.0F;
 
-  ColorSpec withOpacity(ColorSpec color, float opacity) {
-    color.alpha *= opacity;
-    return color;
-  }
-
   const char* batteryStateGlyph(BatteryState state) {
     if (state == BatteryState::Charging) {
       return "bolt-filled";
@@ -111,7 +106,7 @@ void BatteryWidget::createGraphicMode() {
   container->addChild(
       ui::box({
           .out = &m_bodyBg,
-          .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.3F),
+          .fill = scaleAlpha(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.3F),
       })
   );
 
@@ -124,7 +119,7 @@ void BatteryWidget::createGraphicMode() {
   container->addChild(
       ui::box({
           .out = &m_terminalNub,
-          .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.3F),
+          .fill = scaleAlpha(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.3F),
       })
   );
 
@@ -423,11 +418,11 @@ void BatteryWidget::syncState(Renderer& renderer) {
       m_fillRect->setFill(fgColor);
     }
     if (m_bodyBg != nullptr) {
-      m_bodyBg->setFill(withOpacity(fgColor, 0.3F));
+      m_bodyBg->setFill(scaleAlpha(fgColor, 0.3F));
     }
 
     if (m_terminalNub != nullptr) {
-      m_terminalNub->setFill(withOpacity(fgColor, 0.3F));
+      m_terminalNub->setFill(scaleAlpha(fgColor, 0.3F));
     }
 
     // Animate fill percentage

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <chrono>
 #include <wayland-client-protocol.h>
 
 using namespace mpris;
@@ -220,6 +221,33 @@ void MediaWidget::syncWidgetVisibility(bool hasMedia) {
   }
 }
 
+void MediaWidget::syncProgress() {
+  if (m_progressBar == nullptr) {
+    return;
+  }
+  const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
+  const bool playing = active.has_value() && active->playbackStatus == "Playing";
+  const bool hasLength = active.has_value() && active->lengthUs > 0;
+
+  if (!m_showProgress || !hasLength) {
+    m_progressTimer.stop();
+    return;
+  }
+  const float progress = static_cast<float>(active->positionUs) / static_cast<float>(active->lengthUs);
+  if (std::abs(progress - m_progressBar->progress()) > 0.0005F) {
+    m_progressBar->setProgress(progress);
+    requestRedraw();
+  }
+  if (!playing) {
+    m_progressTimer.stop();
+    return;
+  }
+  const float fillWidth = std::max(1.0F, m_progressBar->width());
+  const auto intervalMs = static_cast<std::int64_t>(
+    std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.F, 1000.0F));
+  m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { syncProgress();});
+}
+
 void MediaWidget::syncState(Renderer& renderer) {
   if (m_art == nullptr || m_label == nullptr) {
     return;
@@ -242,6 +270,7 @@ void MediaWidget::syncState(Renderer& renderer) {
     artUrl = effectiveArtUrl(*active);
   }
 
+  syncProgress();
   const bool textChanged = displayText != m_lastText;
   const bool artChanged = artUrl != m_lastArtUrl;
   const bool playbackChanged = playbackStatus != m_lastPlaybackStatus;

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -28,7 +28,7 @@ MediaWidget::MediaWidget(MprisService* mpris, HttpClient* httpClient, wl_output*
       m_minWidth(static_cast<float>(options.minWidth)), m_artSize(static_cast<float>(options.artSize)),
       m_titleScrollMode(options.titleScrollMode), m_hideWhenNoMedia(options.hideWhenNoMedia),
       m_albumArtOnly(options.albumArtOnly), m_hideAlbumArt(options.hideAlbumArt), m_hideArtist(options.hideArtist),
-      m_artistFirst(options.artistFirst) {}
+      m_artistFirst(options.artistFirst), m_showProgress(options.showProgress) {}
 
 void MediaWidget::create() {
   auto area = ui::inputArea({});
@@ -42,6 +42,20 @@ void MediaWidget::create() {
   });
   m_area = area.get();
 
+  area->addChild(
+    ui::progressBar({
+      .out = &m_progressBar,
+      .fill = colorSpecFromRole(ColorRole::Primary, 0.25F),
+      .track = clearColorSpec(),
+      .visible = false,
+      .participatesInLayout = false,
+      .configure =
+        [](ProgressBar& bar) {
+          bar.setZIndex(-1);
+          bar.setHitTestVisible(false);
+        }
+    })
+);
   area->addChild(
       ui::image({
           .out = &m_art,

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -195,9 +195,12 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
   }
   m_progressBar->setVisible(showProgressFill);
   if (showProgressFill) {
-    const float fillWidth = rootNode->width();
+    // The bar sizes an enabled capsule as content + 2 * padding on the main axis, so widen the fill
+    // by the same padding to span the pill instead of sitting inset within it.
+    const float capsulePad = shouldShowBarCapsule() ? barCapsuleSpec().padding * m_contentScale : 0.0F;
+    const float fillWidth = rootNode->width() + 2.0F * capsulePad;
     const float fillHeight = rootNode->height();
-    m_progressBar->setPosition(0.0F, 0.0F);
+    m_progressBar->setPosition(-capsulePad, 0.0F);
     m_progressBar->setSize(fillWidth, fillHeight);
     m_progressBar->setRadius(std::min(fillWidth, fillHeight) * 0.5F);
   }

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -94,7 +94,7 @@ void MediaWidget::create() {
 
 void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
-  if (rootNode == nullptr || m_art == nullptr || m_label == nullptr || m_emptyGlyph == nullptr) {
+  if (rootNode == nullptr || m_art == nullptr || m_label == nullptr || m_emptyGlyph == nullptr || m_progressBar == nullptr) {
     return;
   }
   syncState(renderer);
@@ -103,6 +103,9 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
   const bool artOnly = isVertical || m_albumArtOnly;
   const float maxLength = std::max(0.0F, m_maxWidth * m_contentScale);
   const float minLength = std::clamp(m_minWidth * m_contentScale, 0.0F, maxLength);
+  const auto progressPlayer = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
+  const bool showProgressFill =
+      m_showProgress && !artOnly && progressPlayer.has_value() && progressPlayer->lengthUs > 0;
 
   m_label->setColor(
       m_lastPlaybackStatus == "Playing" ? widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))
@@ -181,6 +184,14 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
     const float contentWidth = showLabel ? m_label->x() + m_label->width()
                                          : (showArtSlot ? artSize : (showEmptyGlyph ? m_emptyGlyph->width() : 0.0F));
     rootNode->setSize(std::clamp(contentWidth, minLength, maxLength), contentHeight);
+  }
+  m_progressBar->setVisible(showProgressFill);
+  if (showProgressFill) {
+    const float fillWidth = rootNode->width();
+    const float fillHeight = rootNode->height();
+    m_progressBar->setPosition(0.0F, 0.0F);
+    m_progressBar->setSize(fillWidth, fillHeight);
+    m_progressBar->setRadius(std::min(fillWidth, fillHeight) * 0.5F);
   }
 }
 

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -12,8 +12,8 @@
 #include "ui/style.h"
 
 #include <algorithm>
-#include <cmath>
 #include <chrono>
+#include <cmath>
 #include <wayland-client-protocol.h>
 
 using namespace mpris;
@@ -44,19 +44,18 @@ void MediaWidget::create() {
   m_area = area.get();
 
   area->addChild(
-    ui::progressBar({
-      .out = &m_progressBar,
-      .fill = colorSpecFromRole(ColorRole::Primary, 0.25F),
-      .track = clearColorSpec(),
-      .visible = false,
-      .participatesInLayout = false,
-      .configure =
-        [](ProgressBar& bar) {
-          bar.setZIndex(-1);
-          bar.setHitTestVisible(false);
-        }
-    })
-);
+      ui::progressBar(
+          {.out = &m_progressBar,
+           .fill = colorSpecFromRole(ColorRole::Primary, 0.25F),
+           .track = clearColorSpec(),
+           .visible = false,
+           .participatesInLayout = false,
+           .configure = [](ProgressBar& bar) {
+             bar.setZIndex(-1);
+             bar.setHitTestVisible(false);
+           }}
+      )
+  );
   area->addChild(
       ui::image({
           .out = &m_art,
@@ -95,7 +94,11 @@ void MediaWidget::create() {
 
 void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
-  if (rootNode == nullptr || m_art == nullptr || m_label == nullptr || m_emptyGlyph == nullptr || m_progressBar == nullptr) {
+  if (rootNode == nullptr
+      || m_art == nullptr
+      || m_label == nullptr
+      || m_emptyGlyph == nullptr
+      || m_progressBar == nullptr) {
     return;
   }
   syncState(renderer);
@@ -243,9 +246,9 @@ void MediaWidget::syncProgress() {
     return;
   }
   const float fillWidth = std::max(1.0F, m_progressBar->width());
-  const auto intervalMs = static_cast<std::int64_t>(
-    std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.F, 1000.0F));
-  m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { syncProgress();});
+  const auto intervalMs =
+      static_cast<std::int64_t>(std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.F, 1000.0F));
+  m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { syncProgress(); });
 }
 
 void MediaWidget::syncState(Renderer& renderer) {

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -98,7 +98,11 @@ void MediaWidget::create() {
 
 void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
-  if (rootNode == nullptr || m_art == nullptr || m_label == nullptr || m_emptyGlyph == nullptr || m_progressBar == nullptr) {
+  if (rootNode == nullptr
+      || m_art == nullptr
+      || m_label == nullptr
+      || m_emptyGlyph == nullptr
+      || m_progressBar == nullptr) {
     return;
   }
   syncState(renderer);

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -21,6 +21,10 @@ using namespace mpris;
 namespace {
 
   const Logger kLog{"media"};
+  ColorSpec withOpacity(ColorSpec color, float opacity) {
+    color.alpha *= opacity;
+    return color;
+  }
 
 } // namespace
 
@@ -46,7 +50,7 @@ void MediaWidget::create() {
   area->addChild(
       ui::progressBar(
           {.out = &m_progressBar,
-           .fill = colorSpecFromRole(ColorRole::Primary, 0.25F),
+           .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::Primary)), 0.25F),
            .track = clearColorSpec(),
            .visible = false,
            .participatesInLayout = false,
@@ -247,7 +251,7 @@ void MediaWidget::syncProgress() {
   }
   const float fillWidth = std::max(1.0F, m_progressBar->width());
   const auto intervalMs =
-      static_cast<std::int64_t>(std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.F, 1000.0F));
+      static_cast<std::int64_t>(std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.0F, 1000.0F));
   m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { syncProgress(); });
 }
 

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -195,18 +195,18 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
   }
   m_progressBar->setVisible(showProgressFill);
   if (showProgressFill) {
-    // The bar sizes an enabled capsule as content + 2 * padding on the main axis, so widen the fill
-    // by the same padding to span the pill instead of sitting inset within it.
-    const float capsulePad = shouldShowBarCapsule() ? barCapsuleSpec().padding * m_contentScale : 0.0F;
-    const float fillWidth = rootNode->width() + 2.0F * capsulePad;
+    const float fillWidth = rootNode->width();
     const float fillHeight = rootNode->height();
-    m_progressBar->setPosition(-capsulePad, 0.0F);
+    m_progressBar->setPosition(0.0F, 0.0F);
     m_progressBar->setSize(fillWidth, fillHeight);
     m_progressBar->setRadius(std::min(fillWidth, fillHeight) * 0.5F);
   }
 }
 
-void MediaWidget::doUpdate(Renderer& renderer) { syncState(renderer); }
+void MediaWidget::doUpdate(Renderer& renderer) {
+  syncState(renderer);
+  syncProgress();
+}
 
 void MediaWidget::applyTitleScrollMode(bool titleVisible) {
   if (m_label == nullptr) {
@@ -259,7 +259,7 @@ void MediaWidget::syncProgress() {
   const float fillWidth = std::max(1.0F, m_progressBar->width());
   const auto intervalMs =
       static_cast<std::int64_t>(std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.0F, 1000.0F));
-  m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { syncProgress(); });
+  m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { requestUpdate(); });
 }
 
 void MediaWidget::syncState(Renderer& renderer) {
@@ -284,7 +284,6 @@ void MediaWidget::syncState(Renderer& renderer) {
     artUrl = effectiveArtUrl(*active);
   }
 
-  syncProgress();
   const bool textChanged = displayText != m_lastText;
   const bool artChanged = artUrl != m_lastArtUrl;
   const bool playbackChanged = playbackStatus != m_lastPlaybackStatus;

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -21,10 +21,6 @@ using namespace mpris;
 namespace {
 
   const Logger kLog{"media"};
-  ColorSpec withOpacity(ColorSpec color, float opacity) {
-    color.alpha *= opacity;
-    return color;
-  }
 
 } // namespace
 
@@ -50,13 +46,14 @@ void MediaWidget::create() {
   area->addChild(
       ui::progressBar(
           {.out = &m_progressBar,
-           .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::Primary)), 0.25F),
+           .fill = scaleAlpha(widgetForegroundOr(colorSpecFromRole(ColorRole::Primary)), 0.25F),
            .track = clearColorSpec(),
            .visible = false,
            .participatesInLayout = false,
            .configure = [](ProgressBar& bar) {
              bar.setZIndex(-1);
              bar.setHitTestVisible(false);
+             bar.setProgress(0.0F);
            }}
       )
   );
@@ -105,15 +102,15 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
       || m_progressBar == nullptr) {
     return;
   }
-  syncState(renderer);
+  const bool wasVertical = m_isVertical;
+  m_isVertical = containerHeight > containerWidth;
+  const auto active = activePlayer();
+  syncState(renderer, active);
 
-  const bool isVertical = containerHeight > containerWidth;
-  const bool artOnly = isVertical || m_albumArtOnly;
+  const bool artOnly = m_isVertical || m_albumArtOnly;
   const float maxLength = std::max(0.0F, m_maxWidth * m_contentScale);
   const float minLength = std::clamp(m_minWidth * m_contentScale, 0.0F, maxLength);
-  const auto progressPlayer = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
-  const bool showProgressFill =
-      m_showProgress && !artOnly && progressPlayer.has_value() && progressPlayer->lengthUs > 0;
+  const bool showProgressFill = progressFillEligible(active);
 
   m_label->setColor(
       m_lastPlaybackStatus == "Playing" ? widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))
@@ -124,7 +121,7 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
   m_emptyGlyph->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant));
   m_emptyGlyph->measure(renderer);
 
-  const bool hideAlbumArt = m_hideAlbumArt && !isVertical;
+  const bool hideAlbumArt = m_hideAlbumArt && !m_isVertical;
   const bool showArtSlot = !hideAlbumArt && m_art->hasImage();
 
   // Clamp art to the label's single-line height so oversized art_size cannot
@@ -199,13 +196,21 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
     const float fillHeight = rootNode->height();
     m_progressBar->setPosition(0.0F, 0.0F);
     m_progressBar->setSize(fillWidth, fillHeight);
-    m_progressBar->setRadius(std::min(fillWidth, fillHeight) * 0.5F);
+    m_progressBar->setRadius(resolvedBarCapsuleRadius(fillWidth, fillHeight));
+  }
+  // The update phase owns the fill value and the timer, and it runs before layout. Re-enter it when
+  // a layout-only pass changes an input it cannot observe, so the fill never shows a stale value and
+  // the timer cannot stay unarmed while the fill is on screen.
+  if (m_isVertical != wasVertical || showProgressFill != m_progressFillVisible) {
+    m_progressFillVisible = showProgressFill;
+    requestUpdate();
   }
 }
 
 void MediaWidget::doUpdate(Renderer& renderer) {
-  syncState(renderer);
-  syncProgress();
+  const auto active = activePlayer();
+  syncState(renderer, active);
+  syncProgress(active);
 }
 
 void MediaWidget::applyTitleScrollMode(bool titleVisible) {
@@ -231,43 +236,49 @@ void MediaWidget::syncWidgetVisibility(bool hasMedia) {
   }
 }
 
-void MediaWidget::syncProgress() {
+std::optional<MprisPlayerInfo> MediaWidget::activePlayer() const {
+  return m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
+}
+
+bool MediaWidget::progressFillEligible(const std::optional<MprisPlayerInfo>& active) const noexcept {
+  return m_showProgress && !m_isVertical && !m_albumArtOnly && active.has_value() && active->lengthUs > 0;
+}
+
+void MediaWidget::syncProgress(const std::optional<MprisPlayerInfo>& active) {
   if (m_progressBar == nullptr) {
     return;
   }
-  if (!m_progressBar->visible()) {
+  // Reset while ineligible so a later reveal cannot flash the previous track's position.
+  if (!progressFillEligible(active)) {
     m_progressTimer.stop();
+    if (m_progressBar->progress() != 0.0F) {
+      m_progressBar->setProgress(0.0F);
+      requestRedraw();
+    }
     return;
   }
-  const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
-  const bool playing = active.has_value() && active->playbackStatus == "Playing";
-  const bool hasLength = active.has_value() && active->lengthUs > 0;
 
-  if (!m_showProgress || !hasLength) {
-    m_progressTimer.stop();
-    return;
-  }
   const float progress = static_cast<float>(active->positionUs) / static_cast<float>(active->lengthUs);
   if (std::abs(progress - m_progressBar->progress()) > 0.0005F) {
     m_progressBar->setProgress(progress);
     requestRedraw();
   }
-  if (!playing) {
+  if (active->playbackStatus != "Playing") {
     m_progressTimer.stop();
     return;
   }
+  // One wakeup per pixel of travel: a 3-minute track in a 200 px widget moves a pixel every ~900 ms.
   const float fillWidth = std::max(1.0F, m_progressBar->width());
   const auto intervalMs =
       static_cast<std::int64_t>(std::clamp(static_cast<float>(active->lengthUs / 1000) / fillWidth, 250.0F, 1000.0F));
   m_progressTimer.start(std::chrono::milliseconds(intervalMs), [this]() { requestUpdate(); });
 }
 
-void MediaWidget::syncState(Renderer& renderer) {
+void MediaWidget::syncState(Renderer& renderer, const std::optional<MprisPlayerInfo>& active) {
   if (m_art == nullptr || m_label == nullptr) {
     return;
   }
 
-  const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
   syncWidgetVisibility(active.has_value());
   if (m_hideWhenNoMedia && !active.has_value()) {
     applyTitleScrollMode(false);

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -235,6 +235,10 @@ void MediaWidget::syncProgress() {
   if (m_progressBar == nullptr) {
     return;
   }
+  if (!m_progressBar->visible()) {
+    m_progressTimer.stop();
+    return;
+  }
   const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
   const bool playing = active.has_value() && active->playbackStatus == "Playing";
   const bool hasLength = active.has_value() && active->lengthUs > 0;

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -98,11 +98,7 @@ void MediaWidget::create() {
 
 void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
-  if (rootNode == nullptr
-      || m_art == nullptr
-      || m_label == nullptr
-      || m_emptyGlyph == nullptr
-      || m_progressBar == nullptr) {
+  if (rootNode == nullptr || m_art == nullptr || m_label == nullptr || m_emptyGlyph == nullptr || m_progressBar == nullptr) {
     return;
   }
   syncState(renderer);

--- a/src/shell/bar/widgets/media_widget.h
+++ b/src/shell/bar/widgets/media_widget.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "shell/bar/widget.h"
 #include "core/timer_manager.h"
+#include "shell/bar/widget.h"
 
 #include <cstdint>
 #include <memory>

--- a/src/shell/bar/widgets/media_widget.h
+++ b/src/shell/bar/widgets/media_widget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "shell/bar/widget.h"
+#include "core/timer_manager.h"
 
 #include <cstdint>
 #include <memory>
@@ -14,6 +15,7 @@ class Glyph;
 class Label;
 class MprisService;
 class Renderer;
+class ProgressBar;
 struct MprisPlayerInfo;
 struct wl_output;
 
@@ -35,6 +37,7 @@ public:
     bool hideAlbumArt = false;
     bool hideArtist = false;
     bool artistFirst = false;
+    bool showProgress = false;
   };
 
   MediaWidget(MprisService* mpris, HttpClient* httpClient, wl_output* output, Options options);
@@ -47,6 +50,7 @@ private:
   void applyTitleScrollMode(bool titleVisible);
   void syncState(Renderer& renderer);
   void syncWidgetVisibility(bool hasMedia);
+  void syncProgress();
   [[nodiscard]] static std::string buildDisplayText(const MprisPlayerInfo& player, bool hideArtist, bool artistFirst);
 
   MprisService* m_mpris = nullptr;
@@ -60,14 +64,17 @@ private:
   bool m_hideAlbumArt = false;
   bool m_hideArtist = false;
   bool m_artistFirst = false;
+  bool m_showProgress = false;
   InputArea* m_area = nullptr;
   Image* m_art = nullptr;
   Glyph* m_emptyGlyph = nullptr;
   Label* m_label = nullptr;
+  ProgressBar* m_progressBar = nullptr;
 
   std::string m_lastText;
   std::string m_lastArtUrl;
   std::string m_lastPlaybackStatus;
   std::unordered_set<std::string> m_pendingArtDownloads;
   std::shared_ptr<void> m_aliveGuard = std::make_shared<int>(0);
+  Timer m_progressTimer;
 };

--- a/src/shell/bar/widgets/media_widget.h
+++ b/src/shell/bar/widgets/media_widget.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_set>
 
@@ -48,9 +49,13 @@ private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   void applyTitleScrollMode(bool titleVisible);
-  void syncState(Renderer& renderer);
+  void syncState(Renderer& renderer, const std::optional<MprisPlayerInfo>& active);
   void syncWidgetVisibility(bool hasMedia);
-  void syncProgress();
+  // Applies playback position to the fill and arms the update timer. Update-phase only: it decides
+  // eligibility itself instead of reading the visibility that doLayout() applies afterwards.
+  void syncProgress(const std::optional<MprisPlayerInfo>& active);
+  [[nodiscard]] bool progressFillEligible(const std::optional<MprisPlayerInfo>& active) const noexcept;
+  [[nodiscard]] std::optional<MprisPlayerInfo> activePlayer() const;
   [[nodiscard]] static std::string buildDisplayText(const MprisPlayerInfo& player, bool hideArtist, bool artistFirst);
 
   MprisService* m_mpris = nullptr;
@@ -65,6 +70,9 @@ private:
   bool m_hideArtist = false;
   bool m_artistFirst = false;
   bool m_showProgress = false;
+  // Cached from the last doLayout(); the update phase has no container extents of its own.
+  bool m_isVertical = false;
+  bool m_progressFillVisible = false;
   InputArea* m_area = nullptr;
   Image* m_art = nullptr;
   Glyph* m_emptyGlyph = nullptr;

--- a/src/shell/bar/widgets/media_widget_definition.cpp
+++ b/src/shell/bar/widgets/media_widget_definition.cpp
@@ -93,6 +93,14 @@ const noctalia::bar::WidgetDefinition<MediaWidget::Options>& mediaWidgetDefiniti
                       .visibleWhen = notAlbumArtOnly,
                   },
           }),
+          field<&Options::showProgress>({
+              .key = "show_progress",
+              .presentation =
+                  settings::WidgetSettingPresentation{
+                      .visibleWhen = notAlbumArtOnly,
+                      .horizontalBarOnly = true,
+                  },
+          }),
           field<&Options::hideWhenNoMedia>({
               .key = "hide_when_no_media",
           }),

--- a/src/ui/palette.h
+++ b/src/ui/palette.h
@@ -4,6 +4,7 @@
 #include "ui/signal.h"
 #include "ui/style.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <optional>
@@ -66,6 +67,15 @@ constexpr bool operator==(const ColorSpec& a, const ColorSpec& b) noexcept {
 
 [[nodiscard]] constexpr ColorSpec clearColorSpec() noexcept {
   return ColorSpec{.role = std::nullopt, .fixed = clearColor(), .alpha = 1.0F};
+}
+
+// Multiplies a spec's alpha, keeping any color role intact so theme switches still resolve.
+// Distinct from withAlpha(Color, float) in render/core/color.h, which replaces the alpha of an
+// already-resolved color and therefore cannot preserve the role.
+[[nodiscard]] constexpr ColorSpec scaleAlpha(const ColorSpec& color, float factor) noexcept {
+  ColorSpec out = color;
+  out.alpha = std::clamp(out.alpha * std::clamp(factor, 0.0F, 1.0F), 0.0F, 1.0F);
+  return out;
 }
 
 struct Palette {


### PR DESCRIPTION
## Summary

Adds an opt-in `show_progress` option to the bar's media widget. When enabled, the widget's
background fills left-to-right in proportion to the current track's playback position, so the pill
itself doubles as a progress indicator.

The fill is a `ProgressBar` child of the widget's own root, sized to the widget content and widened
by the capsule padding so it spans the pill. It is drawn at `zIndex(-1)`, opted out of layout, and
not hit-testable, so it changes nothing about the widget's measured size or input behavior.

Defaults to off and hidden on vertical bars and in album-art-only mode, where a rectangular fill behind
a circular album-art disc doesn't read well.

## Motivation

The media widget shows what's playing but gives no sense of *where* you are in the track. Getting
that today means opening the control center. A background fill answers it without
consuming any extra bar width.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None — this wasn't tracked by an existing issue.

## Testing

```
just build      # clean, no new warnings
just test       # 72/72 pass
just format     # clang-format, no diff
python3 tools/i18n-check.py    # OK: 867 tr keys, all present in catalog
```

Manual testing against a live debug shell with Spotify and browser MPRIS sources:

- Fill advances smoothly during playback; title stays legible over it.
- Paused: fill freezes and the update timer stops — verified via `/proc/<pid>/stat` sampling that no
  additional wakeups occur while paused.
- Seeking from the control center: the bar fill jumps to match.
- Live stream / unknown duration (`lengthUs == 0`): fill hidden, no divide-by-zero, no full bar.
- Option off: no fill, no timer.
- Widget capsule enabled *and* disabled: fill geometry correct in both (the capsule-padding
  extension is gated on `shouldShowBarCapsule()`).
- Vertical bar: fill hidden, setting hidden, existing art-only rendering unchanged.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
<img width="977" height="960" alt="image" src="https://github.com/user-attachments/assets/6391b779-9bc1-442c-b399-be3cb5d7c178" />
<img width="975" height="960" alt="image" src="https://github.com/user-attachments/assets/83757d02-0732-4ccc-a2b6-8fed4153d8c6" />

With capsule
<img width="344" height="97" alt="image" src="https://github.com/user-attachments/assets/d29a7117-0db8-46c3-89ae-8f4852bf39cf" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
Why a timer instead of a frame tick: The fill only moves in whole pixels, and the widget is
80–220 px wide, so one pixel of travel takes `trackLength / widgetWidth`. Roughly 0.9 s for a
3-minute track in a 200 px widget. Driving this from `needsFrameTick()` would redraw ~60x more often
to produce an identical image. Instead `syncProgress()` arms a one-shot `Timer` with

```
intervalMs = clamp(trackLengthMs / fillWidthPx, 250, 1000)
```

and re-arms it from its own callback, so the cadence tracks the current track length and widget
width. It is armed only while `playbackStatus == "Playing"` with a known duration, and `stop()`s on
pause, stop, and when the option is off. A paused track costs zero wakeups.

Reused existing primitives, no new ones.: `ProgressBar` (`src/ui/controls/progress_bar.h`)
already renders a full-size fill revealed through a clip node, which keeps the leading end's rounded
cap instead of squaring off at low progress. Position comes from `MprisService::activePlayer()`,
which already returns a wall-clock-projected snapshot, so there's no extra D-Bus traffic.

Fill color: routes through `widgetForegroundOr(...)` at 25% opacity, matching how
`battery_widget.cpp` and `sysmon_widget.cpp` tint their fills, so a `[widget.media] color` override
applies to the fill as well as the text. Because `ColorSpec` stores a role rather than a resolved
color, theme switches are picked up automatically by `ProgressBar`'s `paletteChanged()` connection.

No customization options: I wanted this PR as a base for the function and further customization options would be better suited for a new PR.
