### PR TITLE
Prevent apply.sh from overriding user-defined font

### DIFF
--- a/assets/templates/labwc/apply.sh
+++ b/assets/templates/labwc/apply.sh
@@ -46,8 +46,16 @@ if grep -q '<theme>' "$rc_file"; then
         exit 1
     fi
 
-    if sed -n '/<theme>/,/<\/theme>/p' "$rc_file" | grep -q '<name>.*</name>'; then
-        sed '/<theme>/,/<\/theme>/ { /<font/,/<\/font>/! s|<name>.*</name>|<name>noctalia</name>|; }' "$rc_file" >"$tmp_file"
+    if sed -n '/<theme>/,/<\/theme>/ {
+        /<font[[:space:]>].*<\/font>/d
+        /<font[[:space:]>]/,/<\/font>/d
+        /<name>.*<\/name>/p
+    }' "$rc_file" | grep -q .; then
+        sed '/<theme>/,/<\/theme>/ {
+            /<font[[:space:]>].*<\/font>/b
+            /<font[[:space:]>]/,/<\/font>/b
+            s|<name>.*</name>|<name>noctalia</name>|
+        }' "$rc_file" >"$tmp_file"
     else
         sed '/<theme>/a\    <name>noctalia</name>' "$rc_file" >"$tmp_file"
     fi

--- a/assets/templates/labwc/apply.sh
+++ b/assets/templates/labwc/apply.sh
@@ -47,7 +47,7 @@ if grep -q '<theme>' "$rc_file"; then
     fi
 
     if sed -n '/<theme>/,/<\/theme>/p' "$rc_file" | grep -q '<name>.*</name>'; then
-        sed '/<theme>/,/<\/theme>/s|<name>.*</name>|<name>noctalia</name>|' "$rc_file" >"$tmp_file"
+        sed '/<theme>/,/<\/theme>/ { /<font/,/<\/font>/! s|<name>.*</name>|<name>noctalia</name>|; }' "$rc_file" >"$tmp_file"
     else
         sed '/<theme>/a\    <name>noctalia</name>' "$rc_file" >"$tmp_file"
     fi


### PR DESCRIPTION
The 'sed' command on line 50 was changed, so that the replace operation would be done inside of the `<theme> `block but ignoring `<font>` blocks inside of the former.

See issue #3915 for details

## Summary

What changed was a `sed` command that would replace all occurences of `<name>*</name>` with `<name>noctalia</name>`, inside of the `<theme>` block.

## Motivation

The problem was that this would override the theme (expected behavior), but also override user-defined fonts (unexpected behavior, especially as it would tell Labwc to use the `noctalia` font which doesnt exist).

The problem has been solved by doing the operation inside of the `<theme>` block, _while_ ignoring the `<font>` blocks.

Now, the user can use the Labwc template to synchronise Labwc with the Noctalia theme, without losing their font declarations.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes issue #3915 

## Testing

After changing the `sed` command on line 50, I have done the following :

1. Toggled the Wallpaper widget
2. Made sure that I have set my own font declarations for Labwc
3. Changed wallpaper to trigger the apply.sh script, as intended
4. Observed the used Labwc font, which has stayed the same since step 2

Due to the extremely small change, I've done no formal testing though `just format` and such.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [X] Tested on another compositor: Labwc
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

None to be added

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

None to be added