### PR TITLE
feat(theme): allow setting a separate theme mode for apps

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1446,6 +1446,9 @@
           "dark": "Dark",
           "light": "Light"
         },
+        "shell-mode": {
+          "follow": "Follow"
+        },
         "source": {
           "built-in": "Built-In",
           "community": "Community",
@@ -1602,9 +1605,6 @@
           "description": "Recolor application icons across the shell to match the active palette",
           "label": "Colorize App Icons"
         },
-        "app-theme-mode": {
-          "label": "App Theme Mode"
-        },
         "builtin-palette": {
           "description": "Choose a palette from the bundled catalog",
           "label": "Built-In Palette"
@@ -1670,12 +1670,12 @@
           "description": "Anchor dark surfaces to true black, preventing banding on OLED panels (dark mode only)",
           "label": "Pure Black"
         },
-        "separate-theme-mode-for-apps": {
-          "description": "Apps use a separate theme mode from Noctalia",
-          "label": "Separate Theme Mode For Apps"
+        "shell-theme-mode": {
+          "description": "Pin Noctalia's own light or dark mode; Follow keeps it in sync with Theme Mode",
+          "label": "Shell Theme Mode"
         },
         "theme-mode": {
-          "description": "Choose Dark, Light, or Auto based on time of day",
+          "description": "Choose Dark, Light, or Auto based on time of day; also applies to apps through templates",
           "label": "Theme Mode"
         },
         "ui-scale": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1602,6 +1602,9 @@
           "description": "Recolor application icons across the shell to match the active palette",
           "label": "Colorize App Icons"
         },
