### PR TITLE
fix(plugin-store): keep scroll position across sheet body rebuilds

### DIFF
--- a/src/shell/settings/plugin_store_content.cpp
+++ b/src/shell/settings/plugin_store_content.cpp
@@ -1,7 +1,6 @@
 #include "shell/settings/plugin_store_content.h"
 
 #include "config/config_service.h"
-#include "core/deferred_call.h"
 #include "core/input/key_symbols.h"
 #include "core/input/keybind_matcher.h"
 #include "i18n/i18n.h"
@@ -142,25 +141,6 @@ namespace settings {
   }
 
   PluginStoreContent::~PluginStoreContent() = default;
-
-  void PluginStoreContent::stashScrollOffset() {
-    if (m_grid != nullptr && !isDetailView()) {
-      m_pendingRestoreScrollOffset = m_grid->scrollView().scrollOffset();
-    }
-  }
-
-  void PluginStoreContent::restoreScrollOffset() {
-    if (!m_pendingRestoreScrollOffset.has_value()) {
-      return;
-    }
-    const float offset = *m_pendingRestoreScrollOffset;
-    m_pendingRestoreScrollOffset.reset();
-    VirtualGridView* grid = m_grid;
-    if (grid == nullptr) {
-      return;
-    }
-    DeferredCall::callLater([grid, offset]() { grid->scrollView().setScrollOffset(offset); });
-  }
 
   void PluginStoreContent::setOnRebuildNeeded(std::function<void()> cb) { m_onRebuildNeeded = std::move(cb); }
 
@@ -472,7 +452,6 @@ namespace settings {
                 }
 
                 applyFilter();
-                stashScrollOffset();
                 if (m_onRebuildNeeded) {
                   m_onRebuildNeeded();
                 }
