### PR TITLE
feat(audio): add Bluetooth codec selector drop-down

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -183,6 +183,8 @@
   "control-center": {
     "audio": {
       "application-volumes": "Application Volumes",
+      "choose-codec": "Choose a codec",
+      "codec": "Codec",
       "choose-effects-profile": "Choose a profile",
       "effects-profile": "Effects",
       "input-device-prefix": "Input",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -186,7 +186,7 @@
       "choose-codec": "Choose a codec",
       "choose-effects-profile": "Choose a profile",
       "codec": "Codec",
-      "codec-tooltip": "Codec used for this Bluetooth device. Higher-quality codecs may use more bandwidth and battery.",
+      "codec-tooltip": "Select codec to use for this Bluetooth device. Higher-quality codecs may use more bandwidth and battery.",
       "effects-profile": "Effects",
       "input-device-prefix": "Input",
       "no-application-audio": "No application audio",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -184,8 +184,9 @@
     "audio": {
       "application-volumes": "Application Volumes",
       "choose-codec": "Choose a codec",
-      "codec": "Codec",
       "choose-effects-profile": "Choose a profile",
+      "codec": "Codec",
+      "codec-tooltip": "Codec used for this Bluetooth device. Higher-quality codecs may use more bandwidth and battery.",
       "effects-profile": "Effects",
       "input-device-prefix": "Input",
       "no-application-audio": "No application audio",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -186,7 +186,7 @@
       "choose-codec": "Choose a codec",
       "choose-effects-profile": "Choose a profile",
       "codec": "Codec",
-      "codec-tooltip": "Select codec to use for this Bluetooth device. Higher-quality codecs may use more bandwidth and battery.",
+      "codec-tooltip": "Select codec to use for this device. Please note that higher-quality codecs can use more bandwidth and battery.",
       "effects-profile": "Effects",
       "input-device-prefix": "Input",
       "no-application-audio": "No application audio",

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -2023,6 +2023,26 @@ void PipeWireService::setSourceVolume(std::uint32_t id, float volume) {
 }
 void PipeWireService::setSourceMuted(std::uint32_t id, bool muted) { setNodeMuted(id, muted); }
 void PipeWireService::setDefaultSource(std::uint32_t id) { setDefaultNode(id, "default.audio.source"); }
+void PipeWireService::setDeviceProfile(std::uint32_t deviceId, std::int32_t profileIndex) {
+  const auto it = m_devices.find(deviceId);
+  if (it == m_devices.end() || it->second.proxy == nullptr) {
+    return;
+  }
+
+  std::uint8_t buffer[256];
+  spa_pod_builder builder;
+  spa_pod_builder_init(&builder, buffer, sizeof(buffer));
+
+  spa_pod_frame frame;
+  spa_pod_builder_push_object(&builder, &frame, SPA_TYPE_OBJECT_ParamProfile, SPA_PARAM_Profile);
+  spa_pod_builder_prop(&builder, SPA_PARAM_PROFILE_index, 0);
+  spa_pod_builder_int(&builder, profileIndex);
+  spa_pod_builder_prop(&builder, SPA_PARAM_PROFILE_save, 0);
+  spa_pod_builder_bool(&builder, true);
+  auto* pod = static_cast<spa_pod*>(spa_pod_builder_pop(&builder, &frame));
+
+  pw_device_set_param(it->second.proxy, SPA_PARAM_Profile, 0, pod);
+}
 
 void PipeWireService::setProgramOutputVolume(std::uint32_t id, float volume) { setNodeVolume(id, volume); }
 void PipeWireService::setProgramOutputMuted(std::uint32_t id, bool muted) { setNodeMuted(id, muted); }

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -529,7 +529,7 @@ namespace {
   // "a2dp-sink-ldac", "headset-head-unit" — map the common ones to a short display label,
   // falling back to PipeWire's own description so an unrecognized profile never disappears.
   [[nodiscard]] std::string codecShortLabel(const std::string& name, const std::string& description) {
-    auto contains = [&name](std::string_view needle) { return name.find(needle) != std::string::npos; };
+    auto contains = [&name](const std::string_view needle) { return name.contains(needle); };
     if (contains("ldac")) {
       return "LDAC";
     }

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -24,6 +24,7 @@
 #include <spa/param/param.h>
 #include <spa/param/props.h>
 #include <spa/param/route.h>
+#include <spa/param/profile.h>
 #include <spa/pod/builder.h>
 #include <spa/pod/iter.h>
 #include <spa/pod/parser.h>
@@ -925,6 +926,7 @@ void PipeWireService::onRegistryGlobal(std::uint32_t id, const char* type, std::
     DeviceData device;
     device.service = this;
     device.id = id;
+    device.isBluetooth = dictGet(props, "device.api") == "bluez5";
     auto [it, inserted] = m_devices.insert_or_assign(id, std::move(device));
 
     auto& stored = it->second;
@@ -935,8 +937,15 @@ void PipeWireService::onRegistryGlobal(std::uint32_t id, const char* type, std::
         stored.listener = new spa_hook{};
         spa_zero(*stored.listener);
         pw_device_add_listener(proxy, stored.listener, &kDeviceEvents, &stored);
-        std::uint32_t params[] = {SPA_PARAM_Route};
-        pw_device_subscribe_params(proxy, params, 1);
+        if (stored.isBluetooth) {
+          std::uint32_t params[] = {SPA_PARAM_Route, SPA_PARAM_EnumProfile, SPA_PARAM_Profile};
+          pw_device_subscribe_params(proxy, params, 3);
+          pw_device_enum_params(proxy, 0, SPA_PARAM_EnumProfile, 0, UINT32_MAX, nullptr);
+          pw_device_enum_params(proxy, 0, SPA_PARAM_Profile, 0, UINT32_MAX, nullptr);
+        } else {
+          std::uint32_t params[] = {SPA_PARAM_Route};
+          pw_device_subscribe_params(proxy, params, 1);
+        }
         pw_device_enum_params(proxy, 0, SPA_PARAM_Route, 0, UINT32_MAX, nullptr);
       }
     }

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -22,9 +22,9 @@
 #include <pipewire/pipewire.h>
 #include <ranges>
 #include <spa/param/param.h>
+#include <spa/param/profile.h>
 #include <spa/param/props.h>
 #include <spa/param/route.h>
-#include <spa/param/profile.h>
 #include <spa/pod/builder.h>
 #include <spa/pod/iter.h>
 #include <spa/pod/parser.h>
@@ -529,7 +529,7 @@ namespace {
   // "a2dp-sink-ldac", "headset-head-unit" — map the common ones to a short display label,
   // falling back to PipeWire's own description so an unrecognized profile never disappears.
   [[nodiscard]] std::string codecShortLabel(const std::string& name, const std::string& description) {
-    auto contains = [&name](std::string_view needle) {return name.find(needle) != std::string::npos; };
+    auto contains = [&name](std::string_view needle) { return name.find(needle) != std::string::npos; };
     if (contains("ldac")) {
       return "LDAC";
     }
@@ -561,8 +561,6 @@ namespace {
       return "Handsfree (HFP)";
     }
     return !description.empty() ? description : name;
-
-
   }
   constexpr Logger kLog("pipewire");
 
@@ -1433,9 +1431,9 @@ void PipeWireService::onDeviceInfo(std::uint32_t id, const pw_device_info* info)
     for (std::uint32_t i = 0; i < info->n_params; ++i) {
       if (info->params[i].id == SPA_PARAM_Route) {
         pw_device_enum_params(it->second.proxy, 0, SPA_PARAM_Route, 0, UINT32_MAX, nullptr);
-     } else if (info->params[i].id == SPA_PARAM_EnumProfile) {
+      } else if (info->params[i].id == SPA_PARAM_EnumProfile) {
         pw_device_enum_params(it->second.proxy, 0, SPA_PARAM_EnumProfile, 0, UINT32_MAX, nullptr);
-     } else if (info->params[i].id == SPA_PARAM_Profile) {
+      } else if (info->params[i].id == SPA_PARAM_Profile) {
         pw_device_enum_params(it->second.proxy, 0, SPA_PARAM_Profile, 0, UINT32_MAX, nullptr);
       }
     }

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -525,42 +525,115 @@ namespace {
     }
     return 0;
   }
-  // Bluetooth (bluez5) profile "name" values encode the codec, e.g. "a2dp-sink-aac",
-  // "a2dp-sink-ldac", "headset-head-unit" — map the common ones to a short display label,
-  // falling back to PipeWire's own description so an unrecognized profile never disappears.
-  [[nodiscard]] std::string codecShortLabel(const std::string& name, const std::string& description) {
-    auto contains = [&name](const std::string_view needle) { return name.contains(needle); };
-    if (contains("ldac")) {
-      return "LDAC";
-    }
-    if (contains("aptx_hd") || contains("aptx-hd")) {
-      return "aptX HD";
-    }
-    if (contains("aptx_ll") || contains("aptx-ll")) {
-      return "aptX LL";
-    }
-    if (contains("aptx")) {
-      return "aptX";
-    }
-    if (contains("aac")) {
-      return "AAC";
-    }
-    if (contains("sbc_xq") || contains("sbc-xq")) {
+  // A bluez5 profile name encodes the codec ("a2dp-sink-sbc_xq", "headset-head-unit-msbc").
+  // Reducing each profile to a stable key collapses duplicates — a headset lists CVSD/mSBC/LC3-SWB
+  // variants that are all one choice to the user — and avoids substring traps such as "msbc"
+  // matching the A2DP "sbc" codec.
+  struct CodecChoice {
+    std::string key; // empty when the profile is not a codec choice, e.g. "off"
+    std::string label;
+  };
+
+  [[nodiscard]] std::string codecDisplayName(std::string_view token) {
+    if (token == "sbc_xq") {
       return "SBC-XQ";
     }
-    if (contains("sbc")) {
-      return "SBC";
+    if (token == "aptx_hd") {
+      return "aptX HD";
     }
-    if (contains("opus")) {
+    if (token == "aptx_ll") {
+      return "aptX LL";
+    }
+    if (token == "aptx") {
+      return "aptX";
+    }
+    if (token == "opus") {
       return "Opus";
     }
-    if (contains("lc3")) {
-      return "LC3";
+    std::string display(token);
+    std::ranges::transform(display, display.begin(), [](unsigned char ch) { return std::toupper(ch); });
+    return display;
+  }
+
+  [[nodiscard]] CodecChoice codecChoiceForProfile(const std::string& name, const std::string& description) {
+    // Every headset variant is one choice: the mode that enables the microphone.
+    if (name.starts_with("headset-") || name.contains("head-unit") || name.contains("handsfree")) {
+      return {.key = "hfp", .label = "HFP"};
     }
-    if (contains("head-unit") || contains("headset") || contains("handsfree")) {
-      return "Handsfree (HFP)";
+    if (name.starts_with("a2dp-sink-")) {
+      const std::string token = name.substr(std::string_view("a2dp-sink-").size());
+      return {.key = token, .label = codecDisplayName(token)};
     }
-    return !description.empty() ? description : name;
+    // The unsuffixed A2DP profile is the device's preferred codec; PipeWire names that codec only
+    // in the description ("... codec AAC").
+    if (name == "a2dp-sink") {
+      const auto pos = description.find("codec ");
+      if (pos == std::string::npos) {
+        return {.key = "a2dp", .label = "A2DP"};
+      }
+      std::string display = description.substr(pos + std::string_view("codec ").size());
+      if (const auto end = display.find(')'); end != std::string::npos) {
+        display.erase(end);
+      }
+      std::string key = display;
+      std::ranges::transform(key, key.begin(), [](unsigned char ch) { return std::tolower(ch); });
+      std::ranges::replace(key, '-', '_');
+      return {.key = std::move(key), .label = std::move(display)};
+    }
+    return {};
+  }
+
+  // One entry per distinct codec choice, keeping the highest-priority profile for each: the
+  // unsuffixed profiles carry the device's best codec and outrank their explicit variants.
+  void collectCodecOptions(const PipeWireService::DeviceData& device, AudioNode& node) {
+    struct Candidate {
+      std::string key;
+      std::string label;
+      std::int32_t index = -1;
+      std::int32_t priority = 0;
+    };
+
+    std::vector<Candidate> candidates;
+    for (const auto& profile : device.profiles) {
+      if (profile.available == SPA_PARAM_AVAILABILITY_no) {
+        continue;
+      }
+      CodecChoice choice = codecChoiceForProfile(profile.name, profile.description);
+      if (choice.key.empty()) {
+        continue;
+      }
+      const auto existing = std::ranges::find(candidates, choice.key, &Candidate::key);
+      if (existing == candidates.end()) {
+        candidates.push_back({std::move(choice.key), std::move(choice.label), profile.index, profile.priority});
+      } else if (profile.priority > existing->priority) {
+        existing->label = std::move(choice.label);
+        existing->index = profile.index;
+        existing->priority = profile.priority;
+      }
+    }
+
+    if (candidates.size() < 2) {
+      return;
+    }
+
+    // Match the active profile by key, not index: it may be a variant folded into another entry
+    // (e.g. "headset-head-unit-cvsd" into "HFP"), and the selection must still show.
+    std::string activeKey;
+    const auto active =
+        std::ranges::find(device.profiles, device.activeProfileIndex, &PipeWireService::DeviceProfileData::index);
+    if (active != device.profiles.end()) {
+      activeKey = codecChoiceForProfile(active->name, active->description).key;
+    }
+
+    node.codecOptions.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+      node.codecOptions.push_back(AudioCodecOption{.profileIndex = candidate.index, .label = candidate.label});
+    }
+
+    const auto activeIt = std::ranges::find(candidates, activeKey, &Candidate::key);
+    node.activeCodecIndex = !activeKey.empty() && activeIt != candidates.end()
+        ? static_cast<std::size_t>(std::distance(candidates.begin(), activeIt))
+        : static_cast<std::size_t>(-1);
   }
   constexpr Logger kLog("pipewire");
 
@@ -1734,26 +1807,7 @@ void PipeWireService::rebuildState() {
 
     node.deviceId = nd->deviceId;
     if (nd->mediaClass == "Audio/Sink" && device != nullptr && device->isBluetooth) {
-      for (const auto& profile : device->profiles) {
-        if (profile.available == SPA_PARAM_AVAILABILITY_no || profile.name == "off") {
-          continue;
-        }
-        node.codecOptions.push_back(
-            AudioCodecOption{
-                .profileIndex = profile.index,
-                .label = codecShortLabel(profile.name, profile.description),
-            }
-        );
-      }
-      if (node.codecOptions.size() < 2) {
-        node.codecOptions.clear();
-      } else {
-        const auto activeIt =
-            std::ranges::find(node.codecOptions, device->activeProfileIndex, &AudioCodecOption::profileIndex);
-        node.activeCodecIndex = activeIt != node.codecOptions.end()
-            ? static_cast<std::size_t>(std::distance(node.codecOptions.begin(), activeIt))
-            : static_cast<std::size_t>(-1);
-      }
+      collectCodecOptions(*device, node);
     }
 
     if (nd->mediaClass == "Audio/Sink") {

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -525,7 +525,45 @@ namespace {
     }
     return 0;
   }
+  // Bluetooth (bluez5) profile "name" values encode the codec, e.g. "a2dp-sink-aac",
+  // "a2dp-sink-ldac", "headset-head-unit" — map the common ones to a short display label,
+  // falling back to PipeWire's own description so an unrecognized profile never disappears.
+  [[nodiscard]] std::string codecShortLabel(const std::string& name, const std::string& description) {
+    auto contains = [&name](std::string_view needle) {return name.find(needle) != std::string::npos; };
+    if (contains("ldac")) {
+      return "LDAC";
+    }
+    if (contains("aptx_hd") || contains("aptx-hd")) {
+      return "aptX HD";
+    }
+    if (contains("aptx_ll") || contains("aptx-ll")) {
+      return "aptX LL";
+    }
+    if (contains("aptx")) {
+      return "aptX";
+    }
+    if (contains("aac")) {
+      return "AAC";
+    }
+    if (contains("sbc_xq") || contains("sbc-xq")) {
+      return "SBC-XQ";
+    }
+    if (contains("sbc")) {
+      return "SBC";
+    }
+    if (contains("opus")) {
+      return "Opus";
+    }
+    if (contains("lc3")) {
+      return "LC3";
+    }
+    if (contains("head-unit") || contains("headset") || contains("handsfree")) {
+      return "Handsfree (HFP)";
+    }
+    return !description.empty() ? description : name;
 
+
+  }
   constexpr Logger kLog("pipewire");
 
   constexpr auto kTrackedNodeClasses = std::to_array<std::string_view>({
@@ -1695,6 +1733,30 @@ void PipeWireService::rebuildState() {
     const bool hasDirRoutes = std::ranges::any_of(nd->routes, matchesDir)
         || (device != nullptr && std::ranges::any_of(device->routes, matchesDir));
     node.available = activeRoute != nullptr || !hasDirRoutes;
+
+    node.deviceId = nd->deviceId;
+    if (nd->mediaClass == "Audio/Sink" && device != nullptr && device->isBluetooth) {
+      for (const auto& profile : device->profiles) {
+        if (profile.available == SPA_PARAM_AVAILABILITY_no || profile.name == "off") {
+          continue;
+        }
+        node.codecOptions.push_back(
+            AudioCodecOption{
+                .profileIndex = profile.index,
+                .label = codecShortLabel(profile.name, profile.description),
+            }
+        );
+      }
+      if (node.codecOptions.size() < 2) {
+        node.codecOptions.clear();
+      } else {
+        const auto activeIt =
+            std::ranges::find(node.codecOptions, device->activeProfileIndex, &AudioCodecOption::profileIndex);
+        node.activeCodecIndex = activeIt != node.codecOptions.end()
+            ? static_cast<std::size_t>(std::distance(node.codecOptions.begin(), activeIt))
+            : static_cast<std::size_t>(-1);
+      }
+    }
 
     if (nd->mediaClass == "Audio/Sink") {
       node.isDefault = (nd->name == m_defaultSinkName);

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -1395,6 +1395,10 @@ void PipeWireService::onDeviceInfo(std::uint32_t id, const pw_device_info* info)
     for (std::uint32_t i = 0; i < info->n_params; ++i) {
       if (info->params[i].id == SPA_PARAM_Route) {
         pw_device_enum_params(it->second.proxy, 0, SPA_PARAM_Route, 0, UINT32_MAX, nullptr);
+     } else if (info->params[i].id == SPA_PARAM_EnumProfile) {
+        pw_device_enum_params(it->second.proxy, 0, SPA_PARAM_EnumProfile, 0, UINT32_MAX, nullptr);
+     } else if (info->params[i].id == SPA_PARAM_Profile) {
+        pw_device_enum_params(it->second.proxy, 0, SPA_PARAM_Profile, 0, UINT32_MAX, nullptr);
       }
     }
   }
@@ -1403,10 +1407,60 @@ void PipeWireService::onDeviceInfo(std::uint32_t id, const pw_device_info* info)
 void PipeWireService::onDeviceParam(
     std::uint32_t id, std::uint32_t paramId, std::uint32_t index, std::uint32_t, const spa_pod* param
 ) {
-  if (paramId != SPA_PARAM_Route || param == nullptr) {
+  if (param == nullptr) {
     return;
   }
 
+  if (paramId == SPA_PARAM_EnumProfile || paramId == SPA_PARAM_Profile) {
+    auto it = m_devices.find(id);
+    if (it == m_devices.end()) {
+      return;
+    }
+
+    std::int32_t profileIndex = -1;
+    const char* profileName = nullptr;
+    const char* profileDescription = nullptr;
+    std::int32_t profilePriority = 0;
+    if (spa_pod_parse_object(
+            param, SPA_TYPE_OBJECT_ParamProfile, nullptr, SPA_PARAM_PROFILE_index, SPA_POD_Int(&profileIndex),
+            SPA_PARAM_PROFILE_name, SPA_POD_OPT_String(&profileName), SPA_PARAM_PROFILE_description,
+            SPA_POD_OPT_String(&profileDescription), SPA_PARAM_PROFILE_priority, SPA_POD_OPT_Int(&profilePriority)
+        )
+        < 0) {
+      return;
+    }
+
+    const spa_pod_prop* availProp = spa_pod_find_prop(param, nullptr, SPA_PARAM_PROFILE_available);
+    std::uint32_t profileAvailable = SPA_PARAM_AVAILABILITY_unknown;
+    if (availProp != nullptr) {
+      spa_pod_get_id(&availProp->value, &profileAvailable);
+    }
+
+    DeviceProfileData profile;
+    profile.index = profileIndex >= 0 ? profileIndex : static_cast<std::int32_t>(index);
+    profile.name = profileName != nullptr ? profileName : "";
+    profile.description = profileDescription != nullptr ? profileDescription : "";
+    profile.priority = profilePriority;
+    profile.available = profileAvailable;
+
+    if (paramId == SPA_PARAM_EnumProfile) {
+      const auto existing = std::ranges::find(it->second.profiles, profile.index, &DeviceProfileData::index);
+      if (existing == it->second.profiles.end()) {
+        it->second.profiles.push_back(profile);
+      } else {
+        *existing = profile;
+      }
+    } else {
+      it->second.activeProfileIndex = profile.index;
+    }
+
+    rebuildState();
+    return;
+  }
+
+  if (paramId != SPA_PARAM_Route) {
+    return;
+  }
   auto it = m_devices.find(id);
   if (it == m_devices.end()) {
     return;

--- a/src/pipewire/pipewire_service.h
+++ b/src/pipewire/pipewire_service.h
@@ -21,6 +21,12 @@ class ConfigService;
 class IpcService;
 class WirePlumberMixer;
 
+struct AudioCodecOption {
+  std::int32_t profileIndex = -1;
+  std::string label;
+
+  bool operator==(const AudioCodecOption&) const = default;
+};
 struct AudioNode {
   std::uint32_t id = 0;
   std::string name;
@@ -36,6 +42,10 @@ struct AudioNode {
   std::uint32_t channelCount = 0;
   bool isDefault = false;
   bool available = true; // false for a device whose active route is unavailable (e.g. unplugged HDMI)
+
+  std::uint32_t deviceId = 0; // Bluetooth codec/profile options for this device (e.g. AAC/SBC/LDAC), empty for non-Bluetooth devices or Bluetooth devices with only one usable profile.
+  std::vector<AudioCodecOption> codecOptions;
+  std::size_t activeCodecIndex = static_cast<std::size_t>(-1);
 
   bool operator==(const AudioNode&) const = default;
 };
@@ -111,6 +121,9 @@ public:
   void setSourceVolume(std::uint32_t id, float volume);
   void setSourceMuted(std::uint32_t id, bool muted);
   void setDefaultSource(std::uint32_t id);
+  // Applies a PipeWire device profile by index (the mechanism Bluetooth codec choice is exposed
+  // through — see AudioNode::codecOptions). No-op if the device is no longer known. 
+  void setDeviceProfile(std::uint32_t deviceId, std::int32_t profileIndex);
 
   // Convenience (operates on default sink/source)
   void setVolume(float volume);
@@ -136,6 +149,13 @@ public:
     std::int32_t priority = 0;
     std::uint32_t available = SPA_PARAM_AVAILABILITY_unknown;
     bool muted = false;
+  };
+  struct DeviceProfileData {
+    std::int32_t index = -1;
+    std::string name;
+    std::string description;
+    std::int32_t priority = 0;
+    std::uint32_t available = SPA_PARAM_AVAILABILITY_unknown;
   };
   struct NodeData {
     PipeWireService* service = nullptr;
@@ -190,6 +210,9 @@ public:
     struct pw_device* proxy = nullptr;
     spa_hook* listener = nullptr;
     std::vector<DeviceRouteData> routes;
+    bool isBluetooth = false;
+    std::vector<DeviceProfileData> profiles;
+    std::int32_t activeProfileIndex = -1;
   };
   struct LinkData {
     std::uint32_t id = 0;

--- a/src/pipewire/pipewire_service.h
+++ b/src/pipewire/pipewire_service.h
@@ -43,7 +43,8 @@ struct AudioNode {
   bool isDefault = false;
   bool available = true; // false for a device whose active route is unavailable (e.g. unplugged HDMI)
 
-  std::uint32_t deviceId = 0; // Bluetooth codec/profile options for this device (e.g. AAC/SBC/LDAC), empty for non-Bluetooth devices or Bluetooth devices with only one usable profile.
+  std::uint32_t deviceId = 0; // Bluetooth codec/profile options for this device (e.g. AAC/SBC/LDAC), empty for
+                              // non-Bluetooth devices or Bluetooth devices with only one usable profile.
   std::vector<AudioCodecOption> codecOptions;
   std::size_t activeCodecIndex = static_cast<std::size_t>(-1);
 
@@ -122,7 +123,7 @@ public:
   void setSourceMuted(std::uint32_t id, bool muted);
   void setDefaultSource(std::uint32_t id);
   // Applies a PipeWire device profile by index (the mechanism Bluetooth codec choice is exposed
-  // through — see AudioNode::codecOptions). No-op if the device is no longer known. 
+  // through — see AudioNode::codecOptions). No-op if the device is no longer known.
   void setDeviceProfile(std::uint32_t deviceId, std::int32_t profileIndex);
 
   // Convenience (operates on default sink/source)

--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -1713,6 +1713,7 @@ std::unique_ptr<Flex> AudioTab::createDeviceVolumeCard(DeviceVolumeCardSpec card
                     .text = i18n::tr("control-center.audio.codec") + ":",
                     .fontSize = Style::fontSizeCaption * scale,
                     .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                    .configure = [](Label& label) { label.setTooltip(i18n::tr("control-center.audio.codec-tooltip")); },
                 }),
                 ui::select({
                     .out = &card.state.codecSelect,

--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -1702,33 +1702,33 @@ std::unique_ptr<Flex> AudioTab::createDeviceVolumeCard(DeviceVolumeCardSpec card
           })
       ),
       ui::row(
-                {
-                    .out = &card.state.codecRow,
-                    .align = FlexAlign::Center,
-                    .gap = Style::spaceSm * scale,
-                    .visible = false,
-                    .participatesInLayout = false,
-                },
-                ui::label({
-                    .text = i18n::tr("control-center.audio.codec") + ":",
-                    .fontSize = Style::fontSizeCaption * scale,
-                    .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                    .configure = [](Label& label) { label.setTooltip(i18n::tr("control-center.audio.codec-tooltip")); },
-                }),
-                ui::select({
-                    .out = &card.state.codecSelect,
-                    .placeholder = i18n::tr("control-center.audio.choose-codec"),
-                    .fontSize = Style::fontSizeCaption * scale,
-                    .controlHeight = Style::controlHeightSm * scale,
-                    .horizontalPadding = Style::spaceSm * scale,
-                    .glyphSize = Style::fontSizeBody * scale,
-                    .notifyOnReselect = true,
-                    .enabled = false,
-                    .surfaceOpacity = panelCardOpacity(),
-                    .height = Style::controlHeightSm * scale,
-                    .flexGrow = 1.0F,
-                })
-            )
+          {
+              .out = &card.state.codecRow,
+              .align = FlexAlign::Center,
+              .gap = Style::spaceSm * scale,
+              .visible = false,
+              .participatesInLayout = false,
+          },
+          ui::label({
+              .text = i18n::tr("control-center.audio.codec") + ":",
+              .fontSize = Style::fontSizeCaption * scale,
+              .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+              .configure = [](Label& label) { label.setTooltip(i18n::tr("control-center.audio.codec-tooltip")); },
+          }),
+          ui::select({
+              .out = &card.state.codecSelect,
+              .placeholder = i18n::tr("control-center.audio.choose-codec"),
+              .fontSize = Style::fontSizeCaption * scale,
+              .controlHeight = Style::controlHeightSm * scale,
+              .horizontalPadding = Style::spaceSm * scale,
+              .glyphSize = Style::fontSizeBody * scale,
+              .notifyOnReselect = true,
+              .enabled = false,
+              .surfaceOpacity = panelCardOpacity(),
+              .height = Style::controlHeightSm * scale,
+              .flexGrow = 1.0F,
+          })
+      )
   );
 }
 

--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -1700,7 +1700,34 @@ std::unique_ptr<Flex> AudioTab::createDeviceVolumeCard(DeviceVolumeCardSpec card
               .height = Style::controlHeightSm * scale,
               .flexGrow = 1.0F,
           })
-      )
+      ),
+      ui::row(
+                {
+                    .out = &card.state.codecRow,
+                    .align = FlexAlign::Center,
+                    .gap = Style::spaceSm * scale,
+                    .visible = false,
+                    .participatesInLayout = false,
+                },
+                ui::label({
+                    .text = i18n::tr("control-center.audio.codec") + ":",
+                    .fontSize = Style::fontSizeCaption * scale,
+                    .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                }),
+                ui::select({
+                    .out = &card.state.codecSelect,
+                    .placeholder = i18n::tr("control-center.audio.choose-codec"),
+                    .fontSize = Style::fontSizeCaption * scale,
+                    .controlHeight = Style::controlHeightSm * scale,
+                    .horizontalPadding = Style::spaceSm * scale,
+                    .glyphSize = Style::fontSizeBody * scale,
+                    .notifyOnReselect = true,
+                    .enabled = false,
+                    .surfaceOpacity = panelCardOpacity(),
+                    .height = Style::controlHeightSm * scale,
+                    .flexGrow = 1.0F,
+                })
+            )
   );
 }
 
@@ -1833,6 +1860,7 @@ void AudioTab::doUpdate(Renderer& renderer) {
   rebuildProgramVolumes(renderer);
   syncValueLabelWidths(renderer);
   syncEffectsProfileControls(renderer);
+  syncCodecControls(renderer);
 
   if (m_audio != nullptr) {
     const AudioState& state = m_audio->state();
@@ -1954,6 +1982,7 @@ void AudioTab::onClose() {
   m_outputDeviceVolume = {};
   m_inputDeviceVolume = {};
   m_lastEffectsProfileListKey.clear();
+  m_lastCodecListKey.clear();
   m_lastOutputWidth = -1.0F;
   m_lastInputWidth = -1.0F;
   m_lastOutputListKey.clear();
@@ -2060,6 +2089,65 @@ void AudioTab::syncEffectsProfileControls(Renderer& /*renderer*/) {
       inputProfiles, activeInput, m_inputDeviceVolume.effectsProfileRow, m_inputDeviceVolume.effectsProfileSelect,
       AudioEffectsProfileKind::Input
   );
+}
+void AudioTab::syncCodecControls(Renderer& /*renderer*/) {
+  const AudioNode* sink = m_audio != nullptr ? m_audio->defaultSink() : nullptr;
+  static const std::vector<AudioCodecOption> kNoOptions;
+  const std::vector<AudioCodecOption>& options = sink != nullptr ? sink->codecOptions : kNoOptions;
+  const std::uint32_t deviceId = sink != nullptr ? sink->deviceId : 0;
+  const std::size_t activeIndex = sink != nullptr ? sink->activeCodecIndex : static_cast<std::size_t>(-1);
+
+  std::string key = std::to_string(deviceId);
+  key.push_back('\n');
+  key += std::to_string(activeIndex);
+  key.push_back('\n');
+  for (const auto& option : options) {
+    key += option.label;
+    key.push_back('\n');
+  }
+
+  if (key == m_lastCodecListKey) {
+    return;
+  }
+  m_lastCodecListKey = std::move(key);
+
+  Flex* row = m_outputDeviceVolume.codecRow;
+  Select* select = m_outputDeviceVolume.codecSelect;
+  if (row == nullptr || select == nullptr) {
+    return;
+  }
+
+  const bool hasOptions = options.size() >= 2;
+  row->setVisible(hasOptions);
+  row->setParticipatesInLayout(hasOptions);
+  select->setEnabled(hasOptions);
+  select->setOnSelectionChanged(nullptr);
+
+  if (!hasOptions) {
+    select->setOptions({});
+    select->clearSelection();
+    return;
+  }
+
+  std::vector<std::string> labels;
+  labels.reserve(options.size());
+  for (const auto& option : options) {
+    labels.push_back(option.label);
+  }
+  select->setOptions(labels);
+
+  if (activeIndex < options.size()) {
+    select->setSelectedIndex(activeIndex);
+  } else {
+    select->clearSelection();
+  }
+
+  select->setOnSelectionChanged([this, deviceId, options](std::size_t index, std::string_view /*label*/) {
+    if (m_audio == nullptr || index >= options.size()) {
+      return;
+    }
+    m_audio->setDeviceProfile(deviceId, options[index].profileIndex);
+  });
 }
 
 void AudioTab::rebuildProgramVolumes(Renderer& renderer) {

--- a/src/shell/control_center/tabs/audio_tab.h
+++ b/src/shell/control_center/tabs/audio_tab.h
@@ -52,6 +52,8 @@ private:
     Button* muteButton = nullptr;
     Flex* effectsProfileRow = nullptr;
     Select* effectsProfileSelect = nullptr;
+    Flex* codecRow = nullptr;
+    Select* codecSelect = nullptr;
     Timer volumeDebounceTimer;
     bool syncing = false;
   };
@@ -86,6 +88,7 @@ private:
 
   void openDeviceMenu(DeviceVolumeCardState& card, const DeviceMenuModel& menu);
   void syncEffectsProfileControls(Renderer& renderer);
+  void syncCodecControls(Renderer& renderer);
 
   PipeWireService* m_audio = nullptr;
   EasyEffectsService* m_easyEffects = nullptr;
@@ -107,6 +110,7 @@ private:
   Flex* m_programList = nullptr;
   std::vector<Flex*> m_programRows;
   std::string m_lastProgramListKey;
+  std::string m_lastCodecListKey;
   float m_lastProgramSliderMax = -1.0F;
   std::string m_lastEffectsProfileListKey;
   float m_syncedPercentLabelMinWidth = -1.0F;


### PR DESCRIPTION
## Summary

Adds a **Codec** drop-down menu to the Output card in the Audio control-center tab, letting users switch the codec of a connected Bluetooth audio device (SBC / SBC-XQ / AAC / LDAC / aptX / HFP) without leaving the shell.

`PipeWireService` already tracks PipeWire `Device` objects for route/port handling, so this extends that to subscribe to `SPA_PARAM_EnumProfile` / `SPA_PARAM_Profile`. Only for devices reporting `device.api = "bluez5"`, so non-Bluetooth cards see no additional registry traffic. Applying a selection builds a `SPA_TYPE_OBJECT_ParamProfile` pod with `save = true`, the same mechanism `wpctl set-profile` uses, so WirePlumber persists the choice across reconnects with no extra state on our side.

The row hides itself unless the active output is a Bluetooth device exposing two or more codec choices, matching the existing behavior of the Effects profile row directly above it.

## Motivation

Bluetooth headsets frequently drop to a low-quality handsfree codec commonly after handling a call. As of now there is currently no in-shell way to switch back. Users have to reach for `wiremix`, `wpctl`, or `pavucontrol`. Some also want to trade quality against latency depending on what they are doing.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3634

## Testing

```sh
just build          # clean, no new warnings
just test           # 75/75 passing
just format         # applied
just lint           # clang-tidy clean on changed files
python3 tools/i18n-check.py   # OK, 874 keys
```

Manual, on a Galaxy Buds3 Pro (multi-codec: SBC / SBC-XQ / AAC, plus HFP variants):

- Codec row appears once the device is the active output, listing `SBC`, `SBC-XQ`, `AAC`, `HFP`
- Selecting a codec applies immediately; the active profile is reflected with a checkmark
- Row stays hidden for a USB wireless headset (Logitech G733; not `bluez5`)
- Renders correctly alongside the EasyEffects profile row when both are present

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
<img width="769" height="630" alt="1" src="https://github.com/user-attachments/assets/2bcd0f37-be3f-425f-adff-eea55e5323fe" />

<img width="723" height="623" alt="2" src="https://github.com/user-attachments/assets/85942ad0-13d0-4442-9026-3f61b9efd627" />

<img width="628" height="610" alt="with effects" src="https://github.com/user-attachments/assets/08d907a4-49a6-4f4f-9660-7a1cb7bbee82" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

**Why the labels are derived rather than taken verbatim.** PipeWire reports these profiles for the test device:

| name | description | priority |
|---|---|---|
| `off` | Off | 0 |
| `a2dp-sink-sbc` | High Fidelity Playback (A2DP Sink, codec SBC) | 133 |
| `a2dp-sink-sbc_xq` | High Fidelity Playback (A2DP Sink, codec SBC-XQ) | 132 |
| `a2dp-sink` | High Fidelity Playback (A2DP Sink, codec AAC) | 134 |
| `headset-head-unit-cvsd` | Headset Head Unit (HSP/HFP, codec CVSD) | 5 |
| `headset-head-unit-msbc` | Headset Head Unit (HSP/HFP, codec MSBC) | 6 |
| `headset-head-unit` | Headset Head Unit (HSP/HFP, codec LC3-SWB) | 7 |

Three things fall out of this:

1. Seven profiles are only four meaningful choices and the three headset variants are one decision to a user ("the mode with a microphone"), so they are collapsed.
2. Matching codec names by substring is unsafe: `headset-head-unit-msbc` contains `sbc` and would be mislabeled as the A2DP SBC codec. Each profile is therefore reduced to a codec *key* first, with headset profiles classified before any codec parsing.
3. The unsuffixed names (`a2dp-sink`, `headset-head-unit`) carry the device's *best* codec and the highest priority in their group, so where several profiles share a key the highest-priority one wins. Picking the first would have selected CVSD, the worst option available.

The active selection is matched by codec key rather than profile index, so if PipeWire reports the active profile as a variant that was folded into another entry, the surviving entry still shows as selected.

Labels are codec and protocol acronyms only (`SBC`, `AAC`, `HFP`, …), so nothing here needs translating and no i18n plumbing was added to `src/pipewire`.

**Known limitation.** If a user manually selects a virtual sink (for example "Easy Effects Sink") as their output device, the Codec row hides, since that sink has no device behind it. This is not the default EasyEffects behavior as it intercepts the application streams rather than taking over the default sink. But resolving the real downstream device would need link-graph walking, which seemed disproportionate here. Happy to add it if wanted.