+        "app-theme-mode": {
+          "label": "App Theme Mode"
+        },
         "builtin-palette": {
           "description": "Choose a palette from the bundled catalog",
           "label": "Built-In Palette"
@@ -1666,6 +1669,10 @@
         "pure-black-dark": {
           "description": "Anchor dark surfaces to true black, preventing banding on OLED panels (dark mode only)",
           "label": "Pure Black"
+        },
+        "separate-theme-mode-for-apps": {
+          "description": "Apps use a separate theme mode from Noctalia",
+          "label": "Separate Theme Mode For Apps"
         },
         "theme-mode": {
           "description": "Choose Dark, Light, or Auto based on time of day",

--- a/docs/user/automation/hooks.mdx
+++ b/docs/user/automation/hooks.mdx
@@ -20,7 +20,7 @@ Noctalia's own feedback.
 | `started` | Once after Noctalia finishes startup (IPC ready). |
 | `wallpaper_changed` | After a persisted wallpaper path change is applied. Sets `NOCTALIA_WALLPAPER_PATH` and `NOCTALIA_WALLPAPER_CONNECTOR` (for example `DP-1`; empty when the change is not tied to a live connector). |
 | `colors_changed` | After the theme palette is resolved and terminal templates are updated. |
-| `theme_mode_changed` | After theme templates are applied, when the resolved theme mode changes between `light` and `dark`. Sets `NOCTALIA_THEME_MODE`, `NOCTALIA_THEME_MODE_PREVIOUS`, and `NOCTALIA_THEME_MODE_CONFIGURED` (`dark`, `light`, or `auto`). |
+| `theme_mode_changed` | After theme templates are applied, when the resolved [`[theme].mode`](/noctalia/theming/#mode) changes between `light` and `dark`. This is the app-facing mode, so it ignores [`shell_mode`](/noctalia/theming/#shell_mode). Sets `NOCTALIA_THEME_MODE`, `NOCTALIA_THEME_MODE_PREVIOUS`, and `NOCTALIA_THEME_MODE_CONFIGURED` (`dark`, `light`, or `auto`). |
 | `session_locked` | When the compositor confirms the session lock. |
 | `session_unlocked` | When the session leaves the locked state. |
 | `logging_out` | Immediately before the session panel runs the logout sequence. |

--- a/docs/user/plugins/development/runtime-api.mdx
+++ b/docs/user/plugins/development/runtime-api.mdx
@@ -21,7 +21,7 @@ boolean immediately to say whether the work was accepted, then deliver results t
 |--------|---------|-------------|
 | `noctalia.setUpdateInterval(ms)` | nothing | Sets how often this entry's `update()` function runs. Values below 16 ms are clamped. |
 | `noctalia.log(msg)` | nothing | Writes a message to Noctalia's log with this plugin's script context. |
-| `noctalia.isDarkMode()` | bool | Returns whether the active theme mode is dark. |
+| `noctalia.isDarkMode()` | bool | Returns whether the palette Noctalia renders with is dark, so it tracks [`[theme].shell_mode`](/noctalia/theming/#shell_mode) when that is pinned. |
 | `noctalia.getSetting(path)` | config value or `nil` | Reads any effective shell config value by TOML dotted path. Tables and arrays become Luau tables; array indices in paths are zero-based. Missing paths log a warning and return `nil`. Requires <PluginApiBadge feature="get-setting" />. |
 | `noctalia.focusedOutputName()` | string or `nil` | Returns the focused output's connector name, falling back to the preferred interactive output when needed. |
 | `noctalia.getConfig(key)` | setting value or `nil` | Reads a declared plugin or entry setting. Undeclared keys log a warning and return `nil`. |

--- a/docs/user/theming/app-theming.mdx
+++ b/docs/user/theming/app-theming.mdx
@@ -7,6 +7,9 @@ sidebar:
 
 Noctalia can render the resolved theme colors into external app config files whenever the palette changes. This lets terminals, editors, browsers, launchers, and other apps follow the same colors as the shell.
 
+Templates always render the variant selected by [`[theme].mode`](/noctalia/theming/#mode), never
+[`shell_mode`](/noctalia/theming/#shell_mode), so pinning Noctalia to dark keeps your apps on whatever `mode` resolves to.
+
 To rerender enabled templates for the current palette without changing the theme, use
 [Media & UI → Theme](/noctalia/ipc/media-and-ui/#theme).
 

--- a/docs/user/theming/index.mdx
+++ b/docs/user/theming/index.mdx
@@ -5,11 +5,12 @@ sidebar:
   order: 8
 ---
 
-Controls the active palette source and dark/light mode used across the shell.
+Controls the active palette source and the dark/light modes used by Noctalia and by your apps.
 
 ```toml
 [theme]
 mode              = "dark"        # dark | light | auto
+shell_mode        = "follow"      # follow | dark | light | auto
 source            = "builtin"     # builtin | wallpaper | community | custom
 builtin           = "Noctalia"    # bundled palette name
 community_palette = "Oxocarbon"   # community palette name when source = "community"
@@ -30,6 +31,25 @@ sunset computed from your coordinates, or your own `sunset` / `sunrise` times wh
 [`custom_schedule = true`](/noctalia/services/location/#custom-schedule). Night light does not need to be enabled for theme
 auto to follow the schedule. When the schedule cannot be resolved, `auto` uses the light (day) palette until a valid
 schedule is available.
+
+This is the mode your apps run in: it selects the palette variant written by
+[templates](/noctalia/theming/templates/), the GNOME `color-scheme` preference, and the mode reported to
+[`theme_mode_changed`](/noctalia/automation/hooks/) hooks. `theme-mode-toggle`, `theme-mode-set`, the control center
+shortcut, and the theme mode bar widget all act on this key.
+
+## `shell_mode`
+
+Noctalia's own mode: bars, panels, the launcher, wallpaper directory selection, and the greeter appearance.
+
+| Value | Description |
+|-------|-------------|
+| `follow` | Track `mode`, so Noctalia and your apps switch together (default). |
+| `dark` / `light` | Pin Noctalia to that variant while `mode` keeps driving apps. |
+| `auto` | Switch Noctalia on the `[location]` schedule, independently of `mode`. |
+
+Pinning it gives combinations such as a permanently dark bar with light apps, or a dark bar while apps follow the
+day/night schedule. Templates and the GNOME `color-scheme` preference never follow `shell_mode`; a `shell_mode`-only
+change repaints Noctalia without rewriting a single template.
 
 ## `pure_black_dark`
 

--- a/meson.build
+++ b/meson.build
@@ -1215,6 +1215,7 @@ if build_tests
     'template_apply_notify',
     'template_hook_async',
     'template_hook_runner',
+    'theme_shell_mode',
     'time_format',
     'tray_identifier',
     'triad_workspace_backend',

--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -762,7 +762,7 @@ void Application::initIpc() {
   m_dock.registerIpc(m_ipcService);
   m_wallpaper.registerIpc(m_ipcService);
   greeter::registerIpc(
-      m_ipcService, m_configService, [this]() { return m_themeService.resolvedMode(); }, &m_compositorPlatform,
+      m_ipcService, m_configService, [this]() { return m_themeService.resolvedShellMode(); }, &m_compositorPlatform,
       [this]() { return m_logindService != nullptr; }
   );
   if (m_mprisService) {

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -559,7 +559,8 @@ void Application::initStyleThemeAndWayland() {
 
   // Apply theme before any UI constructs palette-dependent scene nodes.
   auto syncScriptApiWallpaperDirectory = [this]() {
-    const ThemeMode mode = m_themeService.resolvedMode() == "light" ? ThemeMode::Light : ThemeMode::Dark;
+    // Wallpapers are a shell surface, so they follow Noctalia's own mode.
+    const ThemeMode mode = m_themeService.isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
     m_scriptApi.setWallpaperDirectory(
         wallpaper::resolveGlobalWallpaperDirectory(m_configService.config().wallpaper, mode)
     );
@@ -651,7 +652,7 @@ void Application::initStyleThemeAndWayland() {
                                      ) mutable {
     const std::string resolvedMode(mode);
     const std::string configuredMode(enumToKey(kThemeModes, m_themeService.configuredMode()));
-    m_scriptApi.setDarkMode(resolvedMode != "light");
+    m_scriptApi.setDarkMode(!m_themeService.isLightMode());
     syncScriptApiWallpaperDirectory();
     const std::optional<std::string> previousMode = lastResolvedThemeMode;
     lastResolvedThemeMode = resolvedMode;
@@ -1007,7 +1008,7 @@ void Application::initSystemBusServices() {
             // Screen time must not accumulate across suspend even when lock-before-suspend is off.
             m_screenTimeService.setSuspendPaused(true);
             // Delay inhibit (when lock_before_suspend is on) holds sleep until we lock.
-            // Do not use runAfterSessionLocked here — that slot belongs to lock-and-suspend.
+            // Do not use runAfterSessionLocked here: that slot belongs to lock-and-suspend.
             if (m_skipLockOnNextSleep) {
               // Noctalia-initiated suspend: skip lock-before-sleep (plain Suspend or already locked).
               m_skipLockOnNextSleep = false;

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -234,7 +234,7 @@ void Application::performGreeterSync(bool quiet) {
     m_polkitAgent->markNextRequestInternal();
   }
   const auto launch = greeter::syncAppearanceToGreeterAsync(
-      m_configService, m_themeService.resolvedMode(), complete, &m_compositorPlatform, m_logindService != nullptr
+      m_configService, m_themeService.resolvedShellMode(), complete, &m_compositorPlatform, m_logindService != nullptr
   );
   if (launch == greeter::GreeterSyncLaunch::Failed) {
     if (quiet) {
@@ -447,7 +447,7 @@ void Application::initInputDispatch() {
       m_lockScreen.onKeyboardEvent(event);
       return;
     }
-    // Grab popups are modal — while one is open it owns the keyboard and ESC
+    // Grab popups are modal: while one is open it owns the keyboard and ESC
     // dismisses it before anything behind can react.
     if (ContextMenuPopup::dispatchKeyboardEvent(event)) {
       return;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1441,6 +1441,22 @@ constexpr EnumOption<ThemeMode> kThemeModes[] = {
     {ThemeMode::Auto, "auto", "common.states.auto"},
 };
 
+// Noctalia's own light/dark mode. `follow` tracks [theme].mode, which always drives apps
+// (templates and the GTK color scheme); the other values pin the shell independently.
+enum class ShellThemeMode : std::uint8_t {
+  Follow = 0,
+  Dark = 1,
+  Light = 2,
+  Auto = 3,
+};
+
+constexpr EnumOption<ShellThemeMode> kShellThemeModes[] = {
+    {ShellThemeMode::Follow, "follow", "settings.options.theme.shell-mode.follow"},
+    {ShellThemeMode::Dark, "dark", "settings.options.theme.mode.dark"},
+    {ShellThemeMode::Light, "light", "settings.options.theme.mode.light"},
+    {ShellThemeMode::Auto, "auto", "common.states.auto"},
+};
+
 struct WallpaperFavorite {
   std::string path;
   ThemeMode themeMode = ThemeMode::Auto;
@@ -1526,13 +1542,28 @@ struct ThemeConfig {
   std::string customPalette;
   std::string wallpaperScheme = "m3-content";
   ThemeMode mode = ThemeMode::Dark;
-  bool separateThemeModeForApps = false;
-  ThemeMode appMode = ThemeMode::Dark;
+  ShellThemeMode shellMode = ShellThemeMode::Follow;
   bool pureBlackDark = false;
   TemplatesConfig templates;
 
   bool operator==(const ThemeConfig&) const = default;
 };
+
+// The theme mode Noctalia's own surfaces run in, still expressed as a ThemeMode so `auto`
+// keeps resolving against the day/night schedule.
+[[nodiscard]] constexpr ThemeMode shellThemeMode(const ThemeConfig& theme) noexcept {
+  switch (theme.shellMode) {
+  case ShellThemeMode::Dark:
+    return ThemeMode::Dark;
+  case ShellThemeMode::Light:
+    return ThemeMode::Light;
+  case ShellThemeMode::Auto:
+    return ThemeMode::Auto;
+  case ShellThemeMode::Follow:
+    break;
+  }
+  return theme.mode;
+}
 
 struct ControlCenterConfig {
   static constexpr std::int32_t kDefaultWidth = 700;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1526,6 +1526,8 @@ struct ThemeConfig {
   std::string customPalette;
   std::string wallpaperScheme = "m3-content";
   ThemeMode mode = ThemeMode::Dark;
+  bool separateThemeModeForApps = false;
+  ThemeMode appMode = ThemeMode::Dark;
   bool pureBlackDark = false;
   TemplatesConfig templates;
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1207,6 +1207,8 @@ namespace noctalia::config::schema {
         field(&ThemeConfig::customPalette, "custom_palette"),
         field(&ThemeConfig::wallpaperScheme, "wallpaper_scheme"),
         enumField(&ThemeConfig::mode, "mode", kThemeModes),
+        field(&ThemeConfig::separateThemeModeForApps, "separate_theme_mode_for_apps"),
+        enumField(&ThemeConfig::appMode, "app_mode", kThemeModes),
         field(&ThemeConfig::pureBlackDark, "pure_black_dark"),
         subTable(&ThemeConfig::templates, "templates", templatesSchema()),
     };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1207,8 +1207,7 @@ namespace noctalia::config::schema {
         field(&ThemeConfig::customPalette, "custom_palette"),
         field(&ThemeConfig::wallpaperScheme, "wallpaper_scheme"),
         enumField(&ThemeConfig::mode, "mode", kThemeModes),
-        field(&ThemeConfig::separateThemeModeForApps, "separate_theme_mode_for_apps"),
-        enumField(&ThemeConfig::appMode, "app_mode", kThemeModes),
+        enumField(&ThemeConfig::shellMode, "shell_mode", kShellThemeModes),
         field(&ThemeConfig::pureBlackDark, "pure_black_dark"),
         subTable(&ThemeConfig::templates, "templates", templatesSchema()),
     };

--- a/src/launcher/wallpaper_provider.cpp
+++ b/src/launcher/wallpaper_provider.cpp
@@ -76,7 +76,7 @@ std::vector<LauncherResult> WallpaperProvider::query(std::string_view text) cons
   }
 
   const std::string query = StringUtils::toLower(StringUtils::trim(text));
-  const ThemeMode configured = m_config->config().theme.mode;
+  const ThemeMode configured = shellThemeMode(m_config->config().theme);
   const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
   auto candidates = collectWallpapers(
       wallpaper::resolveGlobalWallpaperDirectory(

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -467,18 +467,11 @@ namespace settings {
         asSegmented(enumSelect(kThemeModes, cfg.theme.mode)), "dark light auto colors"
     ));
     entries.push_back(makeEntry(
-        SettingsSection::Appearance, "theme", tr("settings.schema.appearance.separate-theme-mode-for-apps.label"),
-        tr("settings.schema.appearance.separate-theme-mode-for-apps.description"),
-        {"theme", "separate_theme_mode_for_apps"}, ToggleSetting{cfg.theme.separateThemeModeForApps},
-        "dark light auto colors"
+        SettingsSection::Appearance, "theme", tr("settings.schema.appearance.shell-theme-mode.label"),
+        tr("settings.schema.appearance.shell-theme-mode.description"), {"theme", "shell_mode"},
+        asSegmented(enumSelect(kShellThemeModes, cfg.theme.shellMode)),
+        "dark light auto follow shell apps templates colors"
     ));
-    if (cfg.theme.separateThemeModeForApps) {
-      entries.push_back(makeEntry(
-          SettingsSection::Appearance, "theme", tr("settings.schema.appearance.app-theme-mode.label"),
-          tr("settings.schema.appearance.theme-mode.description"), {"theme", "app_mode"},
-          asSegmented(enumSelect(kThemeModes, cfg.theme.appMode)), "dark light auto colors"
-      ));
-    }
     entries.push_back(makeEntry(
         SettingsSection::Appearance, "theme", tr("settings.schema.appearance.palette-source.label"),
         tr("settings.schema.appearance.palette-source.description"), {"theme", "source"},
@@ -488,7 +481,7 @@ namespace settings {
       entries.push_back(makeEntry(
           SettingsSection::Appearance, "theme", tr("settings.schema.appearance.builtin-palette.label"),
           tr("settings.schema.appearance.builtin-palette.description"), {"theme", "builtin"},
-          builtinPaletteSelect(cfg.theme.builtinPalette, cfg.theme.mode), "builtin palette colors"
+          builtinPaletteSelect(cfg.theme.builtinPalette, shellThemeMode(cfg.theme)), "builtin palette colors"
       ));
     } else if (cfg.theme.source == PaletteSource::Wallpaper) {
       entries.push_back(makeEntry(
@@ -1625,7 +1618,10 @@ namespace settings {
               .browseMode = TextSettingBrowseMode::OpenFile,
               .browseFileExtensions = DirectoryScanner::imageExtensionFilter(true),
               .browseFallbackDirectory = wallpaper::resolveGlobalWallpaperDirectory(
-                  cfg.wallpaper, wallpaper::effectiveThemeMode(cfg.theme.mode, cfg.theme.mode == ThemeMode::Light)
+                  cfg.wallpaper,
+                  wallpaper::effectiveThemeMode(
+                      shellThemeMode(cfg.theme), shellThemeMode(cfg.theme) == ThemeMode::Light
+                  )
               ),
           },
           "lock screen background image custom"

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -467,6 +467,19 @@ namespace settings {
         asSegmented(enumSelect(kThemeModes, cfg.theme.mode)), "dark light auto colors"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "theme", tr("settings.schema.appearance.separate-theme-mode-for-apps.label"),
+        tr("settings.schema.appearance.separate-theme-mode-for-apps.description"),
+        {"theme", "separate_theme_mode_for_apps"}, ToggleSetting{cfg.theme.separateThemeModeForApps},
+        "dark light auto colors"
+    ));
+    if (cfg.theme.separateThemeModeForApps) {
+      entries.push_back(makeEntry(
+          SettingsSection::Appearance, "theme", tr("settings.schema.appearance.app-theme-mode.label"),
+          tr("settings.schema.appearance.theme-mode.description"), {"theme", "app_mode"},
+          asSegmented(enumSelect(kThemeModes, cfg.theme.appMode)), "dark light auto colors"
+      ));
+    }
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "theme", tr("settings.schema.appearance.palette-source.label"),
         tr("settings.schema.appearance.palette-source.description"), {"theme", "source"},
         asSegmented(enumSelect(kPaletteSources, cfg.theme.source)), "palette colors"

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -751,7 +751,7 @@ settings::RegistryEnvironment SettingsWindow::buildRegistryEnvironment() const {
   env.gammaControlAvailable = (m_wayland != nullptr && m_wayland->hasGammaControl());
   env.greeterSyncAvailable =
       m_config != nullptr && greeter::appearanceSyncAvailable(m_config->config().shell.greeterSync);
-  const ThemeMode previewMode = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
+  const ThemeMode previewMode = m_config != nullptr ? shellThemeMode(m_config->config().theme) : ThemeMode::Dark;
   for (const auto& paletteInfo : noctalia::theme::availableCommunityPalettes()) {
     env.communityPalettes.push_back(
         settings::SelectOption{

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -55,7 +55,7 @@ namespace {
   constexpr float kMonitorSelectMinWidth = 136.0F;
   constexpr float kFavoriteSelectMinWidth = 168.0F;
   constexpr float kFavoritesMetaRowGap = Style::spaceSm;
-  constexpr float kTileAspect = 0.78F; // height / width — leaves room for label under widescreen thumb
+  constexpr float kTileAspect = 0.78F; // height / width, leaves room for label under widescreen thumb
 
   [[nodiscard]] std::size_t themeModeSegmentIndex(ThemeMode mode) {
     switch (mode) {
@@ -598,7 +598,7 @@ void WallpaperPanel::create() {
       .fillWidth = true,
   });
 
-  // Only offer palette sources that actually have palettes — Community/Custom are empty
+  // Only offer palette sources that actually have palettes; Community/Custom are empty
   // when nothing is fetched/installed, and selecting them would do nothing.
   m_paletteSourceOrder.clear();
   std::vector<ui::SegmentedOption> paletteSourceOptions;
@@ -1020,7 +1020,7 @@ std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
     return {};
   }
   const auto& wp = m_config->config().wallpaper;
-  const ThemeMode configured = m_config->config().theme.mode;
+  const ThemeMode configured = shellThemeMode(m_config->config().theme);
   const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
   const ThemeMode mode = wallpaper::effectiveThemeMode(configured, isLight);
 
@@ -1274,7 +1274,7 @@ void WallpaperPanel::applyThemeFromControls() {
     return;
   }
 
-  // No favorite target — behave like the Settings window: change the global theme only.
+  // No favorite target, so behave like the Settings window and change the global theme only.
   m_config->setThemeMode(theme.themeMode);
   if (theme.paletteSource.has_value()) {
     (void)m_config->setThemeColorScheme(*theme.paletteSource, paletteSelectionValue(theme));
@@ -1308,7 +1308,7 @@ void WallpaperPanel::refreshScan() {
     m_scanPending = false;
     return;
   }
-  // requestScan() returns false when a worker scan was queued — the entries
+  // requestScan() returns false when a worker scan was queued; the entries
   // arrive later via onScanComplete(). A cached/fresh dir returns true.
   m_scanPending = !m_scanner->requestScan(dir, m_flatten);
 }

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -452,7 +452,7 @@ void Wallpaper::reload() {
   if (!nowEnabled) {
     resetAutomationState();
     m_wallpaperEnabled = false;
-    // Wallpaper disabled — full teardown
+    // Wallpaper disabled, full teardown
     for (auto& inst : m_instances) {
       releaseInstanceTextures(*inst);
     }
@@ -467,7 +467,7 @@ void Wallpaper::reload() {
   m_wallpaperEnabled = true;
   m_lastWallpaperConfig = wallpaperConfig;
 
-  // Wallpaper remains (or becomes) enabled — sync instances without teardown
+  // Wallpaper remains (or becomes) enabled, sync instances without teardown
   // to avoid flickering. syncInstances handles monitor override changes
   // (adds/removes instances) without disturbing existing surfaces.
   syncInstances();
@@ -880,7 +880,7 @@ void Wallpaper::setAutomationGate(std::function<bool()> gate) { m_automationGate
 bool Wallpaper::automationAllowed() const noexcept { return !m_automationGate || m_automationGate(); }
 
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {
-  const ThemeMode configured = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
+  const ThemeMode configured = m_config != nullptr ? shellThemeMode(m_config->config().theme) : ThemeMode::Dark;
   const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
   return wallpaper::effectiveThemeMode(configured, isLight);
 }

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -44,20 +44,20 @@ namespace noctalia::theme {
       GeneratedPalette generated;
       Palette palette;
       std::string mode;
+      std::string appMode;
     };
 
     std::string resolvedModeName(
-        const ThemeConfig& cfg, const LocationConfig& location, std::optional<double> latitude,
-        std::optional<double> longitude
+        ThemeMode mode, const LocationConfig& location, std::optional<double> latitude, std::optional<double> longitude
     ) {
-      if (cfg.mode == ThemeMode::Auto) {
+      if (mode == ThemeMode::Auto) {
         const auto eval = day_night_schedule::evaluate(location, latitude, longitude);
         return eval.night ? "dark" : "light";
       }
-      return cfg.mode == ThemeMode::Light ? "light" : "dark";
+      return mode == ThemeMode::Light ? "light" : "dark";
     }
 
-    ResolvedTheme resolveBuiltin(const ThemeConfig& cfg, std::string_view mode) {
+    ResolvedTheme resolveBuiltin(const ThemeConfig& cfg, std::string_view mode, std::string_view appMode) {
       const auto* palette = findBuiltinPalette(cfg.builtinPalette);
       if (palette == nullptr) {
         kLog.warn("unknown builtin palette '{}', falling back to Noctalia", cfg.builtinPalette);
@@ -68,6 +68,7 @@ namespace noctalia::theme {
           .generated = generated,
           .palette = mapGeneratedPaletteMode(mode == "light" ? generated.light : generated.dark),
           .mode = std::string(mode),
+          .appMode = std::string(appMode),
       };
     }
 
@@ -197,7 +198,8 @@ namespace noctalia::theme {
       }
     }
 
-    ResolvedTheme makeResolvedFromParsed(const ParsedCommunityPalette& parsed, std::string_view mode) {
+    ResolvedTheme
+    makeResolvedFromParsed(const ParsedCommunityPalette& parsed, std::string_view mode, std::string_view appMode) {
       BuiltinPalette bp{
           .name = "community",
           .dark = parsed.dark,
@@ -208,6 +210,7 @@ namespace noctalia::theme {
           .generated = generated,
           .palette = mapGeneratedPaletteMode(mode == "light" ? generated.light : generated.dark),
           .mode = std::string(mode),
+          .appMode = std::string(appMode),
       };
     }
 
@@ -282,7 +285,7 @@ namespace noctalia::theme {
   }
 
   void ThemeService::onAutoSchemeChanged() {
-    if (m_config.config().theme.mode == ThemeMode::Auto) {
+    if (hasAutoMode()) {
       resolveAndSet(/*animate=*/true);
     }
   }
@@ -299,7 +302,7 @@ namespace noctalia::theme {
     }
     m_autoLatitude = latitude;
     m_autoLongitude = longitude;
-    if (m_config.config().theme.mode == ThemeMode::Auto) {
+    if (hasAutoMode()) {
       resolveAndSet(/*animate=*/true);
     }
   }
@@ -334,16 +337,21 @@ namespace noctalia::theme {
 
   std::string_view ThemeService::resolvedMode() const noexcept { return m_isLightMode ? "light" : "dark"; }
 
+  std::string_view ThemeService::resolvedAppMode() const noexcept { return m_isAppLightMode ? "light" : "dark"; }
+
   void ThemeService::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
   void ThemeService::setResolvedCallback(ResolvedCallback callback) { m_resolvedCallback = std::move(callback); }
 
-  void ThemeService::queueResolvedCallback(const GeneratedPalette& generated, std::string_view mode) {
+  void ThemeService::queueResolvedCallback(
+      const GeneratedPalette& generated, std::string_view mode, std::string_view appMode
+  ) {
     if (!m_resolvedCallback) {
       return;
     }
     m_pendingResolvedPalette = generated;
     m_pendingResolvedMode = std::string(mode);
+    m_pendingResolvedAppMode = std::string(appMode);
     ++m_resolvedCallbackGeneration;
   }
 
@@ -354,20 +362,23 @@ namespace noctalia::theme {
 
     GeneratedPalette generated = std::move(*m_pendingResolvedPalette);
     std::string mode = std::move(m_pendingResolvedMode);
+    std::string appMode = std::move(m_pendingResolvedAppMode);
     const std::uint64_t generation = m_resolvedCallbackGeneration;
     m_pendingResolvedPalette.reset();
     m_pendingResolvedMode.clear();
+    m_pendingResolvedAppMode.clear();
 
     if (defer) {
-      DeferredCall::callLater([this, generation, generated = std::move(generated), mode = std::move(mode)]() mutable {
+      DeferredCall::callLater([this, generation, generated = std::move(generated), mode = std::move(mode),
+                               appMode = std::move(appMode)]() mutable {
         if (generation == m_resolvedCallbackGeneration && m_resolvedCallback) {
-          m_resolvedCallback(generated, mode);
+          m_resolvedCallback(generated, mode, appMode);
         }
       });
       return;
     }
 
-    m_resolvedCallback(generated, mode);
+    m_resolvedCallback(generated, mode, appMode);
   }
 
   void ThemeService::startCommunityDownload(const std::string& name) {
@@ -457,13 +468,17 @@ namespace noctalia::theme {
   void ThemeService::resolveAndSet(bool animate) {
     profiling::ScopedTimer t(kLog, "theme: resolveAndSet");
     const auto& cfg = m_config.config().theme;
-    const std::string mode = resolvedModeName(cfg, m_config.config().location, m_autoLatitude, m_autoLongitude);
+    const std::string mode = resolvedModeName(cfg.mode, m_config.config().location, m_autoLatitude, m_autoLongitude);
+    const std::string appMode = cfg.separateThemeModeForApps
+        ? resolvedModeName(cfg.appMode, m_config.config().location, m_autoLatitude, m_autoLongitude)
+        : mode;
+
     std::optional<ResolvedTheme> resolved;
     if (cfg.source == PaletteSource::Custom && !cfg.customPalette.empty()) {
       const auto path = customPalettePath(cfg.customPalette);
       if (std::filesystem::exists(path)) {
         if (auto parsed = parseCommunityPaletteJson(path)) {
-          resolved = makeResolvedFromParsed(*parsed, mode);
+          resolved = makeResolvedFromParsed(*parsed, mode, appMode);
         }
       }
       if (!resolved.has_value()) {
@@ -475,6 +490,7 @@ namespace noctalia::theme {
             .generated = *generated,
             .palette = mapGeneratedPaletteMode(mode == "light" ? generated->light : generated->dark),
             .mode = mode,
+            .appMode = appMode,
         };
       }
     } else if (cfg.source == PaletteSource::Community && !cfg.communityPalette.empty()) {
@@ -482,7 +498,7 @@ namespace noctalia::theme {
       bool stale = true;
       if (std::filesystem::exists(cachePath)) {
         if (auto parsed = parseCommunityPaletteJson(cachePath)) {
-          resolved = makeResolvedFromParsed(*parsed, mode);
+          resolved = makeResolvedFromParsed(*parsed, mode, appMode);
           // Re-fetch when the catalog advertises a different checksum than the
           // cached copy. An empty catalog md5 means "freshness unknown" — keep
           // the cached palette rather than re-downloading on every resolve.
@@ -500,7 +516,7 @@ namespace noctalia::theme {
       }
     }
     if (!resolved.has_value()) {
-      resolved = resolveBuiltin(cfg, mode);
+      resolved = resolveBuiltin(cfg, mode, appMode);
     }
 
     // Every source funnels through here, so the transform covers wallpaper-generated,
@@ -521,8 +537,9 @@ namespace noctalia::theme {
       }
     }
 
-    queueResolvedCallback(resolved->generated, resolved->mode);
+    queueResolvedCallback(resolved->generated, resolved->mode, resolved->appMode);
     m_isLightMode = resolved->mode == "light";
+    m_isAppLightMode = resolved->appMode == "light";
 
     if (animate) {
       setResolvedThemeLight(m_isLightMode);
@@ -551,7 +568,7 @@ namespace noctalia::theme {
 
   void ThemeService::rescheduleAutoTimer() {
     m_autoTimer.stop();
-    if (m_config.config().theme.mode != ThemeMode::Auto) {
+    if (!hasAutoMode()) {
       return;
     }
     constexpr auto kAutoRecheckInterval = std::chrono::minutes(1);
@@ -560,6 +577,11 @@ namespace noctalia::theme {
     const auto delay =
         std::min(nextBoundary, std::chrono::duration_cast<std::chrono::milliseconds>(kAutoRecheckInterval));
     m_autoTimer.start(delay, [this]() { onAutoSchemeChanged(); });
+  }
+
+  bool ThemeService::hasAutoMode() const noexcept {
+    const auto& theme = m_config.config().theme;
+    return theme.mode == ThemeMode::Auto || (theme.separateThemeModeForApps && theme.appMode == ThemeMode::Auto);
   }
 
   void ThemeService::startTransition(const Palette& target) {

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -43,21 +43,12 @@ namespace noctalia::theme {
     struct ResolvedTheme {
       GeneratedPalette generated;
       Palette palette;
+      // Resolved [theme].mode (apps) and the mode Noctalia itself runs in.
       std::string mode;
-      std::string appMode;
+      std::string shellMode;
     };
 
-    std::string resolvedModeName(
-        ThemeMode mode, const LocationConfig& location, std::optional<double> latitude, std::optional<double> longitude
-    ) {
-      if (mode == ThemeMode::Auto) {
-        const auto eval = day_night_schedule::evaluate(location, latitude, longitude);
-        return eval.night ? "dark" : "light";
-      }
-      return mode == ThemeMode::Light ? "light" : "dark";
-    }
-
-    ResolvedTheme resolveBuiltin(const ThemeConfig& cfg, std::string_view mode, std::string_view appMode) {
+    ResolvedTheme resolveBuiltin(const ThemeConfig& cfg, std::string_view mode, std::string_view shellMode) {
       const auto* palette = findBuiltinPalette(cfg.builtinPalette);
       if (palette == nullptr) {
         kLog.warn("unknown builtin palette '{}', falling back to Noctalia", cfg.builtinPalette);
@@ -66,9 +57,9 @@ namespace noctalia::theme {
       const GeneratedPalette generated = expandBuiltinPalette(*palette);
       return {
           .generated = generated,
-          .palette = mapGeneratedPaletteMode(mode == "light" ? generated.light : generated.dark),
+          .palette = mapGeneratedPaletteMode(shellMode == "light" ? generated.light : generated.dark),
           .mode = std::string(mode),
-          .appMode = std::string(appMode),
+          .shellMode = std::string(shellMode),
       };
     }
 
@@ -199,7 +190,7 @@ namespace noctalia::theme {
     }
 
     ResolvedTheme
-    makeResolvedFromParsed(const ParsedCommunityPalette& parsed, std::string_view mode, std::string_view appMode) {
+    makeResolvedFromParsed(const ParsedCommunityPalette& parsed, std::string_view mode, std::string_view shellMode) {
       BuiltinPalette bp{
           .name = "community",
           .dark = parsed.dark,
@@ -208,9 +199,9 @@ namespace noctalia::theme {
       const GeneratedPalette generated = expandBuiltinPalette(bp);
       return {
           .generated = generated,
-          .palette = mapGeneratedPaletteMode(mode == "light" ? generated.light : generated.dark),
+          .palette = mapGeneratedPaletteMode(shellMode == "light" ? generated.light : generated.dark),
           .mode = std::string(mode),
-          .appMode = std::string(appMode),
+          .shellMode = std::string(shellMode),
       };
     }
 
@@ -333,25 +324,22 @@ namespace noctalia::theme {
 
   ThemeMode ThemeService::configuredMode() const noexcept { return m_config.config().theme.mode; }
 
-  bool ThemeService::isLightMode() const noexcept { return m_isLightMode; }
+  bool ThemeService::isLightMode() const noexcept { return m_isShellLightMode; }
+
+  std::string_view ThemeService::resolvedShellMode() const noexcept { return m_isShellLightMode ? "light" : "dark"; }
 
   std::string_view ThemeService::resolvedMode() const noexcept { return m_isLightMode ? "light" : "dark"; }
-
-  std::string_view ThemeService::resolvedAppMode() const noexcept { return m_isAppLightMode ? "light" : "dark"; }
 
   void ThemeService::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
   void ThemeService::setResolvedCallback(ResolvedCallback callback) { m_resolvedCallback = std::move(callback); }
 
-  void ThemeService::queueResolvedCallback(
-      const GeneratedPalette& generated, std::string_view mode, std::string_view appMode
-  ) {
+  void ThemeService::queueResolvedCallback(const GeneratedPalette& generated, std::string_view mode) {
     if (!m_resolvedCallback) {
       return;
     }
     m_pendingResolvedPalette = generated;
     m_pendingResolvedMode = std::string(mode);
-    m_pendingResolvedAppMode = std::string(appMode);
     ++m_resolvedCallbackGeneration;
   }
 
@@ -362,23 +350,20 @@ namespace noctalia::theme {
 
     GeneratedPalette generated = std::move(*m_pendingResolvedPalette);
     std::string mode = std::move(m_pendingResolvedMode);
-    std::string appMode = std::move(m_pendingResolvedAppMode);
     const std::uint64_t generation = m_resolvedCallbackGeneration;
     m_pendingResolvedPalette.reset();
     m_pendingResolvedMode.clear();
-    m_pendingResolvedAppMode.clear();
 
     if (defer) {
-      DeferredCall::callLater([this, generation, generated = std::move(generated), mode = std::move(mode),
-                               appMode = std::move(appMode)]() mutable {
+      DeferredCall::callLater([this, generation, generated = std::move(generated), mode = std::move(mode)]() mutable {
         if (generation == m_resolvedCallbackGeneration && m_resolvedCallback) {
-          m_resolvedCallback(generated, mode, appMode);
+          m_resolvedCallback(generated, mode);
         }
       });
       return;
     }
 
-    m_resolvedCallback(generated, mode, appMode);
+    m_resolvedCallback(generated, mode);
   }
 
   void ThemeService::startCommunityDownload(const std::string& name) {
@@ -468,17 +453,27 @@ namespace noctalia::theme {
   void ThemeService::resolveAndSet(bool animate) {
     profiling::ScopedTimer t(kLog, "theme: resolveAndSet");
     const auto& cfg = m_config.config().theme;
-    const std::string mode = resolvedModeName(cfg.mode, m_config.config().location, m_autoLatitude, m_autoLongitude);
-    const std::string appMode = cfg.separateThemeModeForApps
-        ? resolvedModeName(cfg.appMode, m_config.config().location, m_autoLatitude, m_autoLongitude)
-        : mode;
+    // [theme].mode is the app-facing mode; the shell either follows it or runs its own.
+    // Both resolve `auto` against one schedule evaluation.
+    std::optional<bool> scheduleNight;
+    const auto modeName = [&](ThemeMode themeMode) -> std::string {
+      if (themeMode != ThemeMode::Auto) {
+        return themeMode == ThemeMode::Light ? "light" : "dark";
+      }
+      if (!scheduleNight.has_value()) {
+        scheduleNight = day_night_schedule::evaluate(m_config.config().location, m_autoLatitude, m_autoLongitude).night;
+      }
+      return *scheduleNight ? "dark" : "light";
+    };
+    const std::string mode = modeName(cfg.mode);
+    const std::string shellMode = modeName(shellThemeMode(cfg));
 
     std::optional<ResolvedTheme> resolved;
     if (cfg.source == PaletteSource::Custom && !cfg.customPalette.empty()) {
       const auto path = customPalettePath(cfg.customPalette);
       if (std::filesystem::exists(path)) {
         if (auto parsed = parseCommunityPaletteJson(path)) {
-          resolved = makeResolvedFromParsed(*parsed, mode, appMode);
+          resolved = makeResolvedFromParsed(*parsed, mode, shellMode);
         }
       }
       if (!resolved.has_value()) {
@@ -488,9 +483,9 @@ namespace noctalia::theme {
       if (auto generated = resolveWallpaperGenerated(cfg, m_config.getPaletteWallpaperPath())) {
         resolved = ResolvedTheme{
             .generated = *generated,
-            .palette = mapGeneratedPaletteMode(mode == "light" ? generated->light : generated->dark),
+            .palette = mapGeneratedPaletteMode(shellMode == "light" ? generated->light : generated->dark),
             .mode = mode,
-            .appMode = appMode,
+            .shellMode = shellMode,
         };
       }
     } else if (cfg.source == PaletteSource::Community && !cfg.communityPalette.empty()) {
@@ -498,9 +493,9 @@ namespace noctalia::theme {
       bool stale = true;
       if (std::filesystem::exists(cachePath)) {
         if (auto parsed = parseCommunityPaletteJson(cachePath)) {
-          resolved = makeResolvedFromParsed(*parsed, mode, appMode);
+          resolved = makeResolvedFromParsed(*parsed, mode, shellMode);
           // Re-fetch when the catalog advertises a different checksum than the
-          // cached copy. An empty catalog md5 means "freshness unknown" — keep
+          // cached copy. An empty catalog md5 means "freshness unknown": keep
           // the cached palette rather than re-downloading on every resolve.
           const std::string expectedMd5 = communityPaletteCatalogMd5(cfg.communityPalette);
           stale = !expectedMd5.empty() && util::fileMd5Hex(cachePath) != StringUtils::toLower(expectedMd5);
@@ -516,12 +511,12 @@ namespace noctalia::theme {
       }
     }
     if (!resolved.has_value()) {
-      resolved = resolveBuiltin(cfg, mode, appMode);
+      resolved = resolveBuiltin(cfg, mode, shellMode);
     }
 
     // Every source funnels through here, so the transform covers wallpaper-generated,
     // builtin, community and custom palettes alike. It runs after the wallpaper cache,
-    // which keeps storing the untransformed palette — toggling this cannot serve a stale one.
+    // which keeps storing the untransformed palette, so toggling this cannot serve a stale one.
     if (cfg.pureBlackDark) {
       applyPureBlackDark(resolved->generated);
     }
@@ -530,24 +525,25 @@ namespace noctalia::theme {
     }
 
     if (cfg.pureBlackDark || m_config.config().accessibility.highContrast) {
-      if (resolved->mode != "light") {
+      if (resolved->shellMode != "light") {
         resolved->palette = mapGeneratedPaletteMode(resolved->generated.dark);
       } else {
         resolved->palette = mapGeneratedPaletteMode(resolved->generated.light);
       }
     }
 
-    queueResolvedCallback(resolved->generated, resolved->mode, resolved->appMode);
+    queueResolvedCallback(resolved->generated, resolved->mode);
     m_isLightMode = resolved->mode == "light";
-    m_isAppLightMode = resolved->appMode == "light";
+    m_isShellLightMode = resolved->shellMode == "light";
 
     if (animate) {
-      setResolvedThemeLight(m_isLightMode);
+      setResolvedThemeLight(m_isShellLightMode);
       notifyShellAppIconColorizationChanged();
       startTransition(resolved->palette);
     } else {
       if (m_transitionAnimId == 0 && palette == resolved->palette) {
         flushResolvedCallback(/*defer=*/false);
+        rescheduleAutoTimer();
         return;
       }
       if (m_transitionAnimId != 0) {
@@ -555,7 +551,7 @@ namespace noctalia::theme {
         m_transitionAnimId = 0;
       }
       m_transitionTimer.stop();
-      setResolvedThemeLight(m_isLightMode);
+      setResolvedThemeLight(m_isShellLightMode);
       notifyShellAppIconColorizationChanged();
       setPalette(resolved->palette);
       if (m_changeCallback) {
@@ -581,7 +577,7 @@ namespace noctalia::theme {
 
   bool ThemeService::hasAutoMode() const noexcept {
     const auto& theme = m_config.config().theme;
-    return theme.mode == ThemeMode::Auto || (theme.separateThemeModeForApps && theme.appMode == ThemeMode::Auto);
+    return theme.mode == ThemeMode::Auto || shellThemeMode(theme) == ThemeMode::Auto;
   }
 
   void ThemeService::startTransition(const Palette& target) {

--- a/src/theme/theme_service.h
+++ b/src/theme/theme_service.h
@@ -21,7 +21,7 @@ namespace noctalia::theme {
   class ThemeService {
   public:
     using ChangeCallback = std::function<void()>;
-    using ResolvedCallback = std::function<void(const GeneratedPalette&, std::string_view)>;
+    using ResolvedCallback = std::function<void(const GeneratedPalette&, std::string_view, std::string_view)>;
 
     ThemeService(ConfigService& config, HttpClient& httpClient);
 
@@ -38,6 +38,7 @@ namespace noctalia::theme {
     [[nodiscard]] ThemeMode configuredMode() const noexcept;
     [[nodiscard]] bool isLightMode() const noexcept;
     [[nodiscard]] std::string_view resolvedMode() const noexcept;
+    [[nodiscard]] std::string_view resolvedAppMode() const noexcept;
 
     void setChangeCallback(ChangeCallback callback);
     void setResolvedCallback(ResolvedCallback callback);
@@ -53,13 +54,14 @@ namespace noctalia::theme {
     // Decodes + generates the wallpaper palette, memoized on (path, mtime, scheme)
     // so repeated resolves for an unchanged wallpaper skip the ~100ms image decode.
     std::optional<GeneratedPalette> resolveWallpaperGenerated(const ThemeConfig& cfg, const std::string& wallpaperPath);
-    void queueResolvedCallback(const GeneratedPalette& generated, std::string_view mode);
+    void queueResolvedCallback(const GeneratedPalette& generated, std::string_view mode, std::string_view appMode);
     void flushResolvedCallback(bool defer);
     void startTransition(const Palette& target);
     void finishTransition(bool deferResolvedCallback);
     void tickTransition();
     void startCommunityDownload(const std::string& name);
     void rescheduleAutoTimer();
+    [[nodiscard]] bool hasAutoMode() const noexcept;
 
     ConfigService& m_config;
     HttpClient& m_httpClient;
@@ -78,6 +80,7 @@ namespace noctalia::theme {
     // applied, and deferred callbacks must be able to drop stale resolves.
     std::optional<GeneratedPalette> m_pendingResolvedPalette;
     std::string m_pendingResolvedMode;
+    std::string m_pendingResolvedAppMode;
     std::uint64_t m_resolvedCallbackGeneration = 0;
 
     AnimationManager m_animations;
@@ -87,6 +90,7 @@ namespace noctalia::theme {
     AnimationManager::Id m_transitionAnimId = 0;
     bool m_transitionResolvedCallbackFlushed = false;
     bool m_isLightMode = false;
+    bool m_isAppLightMode = false;
     std::optional<double> m_autoLatitude;
     std::optional<double> m_autoLongitude;
     Timer m_autoTimer;

--- a/src/theme/theme_service.h
+++ b/src/theme/theme_service.h
@@ -21,7 +21,9 @@ namespace noctalia::theme {
   class ThemeService {
   public:
     using ChangeCallback = std::function<void()>;
-    using ResolvedCallback = std::function<void(const GeneratedPalette&, std::string_view, std::string_view)>;
+    // Carries the resolved [theme].mode: the app-facing mode templates and the GTK color
+    // scheme run in. Shell-facing consumers read resolvedShellMode()/isLightMode().
+    using ResolvedCallback = std::function<void(const GeneratedPalette&, std::string_view)>;
 
     ThemeService(ConfigService& config, HttpClient& httpClient);
 
@@ -36,9 +38,11 @@ namespace noctalia::theme {
     void toggleLightDark();
     void cycleMode();
     [[nodiscard]] ThemeMode configuredMode() const noexcept;
+    // Noctalia's own resolved mode ([theme].shell_mode, or [theme].mode when it follows).
     [[nodiscard]] bool isLightMode() const noexcept;
+    [[nodiscard]] std::string_view resolvedShellMode() const noexcept;
+    // The resolved [theme].mode, which drives apps.
     [[nodiscard]] std::string_view resolvedMode() const noexcept;
-    [[nodiscard]] std::string_view resolvedAppMode() const noexcept;
 
     void setChangeCallback(ChangeCallback callback);
     void setResolvedCallback(ResolvedCallback callback);
@@ -54,7 +58,7 @@ namespace noctalia::theme {
     // Decodes + generates the wallpaper palette, memoized on (path, mtime, scheme)
     // so repeated resolves for an unchanged wallpaper skip the ~100ms image decode.
     std::optional<GeneratedPalette> resolveWallpaperGenerated(const ThemeConfig& cfg, const std::string& wallpaperPath);
-    void queueResolvedCallback(const GeneratedPalette& generated, std::string_view mode, std::string_view appMode);
+    void queueResolvedCallback(const GeneratedPalette& generated, std::string_view mode);
     void flushResolvedCallback(bool defer);
     void startTransition(const Palette& target);
     void finishTransition(bool deferResolvedCallback);
@@ -80,7 +84,6 @@ namespace noctalia::theme {
     // applied, and deferred callbacks must be able to drop stale resolves.
     std::optional<GeneratedPalette> m_pendingResolvedPalette;
     std::string m_pendingResolvedMode;
-    std::string m_pendingResolvedAppMode;
     std::uint64_t m_resolvedCallbackGeneration = 0;
 
     AnimationManager m_animations;
@@ -89,8 +92,8 @@ namespace noctalia::theme {
     Palette m_targetPalette{};
     AnimationManager::Id m_transitionAnimId = 0;
     bool m_transitionResolvedCallbackFlushed = false;
+    bool m_isShellLightMode = false;
     bool m_isLightMode = false;
-    bool m_isAppLightMode = false;
     std::optional<double> m_autoLatitude;
     std::optional<double> m_autoLongitude;
     Timer m_autoTimer;

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -525,6 +525,7 @@ location = "https://example.invalid/bad"
     c.theme.source = PaletteSource::Wallpaper;
     c.theme.builtinPalette = "Tokyo";
     c.theme.mode = ThemeMode::Light;
+    c.theme.shellMode = ShellThemeMode::Auto;
     c.theme.templates.enableBuiltinTemplates = false;
     c.theme.templates.builtinIds = {"a", "b"};
     c.theme.templates.customColors = {

--- a/tests/theme_shell_mode_test.cpp
+++ b/tests/theme_shell_mode_test.cpp
@@ -1,0 +1,106 @@
+// [theme].mode is the app-facing mode: it is what the resolved callback carries to templates,
+// the GTK color scheme, and theme_mode_changed hooks. [theme].shell_mode pins the palette
+// Noctalia itself renders with, without moving the app-facing mode.
+
+#include "config/config_service.h"
+#include "core/deferred_call.h"
+#include "net/http_client.h"
+#include "tests/test_check.h"
+#include "theme/theme_service.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+namespace {
+
+  struct Resolution {
+    std::string appliedMode; // mode handed to the resolved callback
+    std::string mode;        // ThemeService::resolvedMode()
+    std::string shellMode;   // ThemeService::resolvedShellMode()
+    bool shellLight = false; // ThemeService::isLightMode()
+  };
+
+  Resolution resolve(const std::filesystem::path& overridesPath, std::string_view themeToml) {
+    {
+      std::ofstream out(overridesPath, std::ios::trunc);
+      out << themeToml;
+    }
+
+    ConfigService config;
+    HttpClient http;
+    noctalia::theme::ThemeService theme(config, http);
+
+    Resolution result;
+    theme.setResolvedCallback([&result](const noctalia::theme::GeneratedPalette&, std::string_view mode) {
+      result.appliedMode = std::string(mode);
+    });
+    theme.apply();
+    for (auto& call : DeferredCall::takePending()) {
+      call();
+    }
+
+    result.mode = std::string(theme.resolvedMode());
+    result.shellMode = std::string(theme.resolvedShellMode());
+    result.shellLight = theme.isLightMode();
+    return result;
+  }
+
+} // namespace
+
+int main() {
+  const std::filesystem::path root =
+      std::filesystem::temp_directory_path() / ("noctalia-theme-shell-mode-" + std::to_string(::getpid()));
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root / "config" / "noctalia");
+  std::filesystem::create_directories(root / "state" / "noctalia");
+  std::filesystem::create_directories(root / "data");
+  ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+  ::setenv("NOCTALIA_STATE_HOME", (root / "state").c_str(), 1);
+  ::setenv("NOCTALIA_DATA_HOME", (root / "data").c_str(), 1);
+
+  // ConfigService reads its persisted overrides from <state dir>/settings.toml, the same file
+  // the settings GUI writes.
+  const std::filesystem::path overrides = root / "state" / "noctalia" / "settings.toml";
+  // follow: one mode drives Noctalia and apps together.
+  {
+    const Resolution r = resolve(overrides, "[theme]\nmode = \"light\"\nshell_mode = \"follow\"\n");
+    TEST_CHECK(r.mode == "light");
+    TEST_CHECK(r.shellMode == "light");
+    TEST_CHECK(r.shellLight);
+    TEST_CHECK(r.appliedMode == "light");
+  }
+
+  // Pinned dark shell, light apps: only the shell palette is held back.
+  {
+    const Resolution r = resolve(overrides, "[theme]\nmode = \"light\"\nshell_mode = \"dark\"\n");
+    TEST_CHECK(r.mode == "light");
+    TEST_CHECK(r.shellMode == "dark");
+    TEST_CHECK(!r.shellLight);
+    TEST_CHECK(r.appliedMode == "light");
+  }
+
+  // The inverse pinning, so a light shell cannot leak into what apps are told.
+  {
+    const Resolution r = resolve(overrides, "[theme]\nmode = \"dark\"\nshell_mode = \"light\"\n");
+    TEST_CHECK(r.mode == "dark");
+    TEST_CHECK(r.shellMode == "light");
+    TEST_CHECK(r.shellLight);
+    TEST_CHECK(r.appliedMode == "dark");
+  }
+
+  // An unset shell_mode behaves like follow.
+  {
+    const Resolution r = resolve(overrides, "[theme]\nmode = \"dark\"\n");
+    TEST_CHECK(r.mode == "dark");
+    TEST_CHECK(r.shellMode == "dark");
+    TEST_CHECK(!r.shellLight);
+    TEST_CHECK(r.appliedMode == "dark");
+  }
+
+  std::filesystem::remove_all(root);
+  return 0;
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

Added a "Separate Theme Mode For Apps" toggle and "App Theme Mode" enum to settings.

The app theme mode only applies to templates and `gsettings color-scheme`. Wallpaper uses the main theme mode, not the app one.

## Motivation

<!-- What problem does this solve? -->

This allows a "dark bar + light apps" combination, like the GNOME default, or KDE "Twilight" theme. Other combinations are also possible. E.g., keeping the bar dark, while auto switching for apps.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