@@ -497,7 +476,6 @@ namespace settings {
               .variant = ButtonVariant::Ghost,
               .onClick = [this]() {
                 m_tagFiltersCollapsed = !m_tagFiltersCollapsed;
-                stashScrollOffset();
                 if (m_onRebuildNeeded) {
                   m_onRebuildNeeded();
                 }
@@ -518,7 +496,6 @@ namespace settings {
               .onClick = [this, tag = std::move(tag)]() {
                 m_selectedTag = tag;
                 applyFilter();
-                stashScrollOffset();
                 if (m_onRebuildNeeded) {
                   m_onRebuildNeeded();
                 }
@@ -602,7 +579,11 @@ namespace settings {
                   ? std::optional{m_catalog[m_filteredIndices[*index]].entry.id}
                   : std::nullopt;
             },
-        .configure = [](VirtualGridView& view) { view.setFillWidth(true); },
+        .configure =
+            [this](VirtualGridView& view) {
+              view.setFillWidth(true);
+              view.scrollView().bindState(&m_gridScrollState);
+            },
     });
     // The sheet hosts the store without an outer ScrollView, so the grid's own scroll fills the
     // available height and scrolls the catalog. No minimum height: a floor would overflow the
@@ -610,7 +591,6 @@ namespace settings {
     if (const auto index = indexOfPluginId(m_selectedPluginId.value_or("")); index.has_value()) {
       m_grid->setSelectedIndex(index);
     }
-    restoreScrollOffset();
     body.addChild(std::move(grid));
 
     if (m_filteredIndices.empty()) {
@@ -637,6 +617,7 @@ namespace settings {
     // The sheet hosts the store without an outer ScrollView, so the detail view scrolls its own
     // content (header + README can exceed the sheet height).
     auto scroll = ui::scrollView({
+        .state = &m_detailScrollState,
         .scrollbarVisible = true,
         .viewportPaddingH = 0.0F,
         .viewportPaddingV = 0.0F,
@@ -883,7 +864,7 @@ namespace settings {
   }
 
   void PluginStoreContent::openDetail(std::size_t filteredIndex) {
-    stashScrollOffset();
+    m_detailScrollState.offset = 0.0F;
     m_detailIndex = filteredIndex;
     m_selectedPluginId = m_catalog[m_filteredIndices[filteredIndex]].entry.id;
     m_detailReadme.clear();

--- a/src/shell/settings/plugin_store_content.h
+++ b/src/shell/settings/plugin_store_content.h
@@ -2,6 +2,7 @@
 
 #include "config/config_types.h"
 #include "scripting/plugin_catalog.h"
+#include "ui/controls/scroll_view.h"
 
 #include <cstddef>
 #include <functional>
@@ -79,8 +80,6 @@ namespace settings {
   private:
     void buildGridView(Flex& body, Renderer& renderer, AsyncTextureCache* textureCache);
     void buildDetailView(Flex& body, Renderer& renderer, AsyncTextureCache* textureCache);
-    void stashScrollOffset();
-    void restoreScrollOffset();
     void syncSortButtonGlyph();
     void cycleSortMode();
     void setSortMode(SortMode mode);
@@ -131,7 +130,11 @@ namespace settings {
     std::function<void()> m_onRebuildNeeded;
 
     std::unordered_map<std::string, std::string> m_thumbnailPaths;
-    std::optional<float> m_pendingRestoreScrollOffset;
+    // The sheet destroys and repopulates its whole body on every rebuild, including ones the store
+    // never asked for (any external option change reaches the open sheet). Both views bind their
+    // offset to state that outlives those nodes, so scroll position survives a rebuild.
+    ScrollViewState m_gridScrollState;
+    ScrollViewState m_detailScrollState;
 
     Renderer* m_renderer = nullptr;
     AsyncTextureCache* m_textureCache = nullptr;

--- a/src/ui/controls/scroll_view.cpp
+++ b/src/ui/controls/scroll_view.cpp
@@ -425,7 +425,12 @@ void ScrollView::doLayout(Renderer& renderer) {
 
   if (m_boundState != nullptr) {
     m_scrollOffset = clampOffset(m_boundState->offset);
-    m_boundState->offset = m_scrollOffset;
+    // A pass that measures the content unconstrained reports no scrollable extent. Writing the
+    // clamped zero back would drop the remembered offset before the real viewport height lands,
+    // so the state only follows the view once there is something to scroll.
+    if (m_maxScrollOffset > 0.0F) {
+      m_boundState->offset = m_scrollOffset;
+    }
   } else {
     m_scrollOffset = clampOffset(m_scrollOffset);
   }


### PR DESCRIPTION
## Summary

The plugin store's catalog grid and plugin detail page jumped back to the top roughly every 30 seconds. Two things combine to cause it:

1. `SettingsWindow::onExternalOptionsChanged()` runs `requestSceneRebuild()`, which calls `m_editorSheetPopup->rebuildBody()`. That destroys and repopulates the entire sheet body, so any node-local state is gone. `UPowerService` is one of its callers, and `upowerd` polls the battery every 30s — on a laptop the energy/rate values genuinely change, so the open sheet is rebuilt unprompted at that cadence.
2. `ScrollViewState` is the existing mechanism for surviving exactly this, but it did not work for sheet bodies: `ScrollView::doLayout` wrote the clamped offset back into the bound state on every pass, and the first pass after a rebuild measures the content unconstrained (`height() == 0`, so `viewportH == contentH`). That pass reports `maxScrollOffset == 0`, so it zeroed the remembered offset before the real viewport height arrived on the following pass.

So this PR:

- Binds the catalog grid and the detail page to `ScrollViewState` members on `PluginStoreContent` that outlive the rebuilt nodes. `openDetail` resets the detail state so opening a different plugin still starts at the top.
- Replaces the `stashScrollOffset`/`restoreScrollOffset` pair added in 32a3ad31. That approach only covered the three interaction sites that knew a rebuild was coming, so it could not help with rebuilds the store never initiated, and it did not cover the detail view at all.
- Makes `ScrollView` write to bound state only once there is a scrollable extent. This also repairs bound state for the other users of it — `SettingsSheetPopup` binds `m_scrollState` for its scrollable body, so the plugin settings editor sheet had the same latent loss.

`VirtualGridView` never hit the `doLayout` trap because it always hands its `ScrollView` an explicit height, which is why the grid half was salvageable with a stash and the detail half was not.

## Motivation

Fixes the reported behavior: scrolling the store or a plugin's description, then having the view snap back to the top a few seconds later, repeatedly. On a laptop it is unavoidable — the battery poll alone is enough to trigger it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3872

## Testing

- `meson compile -C build-debug` — clean
- `meson test -C build-debug --print-errorlogs` — 79/79 pass
- `clang-format --dry-run -Werror` on the three changed files — clean
- `run-clang-tidy -p build-debug -warnings-as-errors='*'` on the two changed `.cpp` files — clean

Manual verification: the store sheet can only be opened by clicking and this machine has no pointer/key injection tool, so I drove it with a temporary env-gated harness (removed before commit) that auto-opened the store, fired `onExternalOptionsChanged()` on a 30s repeat as a stand-in for the UPower tick, forced a scroll offset, and sampled `scrollOffset()`/`maxScrollOffset()`.

| | grid | detail |
| --- | --- | --- |
| before | 400 → **0** on every tick | 300 → **0** |
| after | 400 → 400 → 400 | 300 → 300 |

Note for anyone reproducing this way: with the display asleep no layout passes run, so the sampled offsets are pre-layout values and mean nothing. The numbers above are from a run with the display kept awake.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

None — the change has no visual output of its own; the observable difference is the scroll offset table above.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The `ScrollView::doLayout` change is shared UI code, so it is worth a careful look. The behavioral delta is narrow: when a bound scroll view's content fits its viewport, the remembered offset is no longer overwritten with zero. Nothing renders differently in that state (there is nothing to scroll), and if the content grows again the offset comes back, which is the intent of binding state in the first place. Callers that want a genuine reset already do it explicitly — for example `settings_window_scene.cpp` sets `m_contentScrollState.offset = 0.0f` on section change, and `openDetail` now does the same.

Left deliberately out of scope: `onExternalOptionsChanged` is a blunt "rebuild everything" signal, so a battery tick rebuilds the whole settings scene every 30 seconds on a laptop. Narrowing it would touch every caller and deserves its own PR rather than riding along with a bug fix.
