### PR TITLE
feat(translations): add "focus existing window" option to multiple la…

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3468,6 +3468,10 @@
           "description": "Allow mouse wheel and trackpad scroll actions on this widget",
           "label": "Enable Scroll"
         },
+        "focus-existing-window": {
+          "description": "Left-click focuses this app's already-open window instead of only sending the tray Activate action, which many apps ignore once their window is open",
+          "label": "Focus Existing Window"
+        },
         "focused-color": {
           "description": "Color role used for the focused workspace; fixed hex colors are also supported",
           "label": "Focused Color"

--- a/meson.build
+++ b/meson.build
@@ -1199,6 +1199,7 @@ if build_tests
     'taskbar_widget',
     'time_format',
     'tray_identifier',
+    'tray_window_match',
     'triad_workspace_backend',
     'ui_tree_reconciler',
     'upower_charge_limit',
@@ -1208,6 +1209,7 @@ if build_tests
     'widget_action',
     'widget_definition',
     'wallpaper_shuffle_state',
+    'window_activation',
     'workspace_alert_service',
   ]
 

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -694,7 +694,9 @@ void Application::initPanelManagerAndPanels() {
           &m_wayland, &m_configService, &m_thumbnailService, &m_wallpaperScanner, &m_themeService
       )
   );
-  m_panelManager.registerPanel("tray-drawer", std::make_unique<TrayDrawerPanel>(m_trayService.get(), &m_configService));
+  m_panelManager.registerPanel(
+      "tray-drawer", std::make_unique<TrayDrawerPanel>(&m_compositorPlatform, m_trayService.get(), &m_configService)
+  );
   m_panelManager.registerPanel("polkit", std::make_unique<PolkitPanel>(&m_configService, [this]() {
                                  return m_polkitAgent.get();
                                }));

--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -201,6 +201,20 @@ namespace {
     return fallback;
   }
 
+  bool get_item_property_bool_from(
+      const std::map<std::string, sdbus::Variant>& properties, std::string_view propertyName, bool fallback
+  ) {
+    const auto* value = findProperty(properties, propertyName);
+    if (value == nullptr) {
+      return fallback;
+    }
+    try {
+      return value->get<bool>();
+    } catch (const sdbus::Error&) {
+    }
+    return fallback;
+  }
+
   using IconPixmapTuple = std::tuple<std::int32_t, std::int32_t, std::vector<std::uint8_t>>;
   using IconPixmapStruct = sdbus::Struct<std::int32_t, std::int32_t, std::vector<std::uint8_t>>;
   using StatusNotifierTextTuple = std::tuple<std::string, std::vector<IconPixmapTuple>, std::string, std::string>;
@@ -2050,6 +2064,7 @@ void TrayService::refreshItemMetadata(const std::string& itemId) {
           next.statusNotifierDescription = std::move(statusNotifierDescription);
           next.status = get_item_property_string_from(properties, "Status", cur.status);
           next.needsAttention = (StringUtils::toLower(next.status) == "needsattention");
+          next.itemIsMenu = get_item_property_bool_from(properties, "ItemIsMenu", cur.itemIsMenu);
 
           if (next.itemName == "chrome_status_icon_1" && !next.statusNotifierTitle.empty()) {
             next.itemName = next.itemName + "::" + next.statusNotifierTitle;

--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -1725,40 +1725,6 @@ void TrayService::requestProcessNameForItem(const std::string& itemId, const std
   }
 }
 
-void TrayService::requestActivateCapabilityForItem(const std::string& itemId) {
-  const auto proxyIt = m_itemProxies.find(itemId);
-  if (proxyIt == m_itemProxies.end()) {
-    return;
-  }
-
-  try {
-    proxyIt->second->callMethodAsync("Introspect")
-        .onInterface("org.freedesktop.DBus.Introspectable")
-        .withTimeout(kItemPropertyTimeout)
-        .uponReplyInvoke([this, itemId](std::optional<sdbus::Error> error, std::string introspectionXml) {
-          if (error.has_value()) {
-            kLog.debug("tray introspect failed id={} err={}", itemId, error->what());
-            return;
-          }
-
-          auto itemIt = m_items.find(itemId);
-          if (itemIt == m_items.end()) {
-            return;
-          }
-
-          const bool hasActivate = sniActivateMethodPresent(introspectionXml);
-          if (itemIt->second.hasActivateMethod == hasActivate) {
-            return;
-          }
-          itemIt->second.hasActivateMethod = hasActivate;
-          kLog.debug("tray item id={} hasActivateMethod={}", itemId, hasActivate);
-          emitChanged();
-        });
-  } catch (const sdbus::Error& e) {
-    kLog.debug("tray introspect dispatch failed id={} err={}", itemId, e.what());
-  }
-}
-
 std::uint32_t TrayService::connectionPidForBusName(const std::string& busName) const {
   if (busName.empty() || m_dbusProxy == nullptr || !looks_like_dbus_name(busName)) {
     return 0;
@@ -1856,7 +1822,6 @@ void TrayService::registerOrRefreshItem(const std::string& busName, const std::s
           itemId, sdbus::createProxy(m_bus.connection(), sdbus::ServiceName{busName}, sdbus::ObjectPath{objectPath})
       );
       attachItemProxySignals(itemId, *proxyIt->second);
-      requestActivateCapabilityForItem(itemId);
     }
 
     notifyWatcherItemRegistered(itemId);
@@ -2015,7 +1980,6 @@ void TrayService::resolvePathOnlyItemProxy(const std::string& itemId) {
                     }
 
                     attachItemProxySignals(itemId, *proxyIt->second);
-                    requestActivateCapabilityForItem(itemId);
                     m_pathOnlyResolutionsInFlight.erase(itemId);
                     refreshItemMetadata(itemId);
                     emitChanged();

--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -836,8 +836,7 @@ bool TrayService::itemUsesDBusMenu(const std::string& itemId) const {
   if (it == m_items.end()) {
     return false;
   }
-  const std::string_view menuPath = it->second.menuObjectPath;
-  return !menuPath.empty() && menuPath != "/NO_DBUSMENU";
+  return trayItemHasDBusMenu(it->second);
 }
 
 namespace {
@@ -1726,6 +1725,40 @@ void TrayService::requestProcessNameForItem(const std::string& itemId, const std
   }
 }
 
+void TrayService::requestActivateCapabilityForItem(const std::string& itemId) {
+  const auto proxyIt = m_itemProxies.find(itemId);
+  if (proxyIt == m_itemProxies.end()) {
+    return;
+  }
+
+  try {
+    proxyIt->second->callMethodAsync("Introspect")
+        .onInterface("org.freedesktop.DBus.Introspectable")
+        .withTimeout(kItemPropertyTimeout)
+        .uponReplyInvoke([this, itemId](std::optional<sdbus::Error> error, std::string introspectionXml) {
+          if (error.has_value()) {
+            kLog.debug("tray introspect failed id={} err={}", itemId, error->what());
+            return;
+          }
+
+          auto itemIt = m_items.find(itemId);
+          if (itemIt == m_items.end()) {
+            return;
+          }
+
+          const bool hasActivate = sniActivateMethodPresent(introspectionXml);
+          if (itemIt->second.hasActivateMethod == hasActivate) {
+            return;
+          }
+          itemIt->second.hasActivateMethod = hasActivate;
+          kLog.debug("tray item id={} hasActivateMethod={}", itemId, hasActivate);
+          emitChanged();
+        });
+  } catch (const sdbus::Error& e) {
+    kLog.debug("tray introspect dispatch failed id={} err={}", itemId, e.what());
+  }
+}
+
 std::uint32_t TrayService::connectionPidForBusName(const std::string& busName) const {
   if (busName.empty() || m_dbusProxy == nullptr || !looks_like_dbus_name(busName)) {
     return 0;
@@ -1823,6 +1856,7 @@ void TrayService::registerOrRefreshItem(const std::string& busName, const std::s
           itemId, sdbus::createProxy(m_bus.connection(), sdbus::ServiceName{busName}, sdbus::ObjectPath{objectPath})
       );
       attachItemProxySignals(itemId, *proxyIt->second);
+      requestActivateCapabilityForItem(itemId);
     }
 
     notifyWatcherItemRegistered(itemId);
@@ -1981,6 +2015,7 @@ void TrayService::resolvePathOnlyItemProxy(const std::string& itemId) {
                     }
 
                     attachItemProxySignals(itemId, *proxyIt->second);
+                    requestActivateCapabilityForItem(itemId);
                     m_pathOnlyResolutionsInFlight.erase(itemId);
                     refreshItemMetadata(itemId);
                     emitChanged();

--- a/src/dbus/tray/tray_service.h
+++ b/src/dbus/tray/tray_service.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <sdbus-c++/sdbus-c++.h>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -37,9 +38,56 @@ struct TrayItemInfo {
   std::int32_t attentionHeight = 0;
   bool needsAttention = false;
   bool itemIsMenu = false;
+  // Defaults true so an item behaves like today until introspection answers (or when it
+  // fails); only a completed introspection that lacks the method flips it off.
+  bool hasActivateMethod = true;
 
   bool operator==(const TrayItemInfo&) const = default;
 };
+
+[[nodiscard]] inline bool trayItemHasDBusMenu(const TrayItemInfo& item) {
+  return !item.menuObjectPath.empty() && item.menuObjectPath != "/NO_DBUSMENU";
+}
+
+// Introspection XML quote style differs by toolkit (GDBus can emit single-quoted
+// attributes, sdbus/Qt double-quoted), so probe both. Returns the position just past the
+// quoted value, or npos.
+[[nodiscard]] inline std::size_t
+findQuotedAttrEnd(std::string_view xml, std::string_view attrPrefix, std::string_view value) {
+  for (const char quote : {'"', '\''}) {
+    std::string needle{attrPrefix};
+    needle += quote;
+    needle += value;
+    needle += quote;
+    if (const auto pos = xml.find(needle); pos != std::string_view::npos) {
+      return pos + needle.size();
+    }
+  }
+  return std::string_view::npos;
+}
+
+// Scoped to the org.kde.StatusNotifierItem interface block so an Activate method on an
+// unrelated interface exported at the same path (e.g. org.freedesktop.Application) does
+// not count. The closing quote in the needle keeps SecondaryActivate/
+// XAyatanaSecondaryActivate from matching.
+[[nodiscard]] inline bool sniActivateMethodPresent(std::string_view introspectionXml) {
+  const auto blockStart = findQuotedAttrEnd(introspectionXml, "name=", "org.kde.StatusNotifierItem");
+  if (blockStart == std::string_view::npos) {
+    return false;
+  }
+  const auto blockEnd = introspectionXml.find("</interface>", blockStart);
+  const auto block = introspectionXml.substr(
+      blockStart, blockEnd == std::string_view::npos ? std::string_view::npos : blockEnd - blockStart
+  );
+  return findQuotedAttrEnd(block, "<method name=", "Activate") != std::string_view::npos;
+}
+
+// A left click cannot reach the app when the item is declared menu-only (ItemIsMenu) or
+// exports no Activate method at all (libappindicator/ayatana items such as nm-applet);
+// open the menu instead of dispatching a call that dies with UnknownMethod.
+[[nodiscard]] inline bool trayItemPrefersMenu(const TrayItemInfo& item) {
+  return (item.itemIsMenu || !item.hasActivateMethod) && trayItemHasDBusMenu(item);
+}
 
 struct TrayMenuEntry {
   std::int32_t id = 0;
@@ -129,6 +177,8 @@ private:
   void attachItemProxySignals(const std::string& itemId, sdbus::IProxy& proxy);
   void resolvePathOnlyItemProxy(const std::string& itemId);
   void requestProcessNameForItem(const std::string& itemId, const std::string& busName);
+
+  void requestActivateCapabilityForItem(const std::string& itemId);
   [[nodiscard]] std::uint32_t connectionPidForBusName(const std::string& busName) const;
   void refreshItemMetadata(const std::string& itemId);
   void ensureMenuCache(const std::string& itemId, const std::string& busName, const std::string& menuPath);

--- a/src/dbus/tray/tray_service.h
+++ b/src/dbus/tray/tray_service.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <sdbus-c++/sdbus-c++.h>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -38,10 +37,6 @@ struct TrayItemInfo {
   std::int32_t attentionHeight = 0;
   bool needsAttention = false;
   bool itemIsMenu = false;
-  // Defaults true so an item behaves like today until introspection answers (or when it
-  // fails); only a completed introspection that lacks the method flips it off.
-  bool hasActivateMethod = true;
-
   bool operator==(const TrayItemInfo&) const = default;
 };
 
@@ -49,44 +44,11 @@ struct TrayItemInfo {
   return !item.menuObjectPath.empty() && item.menuObjectPath != "/NO_DBUSMENU";
 }
 
-// Introspection XML quote style differs by toolkit (GDBus can emit single-quoted
-// attributes, sdbus/Qt double-quoted), so probe both. Returns the position just past the
-// quoted value, or npos.
-[[nodiscard]] inline std::size_t
-findQuotedAttrEnd(std::string_view xml, std::string_view attrPrefix, std::string_view value) {
-  for (const char quote : {'"', '\''}) {
-    std::string needle{attrPrefix};
-    needle += quote;
-    needle += value;
-    needle += quote;
-    if (const auto pos = xml.find(needle); pos != std::string_view::npos) {
-      return pos + needle.size();
-    }
-  }
-  return std::string_view::npos;
-}
-
-// Scoped to the org.kde.StatusNotifierItem interface block so an Activate method on an
-// unrelated interface exported at the same path (e.g. org.freedesktop.Application) does
-// not count. The closing quote in the needle keeps SecondaryActivate/
-// XAyatanaSecondaryActivate from matching.
-[[nodiscard]] inline bool sniActivateMethodPresent(std::string_view introspectionXml) {
-  const auto blockStart = findQuotedAttrEnd(introspectionXml, "name=", "org.kde.StatusNotifierItem");
-  if (blockStart == std::string_view::npos) {
-    return false;
-  }
-  const auto blockEnd = introspectionXml.find("</interface>", blockStart);
-  const auto block = introspectionXml.substr(
-      blockStart, blockEnd == std::string_view::npos ? std::string_view::npos : blockEnd - blockStart
-  );
-  return findQuotedAttrEnd(block, "<method name=", "Activate") != std::string_view::npos;
-}
-
-// A left click cannot reach the app when the item is declared menu-only (ItemIsMenu) or
-// exports no Activate method at all (libappindicator/ayatana items such as nm-applet);
-// open the menu instead of dispatching a call that dies with UnknownMethod.
+// SNI spec: ItemIsMenu declares the context menu as the item's only interaction, so left
+// click opens it — but only when a real DBusMenu is exported; otherwise the flag is a lie
+// and Activate is the only useful behavior left.
 [[nodiscard]] inline bool trayItemPrefersMenu(const TrayItemInfo& item) {
-  return (item.itemIsMenu || !item.hasActivateMethod) && trayItemHasDBusMenu(item);
+  return item.itemIsMenu && trayItemHasDBusMenu(item);
 }
 
 struct TrayMenuEntry {
@@ -177,8 +139,6 @@ private:
   void attachItemProxySignals(const std::string& itemId, sdbus::IProxy& proxy);
   void resolvePathOnlyItemProxy(const std::string& itemId);
   void requestProcessNameForItem(const std::string& itemId, const std::string& busName);
-
-  void requestActivateCapabilityForItem(const std::string& itemId);
   [[nodiscard]] std::uint32_t connectionPidForBusName(const std::string& busName) const;
   void refreshItemMetadata(const std::string& itemId);
   void ensureMenuCache(const std::string& itemId, const std::string& busName, const std::string& menuPath);

--- a/src/dbus/tray/tray_service.h
+++ b/src/dbus/tray/tray_service.h
@@ -36,6 +36,7 @@ struct TrayItemInfo {
   std::int32_t attentionWidth = 0;
   std::int32_t attentionHeight = 0;
   bool needsAttention = false;
+  bool itemIsMenu = false;
 
   bool operator==(const TrayItemInfo&) const = default;
 };

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -332,7 +332,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
           }},
       {"tray", [](const WidgetFactory& f, const BuiltinWidgetContext& context) {
             return createWidget<TrayWidget>(
-                context.contentScale, f.m_configService, f.m_tray,
+                context.contentScale, f.m_platform, f.m_configService, f.m_tray,
                 trayWidgetDefinition().resolve(
                     context.config, context.settingContext,
                     TrayWidgetDefinitionContext{

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace {
 
@@ -785,21 +786,18 @@ void TrayWidget::rebuild(Renderer& renderer) {
       const auto [x, y] = trayPointerCoords(*areaPtr, data);
       if (data.button == BTN_LEFT) {
         const auto decision = decideTrayClickForItem(itemId);
-        switch (decision.action) {
-        case tray::TrayClickAction::FocusWindow:
-          m_platform.activateToplevelInfo(*decision.window);
-          break;
-        case tray::TrayClickAction::Ignore:
-          break;
-        case tray::TrayClickAction::ActivateItem:
-          (void)m_tray->activateItem(itemId, x, y);
-          break;
-        case tray::TrayClickAction::OpenMenu:
+        if (decision.action == tray::TrayClickAction::OpenMenu) {
+          // The drawer's itemActivated closes the panel that parents the menu popup.
           openItemMenu(itemId, x, y);
-          break;
-        }
-        if (m_itemActivated) {
-          m_itemActivated();
+        } else {
+          if (decision.action == tray::TrayClickAction::FocusWindow) {
+            m_platform.activateToplevelInfo(*decision.window);
+          } else {
+            (void)m_tray->activateItem(itemId, x, y);
+          }
+          if (m_itemActivated) {
+            m_itemActivated();
+          }
         }
       } else if (data.button == BTN_RIGHT) {
         openItemMenu(itemId, x, y);
@@ -855,7 +853,13 @@ tray::TrayClickDecision TrayWidget::decideTrayClickForItem(const std::string& it
   const tray::WindowLookup lookup = [this](const std::string& candidate) {
     return m_platform.windowsForApp(candidate, {}, nullptr);
   };
-  return tray::decideTrayClick(*itemIt, lookup, m_platform.activeToplevel(), m_focusExistingWindow);
+  const tray::RunningAppIds runningAppIds = [this] { return m_platform.runningAppIds(nullptr); };
+  const auto focusedCompositorWindowId = m_platform.focusedCompositorWindowId();
+  const std::string_view focusedCompositorWindowIdView =
+      focusedCompositorWindowId.has_value() ? std::string_view(*focusedCompositorWindowId) : std::string_view{};
+  return tray::decideTrayClick(
+      *itemIt, lookup, runningAppIds, m_platform.activeToplevel(), focusedCompositorWindowIdView, m_focusExistingWindow
+  );
 }
 
 void TrayWidget::openItemMenu(const std::string& itemId, std::int32_t x, std::int32_t y) {

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -1,5 +1,6 @@
 #include "shell/bar/widgets/tray_widget.h"
 
+#include "compositors/compositor_platform.h"
 #include "config/config_service.h"
 #include "core/log.h"
 #include "core/ui_phase.h"
@@ -12,6 +13,7 @@
 #include "render/text/glyph_registry.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/tray/tray_identifier.h"
+#include "shell/tray/tray_window_match.h"
 #include "system/desktop_entry.h"
 #include "ui/app_icon_colorization.h"
 #include "ui/builders.h"
@@ -164,14 +166,14 @@ namespace {
 
 } // namespace
 
-TrayWidget::TrayWidget(ConfigService& config, TrayService* tray, Options options)
-    : m_config(config), m_tray(tray), m_hiddenItems(std::move(options.hiddenItems)),
+TrayWidget::TrayWidget(CompositorPlatform& platform, ConfigService& config, TrayService* tray, Options options)
+    : m_platform(platform), m_config(config), m_tray(tray), m_hiddenItems(std::move(options.hiddenItems)),
       m_pinnedItems(std::move(options.pinnedItems)), m_hidePassive(options.hidePassive),
       m_drawerMode(options.drawerMode), m_itemActivated(std::move(options.itemActivated)),
       m_barPosition(std::move(options.barPosition)), m_panelGridMode(options.panelGridMode),
       m_panelGridColumns(std::clamp<std::size_t>(options.panelGridColumns, 1U, 5U)),
       m_inlineEntryGap(std::max(0.0F, options.inlineEntryGap)), m_matchAdjacentSpacing(options.matchAdjacentSpacing),
-      m_customItemSize(options.customItemSize) {
+      m_customItemSize(options.customItemSize), m_focusExistingWindow(options.focusExistingWindow) {
   auto normalizeTokens = [](std::vector<std::string>& tokens) {
     std::vector<std::string> normalized;
     normalized.reserve(tokens.size());
@@ -782,16 +784,25 @@ void TrayWidget::rebuild(Renderer& renderer) {
       }
       const auto [x, y] = trayPointerCoords(*areaPtr, data);
       if (data.button == BTN_LEFT) {
-        (void)m_tray->activateItem(itemId, x, y);
+        const auto decision = decideTrayClickForItem(itemId);
+        switch (decision.action) {
+        case tray::TrayClickAction::FocusWindow:
+          m_platform.activateToplevelInfo(*decision.window);
+          break;
+        case tray::TrayClickAction::Ignore:
+          break;
+        case tray::TrayClickAction::ActivateItem:
+          (void)m_tray->activateItem(itemId, x, y);
+          break;
+        case tray::TrayClickAction::OpenMenu:
+          openItemMenu(itemId, x, y);
+          break;
+        }
         if (m_itemActivated) {
           m_itemActivated();
         }
       } else if (data.button == BTN_RIGHT) {
-        if (m_tray->itemUsesDBusMenu(itemId)) {
-          m_tray->requestMenuToggle(itemId, m_contentScale);
-        } else {
-          (void)m_tray->openContextMenu(itemId, x, y);
-        }
+        openItemMenu(itemId, x, y);
       }
     });
     area->addChild(std::move(iconNode));
@@ -833,6 +844,26 @@ std::string TrayWidget::drawerChevronGlyph(bool panelOpen) const {
     return panelOpen ? "chevron-right" : "chevron-left";
   }
   return panelOpen ? "chevron-up" : "chevron-down";
+}
+
+tray::TrayClickDecision TrayWidget::decideTrayClickForItem(const std::string& itemId) const {
+  const auto itemIt = std::ranges::find(m_items, itemId, &TrayItemInfo::id);
+  if (itemIt == m_items.end()) {
+    return {tray::TrayClickAction::ActivateItem, std::nullopt};
+  }
+  // No output filter: the tray is global, the window may live on another monitor.
+  const tray::WindowLookup lookup = [this](const std::string& candidate) {
+    return m_platform.windowsForApp(candidate, {}, nullptr);
+  };
+  return tray::decideTrayClick(*itemIt, lookup, m_platform.activeToplevel(), m_focusExistingWindow);
+}
+
+void TrayWidget::openItemMenu(const std::string& itemId, std::int32_t x, std::int32_t y) {
+  if (m_tray->itemUsesDBusMenu(itemId)) {
+    m_tray->requestMenuToggle(itemId, m_contentScale);
+  } else {
+    (void)m_tray->openContextMenu(itemId, x, y);
+  }
 }
 
 bool TrayWidget::isHiddenItem(const TrayItemInfo& item) const {

--- a/src/shell/bar/widgets/tray_widget.h
+++ b/src/shell/bar/widgets/tray_widget.h
@@ -2,6 +2,7 @@
 
 #include "dbus/tray/tray_service.h"
 #include "shell/bar/widget.h"
+#include "shell/tray/tray_window_match.h"
 #include "system/icon_resolver.h"
 #include "ui/palette.h"
 #include "ui/signal.h"
@@ -14,6 +15,7 @@
 #include <unordered_map>
 #include <vector>
 
+class CompositorPlatform;
 class ConfigService;
 class Flex;
 class Image;
@@ -35,12 +37,13 @@ public:
     float inlineEntryGap = Style::spaceXs;
     bool matchAdjacentSpacing = false;
     std::optional<float> customItemSize;
+    bool focusExistingWindow = true;
     // Read by TrayDrawerPanel, not by TrayWidget: they live here so the tray widget definition owns their defaults.
     double drawerItemSize = Style::baseGlyphSize;
     bool detachedPanel = false;
   };
 
-  TrayWidget(ConfigService& config, TrayService* tray, Options options);
+  TrayWidget(CompositorPlatform& platform, ConfigService& config, TrayService* tray, Options options);
   ~TrayWidget() override;
 
   void setHoverOverlayParent(Node* node) noexcept { m_hoverOverlayParent = node; }
@@ -65,6 +68,8 @@ private:
   [[nodiscard]] std::string iconForItem(const TrayItemInfo& item) const;
   [[nodiscard]] bool isPinnedItem(const TrayItemInfo& item) const;
   [[nodiscard]] bool isHiddenItem(const TrayItemInfo& item) const;
+  [[nodiscard]] tray::TrayClickDecision decideTrayClickForItem(const std::string& itemId) const;
+  void openItemMenu(const std::string& itemId, std::int32_t x, std::int32_t y);
   [[nodiscard]] std::string drawerChevronGlyph(bool panelOpen) const;
   // Bar section gap is between capsule shells; inline tray icons share one shell, so add the
   // lateral inset that adjacent single-icon capsules would contribute between their icons.
@@ -74,6 +79,7 @@ private:
   void clearHoverOverlays();
   [[nodiscard]] std::optional<ColorSpec> currentAppIconColorizeTint() const;
 
+  CompositorPlatform& m_platform;
   ConfigService& m_config;
   TrayService* m_tray = nullptr;
   Flex* m_container = nullptr;
@@ -101,6 +107,7 @@ private:
   float m_inlineEntryGap = Style::spaceXs;
   bool m_matchAdjacentSpacing = false;
   std::optional<float> m_customItemSize;
+  bool m_focusExistingWindow = true;
   bool m_appIconColorizeDirty = false;
   InputArea* m_drawerTrigger = nullptr;
   Glyph* m_drawerChevron = nullptr;

--- a/src/shell/bar/widgets/tray_widget_definition.cpp
+++ b/src/shell/bar/widgets/tray_widget_definition.cpp
@@ -22,6 +22,9 @@ const noctalia::bar::WidgetDefinition<TrayWidget::Options, TrayWidgetDefinitionC
               field<&Options::matchAdjacentSpacing>({
                   .key = "match_adjacent_spacing",
               }),
+              field<&Options::focusExistingWindow>({
+                  .key = "focus_existing_window",
+              }),
               field<&Options::drawerMode>({
                   .key = "drawer",
               }),

--- a/src/shell/common/window_activation.h
+++ b/src/shell/common/window_activation.h
@@ -3,6 +3,7 @@
 #include "compositors/compositor_detect.h"
 #include "wayland/wayland_toplevels.h"
 
+#include <string_view>
 #include <vector>
 
 namespace shell {
@@ -11,6 +12,36 @@ namespace shell {
     return window.handle != nullptr
         || !window.identifier.empty()
         || (compositors::isKde() && (!window.title.empty() || !window.appId.empty()));
+  }
+
+  [[nodiscard]] inline bool matchesActiveWindow(
+      const ToplevelInfo& window, const ActiveToplevel& active, std::string_view focusedCompositorWindowId,
+      const std::vector<ToplevelInfo>& windows
+  ) {
+    if (active.handle != nullptr && window.handle == active.handle) {
+      return true;
+    }
+
+    // Exact-identity ext toplevels have no wlr handle; match them by the compositor's focused
+    // window id, since `active.identifier` is an appId+title synthetic key for wlr toplevels.
+    if (window.exactIdentity
+        && !window.identifier.empty()
+        && !focusedCompositorWindowId.empty()
+        && window.identifier == focusedCompositorWindowId) {
+      return true;
+    }
+
+    if (active.identifier.empty() || window.identifier.empty() || active.identifier != window.identifier) {
+      return false;
+    }
+
+    int count = 0;
+    for (const auto& w : windows) {
+      if (w.identifier == active.identifier && ++count > 1) {
+        return false;
+      }
+    }
+    return true;
   }
 
   namespace detail {
@@ -45,6 +76,19 @@ namespace shell {
       return best;
     }
     return detail::highestOrderWindow(windows, true);
+  }
+
+  // Verbatim dock semantics: the last activatable element in vector order. The dock's launch-focus
+  // path depends on this exact pick; use newestActivatableWindow only where `order` is meaningful.
+  [[nodiscard]] inline const ToplevelInfo* lastActivatableWindow(const std::vector<ToplevelInfo>& windows) {
+    const ToplevelInfo* best = nullptr;
+    for (const auto& window : windows) {
+      if (!canActivateWindow(window)) {
+        continue;
+      }
+      best = &window;
+    }
+    return best;
   }
 
 } // namespace shell

--- a/src/shell/common/window_activation.h
+++ b/src/shell/common/window_activation.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "compositors/compositor_detect.h"
+#include "wayland/wayland_toplevels.h"
+
+#include <vector>
+
+namespace shell {
+
+  [[nodiscard]] inline bool canActivateWindow(const ToplevelInfo& window) {
+    return window.handle != nullptr
+        || !window.identifier.empty()
+        || (compositors::isKde() && (!window.title.empty() || !window.appId.empty()));
+  }
+
+  namespace detail {
+
+    [[nodiscard]] inline bool isExtOnlyWindow(const ToplevelInfo& window) {
+      return window.handle == nullptr && window.extHandle != nullptr;
+    }
+
+    [[nodiscard]] inline const ToplevelInfo*
+    highestOrderWindow(const std::vector<ToplevelInfo>& windows, bool extOnly) {
+      const ToplevelInfo* best = nullptr;
+      for (const auto& window : windows) {
+        if (isExtOnlyWindow(window) != extOnly || !canActivateWindow(window)) {
+          continue;
+        }
+        // >= keeps the last of an order tie, matching the previous position-based behavior.
+        if (best == nullptr || window.order >= best->order) {
+          best = &window;
+        }
+      }
+      return best;
+    }
+
+  } // namespace detail
+
+  // wlr and ext_foreign_toplevel_list stamp `order` from independent counters, so it only ranks
+  // windows from the same protocol; Hyprland's windowsForApp appends ext-only toplevels after the
+  // wlr ones, which makes vector position meaningless across that boundary. Rank inside the
+  // wlr/KDE group first (those activate by handle), fall back to the ext-only group.
+  [[nodiscard]] inline const ToplevelInfo* newestActivatableWindow(const std::vector<ToplevelInfo>& windows) {
+    if (const ToplevelInfo* best = detail::highestOrderWindow(windows, false); best != nullptr) {
+      return best;
+    }
+    return detail::highestOrderWindow(windows, true);
+  }
+
+} // namespace shell

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -103,36 +103,6 @@ namespace {
     return signature;
   }
 
-  [[nodiscard]] bool matchesActiveWindow(
-      const ToplevelInfo& window, const ActiveToplevel& active, std::string_view focusedCompositorWindowId,
-      const std::vector<ToplevelInfo>& windows
-  ) {
-    if (active.handle != nullptr && window.handle == active.handle) {
-      return true;
-    }
-
-    // Exact-identity ext toplevels have no wlr handle; match them by the compositor's focused
-    // window id, since `active.identifier` is an appId+title synthetic key for wlr toplevels.
-    if (window.exactIdentity
-        && !window.identifier.empty()
-        && !focusedCompositorWindowId.empty()
-        && window.identifier == focusedCompositorWindowId) {
-      return true;
-    }
-
-    if (active.identifier.empty() || window.identifier.empty() || active.identifier != window.identifier) {
-      return false;
-    }
-
-    int count = 0;
-    for (const auto& w : windows) {
-      if (w.identifier == active.identifier && ++count > 1) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   const ToplevelInfo* nextActivatableWindow(
       const std::vector<ToplevelInfo>& windows, const std::optional<ActiveToplevel>& active,
       std::string_view focusedCompositorWindowId, std::string_view preferredIdentifier
@@ -143,7 +113,7 @@ namespace {
 
     if (active.has_value()) {
       for (std::size_t i = 0; i < windows.size(); ++i) {
-        if (!matchesActiveWindow(windows[i], *active, focusedCompositorWindowId, windows)) {
+        if (!shell::matchesActiveWindow(windows[i], *active, focusedCompositorWindowId, windows)) {
           continue;
         }
         for (std::size_t offset = 1; offset <= windows.size(); ++offset) {
@@ -1107,14 +1077,14 @@ void Dock::tryFulfillPendingLaunchFocus() {
 
   auto windowsOnTarget =
       shell::dock::windowsForDockItem(*m_platform, pending.idLower, pending.wmClassLower, pending.targetOutput);
-  const ToplevelInfo* window = shell::newestActivatableWindow(windowsOnTarget);
+  const ToplevelInfo* window = shell::lastActivatableWindow(windowsOnTarget);
   if (window == nullptr) {
     auto windows =
         shell::dock::windowsForDockItem(*m_platform, pending.idLower, pending.wmClassLower, pending.outputFilter);
     if (windows.empty() && pending.outputFilter != nullptr) {
       windows = shell::dock::windowsForDockItem(*m_platform, pending.idLower, pending.wmClassLower, nullptr);
     }
-    window = shell::newestActivatableWindow(windows);
+    window = shell::lastActivatableWindow(windows);
     if (window == nullptr) {
       return;
     }

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -7,6 +7,7 @@
 #include "core/log.h"
 #include "ipc/ipc_service.h"
 #include "render/scene/node.h"
+#include "shell/common/window_activation.h"
 #include "shell/dock/dock_context_menu.h"
 #include "shell/dock/dock_geometry.h"
 #include "shell/dock/dock_instance.h"
@@ -102,23 +103,6 @@ namespace {
     return signature;
   }
 
-  [[nodiscard]] bool canActivateWindow(const ToplevelInfo& window) {
-    return window.handle != nullptr
-        || !window.identifier.empty()
-        || (compositors::isKde() && (!window.title.empty() || !window.appId.empty()));
-  }
-
-  [[nodiscard]] const ToplevelInfo* newestActivatableWindow(const std::vector<ToplevelInfo>& windows) {
-    const ToplevelInfo* best = nullptr;
-    for (const auto& window : windows) {
-      if (!canActivateWindow(window)) {
-        continue;
-      }
-      best = &window;
-    }
-    return best;
-  }
-
   [[nodiscard]] bool matchesActiveWindow(
       const ToplevelInfo& window, const ActiveToplevel& active, std::string_view focusedCompositorWindowId,
       const std::vector<ToplevelInfo>& windows
@@ -164,7 +148,7 @@ namespace {
         }
         for (std::size_t offset = 1; offset <= windows.size(); ++offset) {
           const auto& candidate = windows[(i + offset) % windows.size()];
-          if (canActivateWindow(candidate)) {
+          if (shell::canActivateWindow(candidate)) {
             return &candidate;
           }
         }
@@ -174,14 +158,14 @@ namespace {
 
     if (!preferredIdentifier.empty()) {
       for (const auto& window : windows) {
-        if (window.identifier == preferredIdentifier && canActivateWindow(window)) {
+        if (window.identifier == preferredIdentifier && shell::canActivateWindow(window)) {
           return &window;
         }
       }
     }
 
     for (const auto& window : windows) {
-      if (canActivateWindow(window)) {
+      if (shell::canActivateWindow(window)) {
         return &window;
       }
     }
@@ -1123,14 +1107,14 @@ void Dock::tryFulfillPendingLaunchFocus() {
 
   auto windowsOnTarget =
       shell::dock::windowsForDockItem(*m_platform, pending.idLower, pending.wmClassLower, pending.targetOutput);
-  const ToplevelInfo* window = newestActivatableWindow(windowsOnTarget);
+  const ToplevelInfo* window = shell::newestActivatableWindow(windowsOnTarget);
   if (window == nullptr) {
     auto windows =
         shell::dock::windowsForDockItem(*m_platform, pending.idLower, pending.wmClassLower, pending.outputFilter);
     if (windows.empty() && pending.outputFilter != nullptr) {
       windows = shell::dock::windowsForDockItem(*m_platform, pending.idLower, pending.wmClassLower, nullptr);
     }
-    window = newestActivatableWindow(windows);
+    window = shell::newestActivatableWindow(windows);
     if (window == nullptr) {
       return;
     }

--- a/src/shell/tray/tray_drawer_panel.cpp
+++ b/src/shell/tray/tray_drawer_panel.cpp
@@ -1,5 +1,6 @@
 #include "shell/tray/tray_drawer_panel.h"
 
+#include "compositors/compositor_platform.h"
 #include "config/config_service.h"
 #include "dbus/tray/tray_service.h"
 #include "shell/bar/widgets/tray_widget.h"
@@ -11,7 +12,8 @@
 #include <algorithm>
 #include <vector>
 
-TrayDrawerPanel::TrayDrawerPanel(TrayService* tray, ConfigService* config) : m_tray(tray), m_config(config) {}
+TrayDrawerPanel::TrayDrawerPanel(CompositorPlatform* platform, TrayService* tray, ConfigService* config)
+    : m_platform(platform), m_tray(tray), m_config(config) {}
 
 TrayDrawerPanel::~TrayDrawerPanel() = default;
 
@@ -67,7 +69,7 @@ float TrayDrawerPanel::preferredHeight() const {
 }
 
 void TrayDrawerPanel::create() {
-  if (m_config == nullptr) {
+  if (m_config == nullptr || m_platform == nullptr) {
     return;
   }
 
@@ -91,7 +93,7 @@ void TrayDrawerPanel::create() {
   options.itemActivated = []() { PanelManager::instance().close(); };
   options.panelGridMode = true;
   options.customItemSize = resolved.drawerItemSize;
-  m_drawerWidget = std::make_unique<TrayWidget>(*m_config, m_tray, std::move(options));
+  m_drawerWidget = std::make_unique<TrayWidget>(*m_platform, *m_config, m_tray, std::move(options));
   m_drawerWidget->setContentScale(contentScale());
   if (!m_config->config().bars.empty()) {
     const auto& barConfig = m_config->config().bars.front();

--- a/src/shell/tray/tray_drawer_panel.h
+++ b/src/shell/tray/tray_drawer_panel.h
@@ -6,13 +6,14 @@
 #include <string>
 #include <vector>
 
+class CompositorPlatform;
 class ConfigService;
 class TrayService;
 class TrayWidget;
 
 class TrayDrawerPanel : public Panel {
 public:
-  TrayDrawerPanel(TrayService* tray, ConfigService* config);
+  TrayDrawerPanel(CompositorPlatform* platform, TrayService* tray, ConfigService* config);
   ~TrayDrawerPanel() override;
 
   void create() override;
@@ -32,6 +33,7 @@ private:
   [[nodiscard]] float resolvedItemGap() const;
   [[nodiscard]] std::size_t visibleItemCount() const;
 
+  CompositorPlatform* m_platform = nullptr;
   TrayService* m_tray = nullptr;
   ConfigService* m_config = nullptr;
   std::unique_ptr<TrayWidget> m_drawerWidget;

--- a/src/shell/tray/tray_identifier.h
+++ b/src/shell/tray/tray_identifier.h
@@ -168,6 +168,33 @@ namespace tray {
     return candidates;
   }
 
+  // Window matching orders identity-strong fields first: descriptive fields (title, tooltip)
+  // can collide with an unrelated app's window. Lowercased because compositor lookups compare
+  // against a lowercased app id verbatim.
+  [[nodiscard]] inline std::vector<std::string> windowMatchCandidates(const TrayItemInfo& item) {
+    std::vector<std::string> candidates;
+    appendIdentifierVariants(candidates, item.id);
+    appendIdentifierVariants(candidates, item.busName);
+    appendIdentifierVariants(candidates, item.processName);
+    appendIdentifierVariants(candidates, item.itemName);
+    appendIdentifierVariants(candidates, item.objectPath);
+    appendIdentifierVariants(candidates, item.iconName);
+    appendIdentifierVariants(candidates, item.overlayIconName);
+    appendIdentifierVariants(candidates, item.attentionIconName);
+    appendIdentifierVariants(candidates, item.title);
+    appendIdentifierVariants(candidates, item.statusNotifierTitle);
+    appendIdentifierVariants(candidates, item.statusNotifierDescription);
+
+    std::vector<std::string> lowered;
+    for (const auto& candidate : candidates) {
+      auto lower = StringUtils::toLower(candidate);
+      if (!std::ranges::contains(lowered, lower)) {
+        lowered.push_back(std::move(lower));
+      }
+    }
+    return lowered;
+  }
+
   inline bool tokenMatchesItem(std::string_view token, const TrayItemInfo& item) {
     if (looksGenericStatusItemName(token) || isTransientUniqueIdentifier(token)) {
       return false;

--- a/src/shell/tray/tray_window_match.h
+++ b/src/shell/tray/tray_window_match.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "dbus/tray/tray_service.h"
+#include "shell/common/window_activation.h"
+#include "shell/tray/tray_identifier.h"
+#include "wayland/wayland_toplevels.h"
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace tray {
+
+  // Lookup seam so matching logic is testable without a real CompositorPlatform;
+  // production binds this to CompositorPlatform::windowsForApp.
+  using WindowLookup = std::function<std::vector<ToplevelInfo>(const std::string& candidateLower)>;
+
+  [[nodiscard]] inline std::optional<ToplevelInfo>
+  findNewestWindowForTrayItem(const TrayItemInfo& item, const WindowLookup& lookup) {
+    for (const auto& candidate : windowMatchCandidates(item)) {
+      const auto windows = lookup(candidate);
+      const ToplevelInfo* best = shell::newestActivatableWindow(windows);
+      if (best != nullptr) {
+        return *best;
+      }
+    }
+    return std::nullopt;
+  }
+
+  // Intentionally narrower than dock's matchesActiveWindow: the tray already picked a
+  // single "newest" window, so no multi-window disambiguation is needed, and exactIdentity
+  // is always false for windows from the plain windowsForApp() path.
+  [[nodiscard]] inline bool
+  trayWindowIsFocused(const ToplevelInfo& window, const std::optional<ActiveToplevel>& active) {
+    if (!active.has_value()) {
+      return false;
+    }
+    if (active->handle != nullptr && window.handle == active->handle) {
+      return true;
+    }
+    return !active->identifier.empty() && !window.identifier.empty() && active->identifier == window.identifier;
+  }
+
+  enum class TrayClickAction { ActivateItem, FocusWindow, Ignore, OpenMenu };
+
+  struct TrayClickDecision {
+    TrayClickAction action = TrayClickAction::ActivateItem;
+    std::optional<ToplevelInfo> window;
+  };
+
+  // Clicking the tray icon of the already-focused window is a deliberate no-op: it must not
+  // fall through to the SNI Activate call.
+  [[nodiscard]] inline TrayClickDecision decideTrayClick(
+      const TrayItemInfo& item, const WindowLookup& lookup, const std::optional<ActiveToplevel>& active,
+      bool focusExistingWindow
+  ) {
+    // SNI spec: ItemIsMenu means the item only supports its context menu, Activate is
+    // meaningless. This takes priority regardless of the focus-existing-window setting.
+    if (item.itemIsMenu) {
+      return {TrayClickAction::OpenMenu, std::nullopt};
+    }
+    if (!focusExistingWindow) {
+      return {TrayClickAction::ActivateItem, std::nullopt};
+    }
+    const auto window = findNewestWindowForTrayItem(item, lookup);
+    if (!window.has_value()) {
+      return {TrayClickAction::ActivateItem, std::nullopt};
+    }
+    if (trayWindowIsFocused(*window, active)) {
+      return {TrayClickAction::Ignore, std::nullopt};
+    }
+    return {TrayClickAction::FocusWindow, window};
+  }
+
+} // namespace tray

--- a/src/shell/tray/tray_window_match.h
+++ b/src/shell/tray/tray_window_match.h
@@ -110,15 +110,16 @@ namespace tray {
     std::optional<ToplevelInfo> window;
   };
 
+  // Left click keeps each item's expected behavior: declared menu-only items open their
+  // menu, everything else gets Activate. With focus_existing_window on, an unfocused
+  // already-mapped window is focused instead of trusting Activate to do it — some items
+  // export no Activate at all, and some Electron apps reply OK without doing anything.
   // An already-focused window falls through to Activate so apps whose tray icon is an
   // Activate-driven show/hide toggle keep their hide half (upstream issue 3859).
   [[nodiscard]] inline TrayClickDecision decideTrayClick(
       const TrayItemInfo& item, const WindowLookup& lookup, const RunningAppIds& runningAppIds,
       const std::optional<ActiveToplevel>& active, std::string_view focusedCompositorWindowId, bool focusExistingWindow
   ) {
-    // Menu-only either declared (SNI ItemIsMenu) or structural (no Activate method exported,
-    // per introspection — the libappindicator/ayatana class). Requires a real exported
-    // DBusMenu, else left click would be a silent no-op.
     if (trayItemPrefersMenu(item)) {
       return {TrayClickAction::OpenMenu, std::nullopt};
     }

--- a/src/shell/tray/tray_window_match.h
+++ b/src/shell/tray/tray_window_match.h
@@ -3,11 +3,14 @@
 #include "dbus/tray/tray_service.h"
 #include "shell/common/window_activation.h"
 #include "shell/tray/tray_identifier.h"
+#include "system/app_identity.h"
+#include "util/string_utils.h"
 #include "wayland/wayland_toplevels.h"
 
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace tray {
@@ -16,61 +19,120 @@ namespace tray {
   // production binds this to CompositorPlatform::windowsForApp.
   using WindowLookup = std::function<std::vector<ToplevelInfo>(const std::string& candidateLower)>;
 
-  [[nodiscard]] inline std::optional<ToplevelInfo>
-  findNewestWindowForTrayItem(const TrayItemInfo& item, const WindowLookup& lookup) {
-    for (const auto& candidate : windowMatchCandidates(item)) {
+  // Running app ids as the compositor reports them (raw case). Production binds this to
+  // CompositorPlatform::runningAppIds; it is a separate seam from WindowLookup so the
+  // reverse-DNS pass stays testable.
+  using RunningAppIds = std::function<std::vector<std::string>()>;
+
+  namespace detail {
+
+    // Ambiguity guard: two running apps sharing a tail must never cause a wrong window to
+    // be focused, so a non-unique tail match resolves to nothing.
+    [[nodiscard]] inline std::optional<std::string>
+    uniqueAppIdWithTail(const std::vector<std::string>& appIds, std::string_view candidateLower) {
+      const auto tail = app_identity::appIdTail(candidateLower);
+      if (tail.size() < 3 || looksGenericStatusItemName(tail)) {
+        return std::nullopt;
+      }
+
+      std::optional<std::string> match;
+      int matchCount = 0;
+      for (const auto& appId : appIds) {
+        const auto lower = StringUtils::toLower(appId);
+        if (app_identity::appIdTail(lower) == tail) {
+          match = lower;
+          ++matchCount;
+        }
+      }
+
+      if (matchCount != 1) {
+        return std::nullopt;
+      }
+      return match;
+    }
+
+  } // namespace detail
+
+  struct MatchedWindows {
+    std::vector<ToplevelInfo> windows;
+    std::optional<ToplevelInfo> newest;
+  };
+
+  [[nodiscard]] inline MatchedWindows findNewestWindowForTrayItem(
+      const TrayItemInfo& item, const WindowLookup& lookup, const RunningAppIds& runningAppIds
+  ) {
+    const auto candidates = windowMatchCandidates(item);
+    if (candidates.empty()) {
+      return {};
+    }
+
+    for (const auto& candidate : candidates) {
       const auto windows = lookup(candidate);
       const ToplevelInfo* best = shell::newestActivatableWindow(windows);
       if (best != nullptr) {
-        return *best;
+        MatchedWindows result;
+        result.newest = *best;
+        result.windows = windows;
+        return result;
       }
     }
-    return std::nullopt;
+
+    const auto appIds = runningAppIds();
+    for (const auto& candidate : candidates) {
+      const auto resolved = detail::uniqueAppIdWithTail(appIds, candidate);
+      if (!resolved.has_value() || *resolved == candidate) {
+        continue;
+      }
+      const auto windows = lookup(*resolved);
+      const ToplevelInfo* best = shell::newestActivatableWindow(windows);
+      if (best != nullptr) {
+        MatchedWindows result;
+        result.newest = *best;
+        result.windows = windows;
+        return result;
+      }
+    }
+
+    return {};
   }
 
-  // Intentionally narrower than dock's matchesActiveWindow: the tray already picked a
-  // single "newest" window, so no multi-window disambiguation is needed, and exactIdentity
-  // is always false for windows from the plain windowsForApp() path.
-  [[nodiscard]] inline bool
-  trayWindowIsFocused(const ToplevelInfo& window, const std::optional<ActiveToplevel>& active) {
-    if (!active.has_value()) {
-      return false;
-    }
-    if (active->handle != nullptr && window.handle == active->handle) {
-      return true;
-    }
-    return !active->identifier.empty() && !window.identifier.empty() && active->identifier == window.identifier;
+  [[nodiscard]] inline bool trayWindowIsFocused(
+      const ToplevelInfo& window, const std::vector<ToplevelInfo>& windows, const std::optional<ActiveToplevel>& active,
+      std::string_view focusedCompositorWindowId
+  ) {
+    return active.has_value() && shell::matchesActiveWindow(window, *active, focusedCompositorWindowId, windows);
   }
 
-  enum class TrayClickAction { ActivateItem, FocusWindow, Ignore, OpenMenu };
+  enum class TrayClickAction { ActivateItem, FocusWindow, OpenMenu };
 
   struct TrayClickDecision {
     TrayClickAction action = TrayClickAction::ActivateItem;
     std::optional<ToplevelInfo> window;
   };
 
-  // Clicking the tray icon of the already-focused window is a deliberate no-op: it must not
-  // fall through to the SNI Activate call.
+  // An already-focused window falls through to Activate so apps whose tray icon is an
+  // Activate-driven show/hide toggle keep their hide half (upstream issue 3859).
   [[nodiscard]] inline TrayClickDecision decideTrayClick(
-      const TrayItemInfo& item, const WindowLookup& lookup, const std::optional<ActiveToplevel>& active,
-      bool focusExistingWindow
+      const TrayItemInfo& item, const WindowLookup& lookup, const RunningAppIds& runningAppIds,
+      const std::optional<ActiveToplevel>& active, std::string_view focusedCompositorWindowId, bool focusExistingWindow
   ) {
-    // SNI spec: ItemIsMenu means the item only supports its context menu, Activate is
-    // meaningless. This takes priority regardless of the focus-existing-window setting.
-    if (item.itemIsMenu) {
+    // Menu-only either declared (SNI ItemIsMenu) or structural (no Activate method exported,
+    // per introspection — the libappindicator/ayatana class). Requires a real exported
+    // DBusMenu, else left click would be a silent no-op.
+    if (trayItemPrefersMenu(item)) {
       return {TrayClickAction::OpenMenu, std::nullopt};
     }
     if (!focusExistingWindow) {
       return {TrayClickAction::ActivateItem, std::nullopt};
     }
-    const auto window = findNewestWindowForTrayItem(item, lookup);
-    if (!window.has_value()) {
+    const auto matched = findNewestWindowForTrayItem(item, lookup, runningAppIds);
+    if (!matched.newest.has_value()) {
       return {TrayClickAction::ActivateItem, std::nullopt};
     }
-    if (trayWindowIsFocused(*window, active)) {
-      return {TrayClickAction::Ignore, std::nullopt};
+    if (trayWindowIsFocused(*matched.newest, matched.windows, active, focusedCompositorWindowId)) {
+      return {TrayClickAction::ActivateItem, std::nullopt};
     }
-    return {TrayClickAction::FocusWindow, window};
+    return {TrayClickAction::FocusWindow, matched.newest};
   }
 
 } // namespace tray

--- a/src/system/app_identity.cpp
+++ b/src/system/app_identity.cpp
@@ -29,17 +29,6 @@ namespace app_identity {
       return valueKey == identityKey(candidate);
     }
 
-    std::string_view appIdTail(std::string_view appKey) {
-      std::string_view tail = appKey;
-      if (const auto slash = tail.find_last_of('/'); slash != std::string_view::npos && slash + 1 < tail.size()) {
-        tail = tail.substr(slash + 1);
-      }
-      if (const auto dot = tail.find_last_of('.'); dot != std::string_view::npos && dot + 1 < tail.size()) {
-        tail = tail.substr(dot + 1);
-      }
-      return tail;
-    }
-
     std::optional<DesktopEntry>
     findDesktopEntryByIdTail(std::string_view appKey, std::span<const DesktopEntry> allEntries) {
       const std::string appLower = StringUtils::toLower(std::string(appKey));
@@ -109,6 +98,17 @@ namespace app_identity {
     }
 
   } // namespace
+
+  std::string_view appIdTail(std::string_view appKey) {
+    std::string_view tail = appKey;
+    if (const auto slash = tail.find_last_of('/'); slash != std::string_view::npos && slash + 1 < tail.size()) {
+      tail = tail.substr(slash + 1);
+    }
+    if (const auto dot = tail.find_last_of('.'); dot != std::string_view::npos && dot + 1 < tail.size()) {
+      tail = tail.substr(dot + 1);
+    }
+    return tail;
+  }
 
   bool matchesLower(
       std::string_view valueLower, std::string_view idLower, std::string_view startupWmClassLower,

--- a/src/system/app_identity.h
+++ b/src/system/app_identity.h
@@ -23,6 +23,9 @@ namespace app_identity {
 
   [[nodiscard]] bool desktopEntryMatchesLower(const DesktopEntry& entry, std::string_view valueLower);
 
+  // Last reverse-DNS segment of an app id / desktop-entry id: "org.keepassxc.KeePassXC" -> "KeePassXC".
+  [[nodiscard]] std::string_view appIdTail(std::string_view appKey);
+
   // Best-effort lookup by app id / StartupWMClass. Operates on the parsed desktop-entry list,
   // which already excludes hidden/NoDisplay/wrong-desktop entries.
   [[nodiscard]] std::optional<DesktopEntry> findDesktopEntry(

--- a/tests/tray_window_match_test.cpp
+++ b/tests/tray_window_match_test.cpp
@@ -243,7 +243,7 @@ int main() {
   }
 
   // decideTrayClick: matched window is the active one by handle -> falls through to
-  // ActivateItem (finding 2: preserves each app's Activate-driven hide toggle).
+  // ActivateItem, preserving each app's Activate-driven hide toggle.
   {
     auto* sharedHandle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x2);
     const auto item = makeItem("someapp");
@@ -262,7 +262,7 @@ int main() {
   }
 
   // decideTrayClick: matched window is the active one by identifier -> falls through to
-  // ActivateItem (finding 2: preserves each app's Activate-driven hide toggle).
+  // ActivateItem, preserving each app's Activate-driven hide toggle.
   {
     const auto item = makeItem("otherapp");
     const auto window = makeWindow("shared-id", 1);
@@ -385,102 +385,38 @@ int main() {
     TEST_CHECK(decision.window->identifier == window.identifier);
   }
 
-  // sniActivateMethodPresent: Activate exported on the SNI interface itself -> true.
+  // trayItemPrefersMenu: ItemIsMenu with a real DBusMenu -> menu.
   {
-    const std::string xml = "<node><interface name=\"org.kde.StatusNotifierItem\">"
-                            "<method name=\"Activate\"><arg name=\"x\" type=\"i\"/></method>"
-                            "<method name=\"ContextMenu\"/></interface></node>";
-    TEST_CHECK(sniActivateMethodPresent(xml));
-  }
-
-  // sniActivateMethodPresent: nm-applet-shaped item — SecondaryActivate and the ayatana
-  // variant only, no Activate -> false.
-  {
-    const std::string xml = "<node><interface name=\"org.kde.StatusNotifierItem\">"
-                            "<method name=\"SecondaryActivate\"/>"
-                            "<method name=\"XAyatanaSecondaryActivate\"/>"
-                            "<method name=\"Scroll\"/></interface></node>";
-    TEST_CHECK(!sniActivateMethodPresent(xml));
-  }
-
-  // sniActivateMethodPresent: Activate on a different interface at the same path does not
-  // count for the SNI interface.
-  {
-    const std::string xml = "<node><interface name=\"org.kde.StatusNotifierItem\">"
-                            "<method name=\"ContextMenu\"/></interface>"
-                            "<interface name=\"org.freedesktop.Application\">"
-                            "<method name=\"Activate\"/></interface></node>";
-    TEST_CHECK(!sniActivateMethodPresent(xml));
-  }
-
-  // sniActivateMethodPresent: empty / SNI interface absent -> false.
-  {
-    TEST_CHECK(!sniActivateMethodPresent(""));
-    TEST_CHECK(!sniActivateMethodPresent("<node><interface name=\"org.other\"/></node>"));
-  }
-
-  // sniActivateMethodPresent: single-quoted attributes (GDBus-style XML) -> same results
-  // as double-quoted.
-  {
-    const std::string withActivate = "<node><interface name='org.kde.StatusNotifierItem'>"
-                                     "<method name='Activate'><arg name='x' type='i'/></method>"
-                                     "</interface></node>";
-    TEST_CHECK(sniActivateMethodPresent(withActivate));
-    const std::string withoutActivate = "<node><interface name='org.kde.StatusNotifierItem'>"
-                                        "<method name='SecondaryActivate'/>"
-                                        "</interface></node>";
-    TEST_CHECK(!sniActivateMethodPresent(withoutActivate));
-  }
-
-  // trayItemPrefersMenu: no Activate method + real DBusMenu -> menu, without ItemIsMenu.
-  {
-    auto item = makeItem("no-activate-with-menu");
-    item.hasActivateMethod = false;
+    auto item = makeItem("menu-only");
+    item.itemIsMenu = true;
     item.menuObjectPath = "/MenuBar";
     TEST_CHECK(trayItemPrefersMenu(item));
   }
 
-  // trayItemPrefersMenu: no Activate method but no menu either -> not menu.
+  // trayItemPrefersMenu: ItemIsMenu without a menu -> not menu.
   {
-    auto item = makeItem("no-activate-no-menu");
-    item.hasActivateMethod = false;
+    auto item = makeItem("menu-flag-no-menu");
+    item.itemIsMenu = true;
     TEST_CHECK(!trayItemPrefersMenu(item));
   }
 
-  // trayItemPrefersMenu: default item (Activate assumed present, not menu-only) -> not menu.
+  // trayItemPrefersMenu: regular item with a menu but no ItemIsMenu -> not menu; the menu
+  // stays on right click only.
   {
     auto item = makeItem("regular");
     item.menuObjectPath = "/MenuBar";
     TEST_CHECK(!trayItemPrefersMenu(item));
   }
 
-  // decideTrayClick: no Activate method + menu -> OpenMenu even when a window would match
-  // and even with the focus feature disabled.
+  // decideTrayClick: regular item with a menu and an unfocused matching window -> the menu
+  // must never open on left click; the window is focused.
   {
-    auto item = makeItem("no-activate-menu-app");
-    item.hasActivateMethod = false;
+    auto item = makeItem("windowed-app-with-menu");
     item.menuObjectPath = "/MenuBar";
-    const auto window = makeWindow("no-activate-window", 1);
-    bool lookupCalled = false;
-    const tray::WindowLookup lookup = [&](const std::string&) {
-      lookupCalled = true;
-      return std::vector<ToplevelInfo>{window};
-    };
-    const auto onDecision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
-    TEST_CHECK(onDecision.action == tray::TrayClickAction::OpenMenu);
-    const auto offDecision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", false);
-    TEST_CHECK(offDecision.action == tray::TrayClickAction::OpenMenu);
-    TEST_CHECK(!lookupCalled);
-  }
-
-  // decideTrayClick: no Activate method, no menu, matching window, feature on -> FocusWindow.
-  {
-    auto item = makeItem("no-activate-windowed-app");
-    item.hasActivateMethod = false;
     auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
-    const auto window = makeWindow("no-activate-windowed", 1, handle);
+    const auto window = makeWindow("windowed-app-window", 1, handle);
     const tray::WindowLookup lookup = [&](const std::string& candidate) {
-      if (candidate == "no-activate-windowed-app") {
+      if (candidate == "windowed-app-with-menu") {
         return std::vector<ToplevelInfo>{window};
       }
       return std::vector<ToplevelInfo>{};
@@ -488,5 +424,17 @@ int main() {
     const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
     TEST_CHECK(decision.action == tray::TrayClickAction::FocusWindow);
     TEST_CHECK(decision.window.has_value());
+  }
+
+  // decideTrayClick: regular item with a menu but no matching window -> ActivateItem, never
+  // the menu.
+  {
+    auto item = makeItem("menu-but-no-window");
+    item.menuObjectPath = "/MenuBar";
+    const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
+    const auto onDecision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
+    TEST_CHECK(onDecision.action == tray::TrayClickAction::ActivateItem);
+    const auto offDecision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", false);
+    TEST_CHECK(offDecision.action == tray::TrayClickAction::ActivateItem);
   }
 }

--- a/tests/tray_window_match_test.cpp
+++ b/tests/tray_window_match_test.cpp
@@ -4,6 +4,7 @@
 #include "util/string_utils.h"
 #include "wayland/wayland_toplevels.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -29,10 +30,12 @@ namespace {
 } // namespace
 
 int main() {
+  const tray::RunningAppIds noRunningApps = [] { return std::vector<std::string>{}; };
+
   {
     const auto item = makeItem("firefox-app");
     const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
-    TEST_CHECK(!tray::findNewestWindowForTrayItem(item, lookup).has_value());
+    TEST_CHECK(!tray::findNewestWindowForTrayItem(item, lookup, noRunningApps).newest.has_value());
   }
 
   {
@@ -45,29 +48,130 @@ int main() {
       }
       return std::vector<ToplevelInfo>{};
     };
-    const auto result = tray::findNewestWindowForTrayItem(item, lookup);
-    TEST_CHECK(result.has_value());
-    TEST_CHECK(result->identifier == newer.identifier);
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, noRunningApps);
+    TEST_CHECK(result.newest.has_value());
+    TEST_CHECK(result.newest->identifier == newer.identifier);
   }
 
   {
     const auto item = makeItem("RegularApp");
     const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{ToplevelInfo{}}; };
-    TEST_CHECK(!tray::findNewestWindowForTrayItem(item, lookup).has_value());
+    TEST_CHECK(!tray::findNewestWindowForTrayItem(item, lookup, noRunningApps).newest.has_value());
   }
 
+  // Transient item id short-circuits before any candidate exists: neither lookup nor
+  // runningAppIds is ever invoked.
   {
     const auto item = makeItem(":1.234/org/status/electron");
     TEST_CHECK(tray::isTransientUniqueIdentifier(item.id));
     TEST_CHECK(tray::pinMatchCandidates(item).empty());
     bool lookupCalled = false;
+    bool runningAppIdsCalled = false;
     const tray::WindowLookup lookup = [&](const std::string&) {
       lookupCalled = true;
       return std::vector<ToplevelInfo>{};
     };
-    const auto result = tray::findNewestWindowForTrayItem(item, lookup);
+    const tray::RunningAppIds runningAppIds = [&] {
+      runningAppIdsCalled = true;
+      return std::vector<std::string>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, runningAppIds);
     TEST_CHECK(!lookupCalled);
-    TEST_CHECK(!result.has_value());
+    TEST_CHECK(!runningAppIdsCalled);
+    TEST_CHECK(!result.newest.has_value());
+  }
+
+  // Reverse-DNS tail match: SNI id "keepassxc" matches a running app id whose reverse-DNS
+  // tail is "keepassxc", but only after the exact pass fails.
+  {
+    const auto item = makeItem("keepassxc");
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto window = makeWindow("keepassxc-window", 1, handle);
+    const tray::RunningAppIds runningAppIds = [] { return std::vector<std::string>{"org.keepassxc.KeePassXC"}; };
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "org.keepassxc.keepassxc") {
+        return std::vector<ToplevelInfo>{window};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, runningAppIds);
+    TEST_CHECK(result.newest.has_value());
+    TEST_CHECK(result.newest->identifier == window.identifier);
+  }
+
+  // Ambiguity guard: two running apps share the "slack" tail, so the tail pass must never
+  // resolve either one and lookup must never be called with either resolved app id.
+  {
+    const auto item = makeItem("slack");
+    const tray::RunningAppIds runningAppIds = [] { return std::vector<std::string>{"org.a.Slack", "com.b.Slack"}; };
+    std::vector<std::string> lookupCalls;
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      lookupCalls.push_back(candidate);
+      if (candidate != "slack" && candidate.contains("slack")) {
+        return std::vector<ToplevelInfo>{makeWindow("ambiguous-window")};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, runningAppIds);
+    TEST_CHECK(!result.newest.has_value());
+    TEST_CHECK(!std::ranges::contains(lookupCalls, std::string("org.a.slack")));
+    TEST_CHECK(!std::ranges::contains(lookupCalls, std::string("com.b.slack")));
+  }
+
+  // Exact match must always win over a tail match, even when a tail match would also succeed.
+  {
+    const auto item = makeItem("slack");
+    const auto exactWindow =
+        makeWindow("slack-exact-window", 1, reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1));
+    const auto tailWindow = makeWindow("slack-tail-window", 1, reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x2));
+    const tray::RunningAppIds runningAppIds = [] { return std::vector<std::string>{"org.x.Slack"}; };
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "slack") {
+        return std::vector<ToplevelInfo>{exactWindow};
+      }
+      if (candidate == "org.x.slack") {
+        return std::vector<ToplevelInfo>{tailWindow};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, runningAppIds);
+    TEST_CHECK(result.newest.has_value());
+    TEST_CHECK(result.newest->identifier == exactWindow.identifier);
+  }
+
+  // Short-tail guard: "ab" is under the 3-char minimum, so the tail pass must never call
+  // lookup with the running app id sharing that short tail.
+  {
+    const auto item = makeItem("ab");
+    const tray::RunningAppIds runningAppIds = [] { return std::vector<std::string>{"org.x.ab"}; };
+    std::vector<std::string> lookupCalls;
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      lookupCalls.push_back(candidate);
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, runningAppIds);
+    TEST_CHECK(!result.newest.has_value());
+    TEST_CHECK(!std::ranges::contains(lookupCalls, std::string("org.x.ab")));
+  }
+
+  // findNewestWindowForTrayItem: MatchedWindows.windows carries the full candidate vector
+  // returned by the winning lookup call, not just the chosen window.
+  {
+    const auto item = makeItem("multi-window-app");
+    const auto winner = makeWindow("multi-window-app-newest", 2);
+    const auto sibling = makeWindow("multi-window-app-older", 1);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "multi-window-app") {
+        return std::vector<ToplevelInfo>{winner, sibling};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, noRunningApps);
+    TEST_CHECK(result.newest.has_value());
+    TEST_CHECK(result.newest->identifier == winner.identifier);
+    TEST_CHECK(result.windows.size() == 2);
+    TEST_CHECK(result.windows[0].identifier == winner.identifier);
+    TEST_CHECK(result.windows[1].identifier == sibling.identifier);
   }
 
   {
@@ -76,32 +180,47 @@ int main() {
     ActiveToplevel active;
     active.handle = sharedHandle;
     active.identifier = "window-b";
-    TEST_CHECK(tray::trayWindowIsFocused(window, active));
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(tray::trayWindowIsFocused(window, windows, active, ""));
   }
 
   {
     const auto window = makeWindow("shared-identifier");
     ActiveToplevel active;
     active.identifier = "shared-identifier";
-    TEST_CHECK(tray::trayWindowIsFocused(window, active));
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(tray::trayWindowIsFocused(window, windows, active, ""));
   }
 
   {
     const auto window = makeWindow("window-a");
-    TEST_CHECK(!tray::trayWindowIsFocused(window, std::nullopt));
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(!tray::trayWindowIsFocused(window, windows, std::nullopt, ""));
   }
 
   {
     const auto window = makeWindow("");
     ActiveToplevel active;
-    TEST_CHECK(!tray::trayWindowIsFocused(window, active));
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(!tray::trayWindowIsFocused(window, windows, active, ""));
+  }
+
+  // trayWindowIsFocused: false positive guard - two windows sharing the active identifier
+  // must never resolve to focused.
+  {
+    const auto windowOne = makeWindow("shared-identifier");
+    const auto windowTwo = makeWindow("shared-identifier");
+    ActiveToplevel active;
+    active.identifier = "shared-identifier";
+    const std::vector<ToplevelInfo> windows{windowOne, windowTwo};
+    TEST_CHECK(!tray::trayWindowIsFocused(windowOne, windows, active, ""));
   }
 
   // decideTrayClick: no matched window -> ActivateItem, no window.
   {
     const auto item = makeItem("firefox-app");
     const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
-    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
     TEST_CHECK(decision.action == tray::TrayClickAction::ActivateItem);
     TEST_CHECK(!decision.window.has_value());
   }
@@ -117,13 +236,14 @@ int main() {
       }
       return std::vector<ToplevelInfo>{};
     };
-    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
     TEST_CHECK(decision.action == tray::TrayClickAction::FocusWindow);
     TEST_CHECK(decision.window.has_value());
     TEST_CHECK(decision.window->identifier == newer.identifier);
   }
 
-  // decideTrayClick: matched window is the active one by handle -> Ignore, no window.
+  // decideTrayClick: matched window is the active one by handle -> falls through to
+  // ActivateItem (finding 2: preserves each app's Activate-driven hide toggle).
   {
     auto* sharedHandle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x2);
     const auto item = makeItem("someapp");
@@ -136,12 +256,13 @@ int main() {
     };
     ActiveToplevel active;
     active.handle = sharedHandle;
-    const auto decision = tray::decideTrayClick(item, lookup, active, true);
-    TEST_CHECK(decision.action == tray::TrayClickAction::Ignore);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, active, "", true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::ActivateItem);
     TEST_CHECK(!decision.window.has_value());
   }
 
-  // decideTrayClick: matched window is the active one by identifier -> Ignore, no window.
+  // decideTrayClick: matched window is the active one by identifier -> falls through to
+  // ActivateItem (finding 2: preserves each app's Activate-driven hide toggle).
   {
     const auto item = makeItem("otherapp");
     const auto window = makeWindow("shared-id", 1);
@@ -153,40 +274,63 @@ int main() {
     };
     ActiveToplevel active;
     active.identifier = "shared-id";
-    const auto decision = tray::decideTrayClick(item, lookup, active, true);
-    TEST_CHECK(decision.action == tray::TrayClickAction::Ignore);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, active, "", true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::ActivateItem);
     TEST_CHECK(!decision.window.has_value());
   }
 
-  // decideTrayClick: itemIsMenu -> OpenMenu, no window, lookup never called.
+  // decideTrayClick: itemIsMenu with a real DBusMenu -> OpenMenu, no window, lookup never called.
   {
     auto item = makeItem("menu-only-app");
     item.itemIsMenu = true;
+    item.menuObjectPath = "/MenuBar";
     bool lookupCalled = false;
     const tray::WindowLookup lookup = [&](const std::string&) {
       lookupCalled = true;
       return std::vector<ToplevelInfo>{};
     };
-    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
     TEST_CHECK(decision.action == tray::TrayClickAction::OpenMenu);
     TEST_CHECK(!decision.window.has_value());
     TEST_CHECK(!lookupCalled);
   }
 
-  // decideTrayClick: itemIsMenu wins even when a window would otherwise match.
+  // decideTrayClick: itemIsMenu with a real DBusMenu wins even when a window would otherwise match.
   {
     auto item = makeItem("menu-only-with-window");
     item.itemIsMenu = true;
+    item.menuObjectPath = "/MenuBar";
     const auto window = makeWindow("menu-only-window", 1);
     bool lookupCalled = false;
     const tray::WindowLookup lookup = [&](const std::string&) {
       lookupCalled = true;
       return std::vector<ToplevelInfo>{window};
     };
-    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
     TEST_CHECK(decision.action == tray::TrayClickAction::OpenMenu);
     TEST_CHECK(!decision.window.has_value());
     TEST_CHECK(!lookupCalled);
+  }
+
+  // decideTrayClick: itemIsMenu true but menuObjectPath empty -> NOT OpenMenu, falls through
+  // to the window path.
+  {
+    auto item = makeItem("menu-flag-no-menu-path");
+    item.itemIsMenu = true;
+    const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
+    TEST_CHECK(decision.action != tray::TrayClickAction::OpenMenu);
+  }
+
+  // decideTrayClick: itemIsMenu true but menuObjectPath is the sentinel "/NO_DBUSMENU" ->
+  // NOT OpenMenu.
+  {
+    auto item = makeItem("menu-flag-sentinel-menu-path");
+    item.itemIsMenu = true;
+    item.menuObjectPath = "/NO_DBUSMENU";
+    const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
+    TEST_CHECK(decision.action != tray::TrayClickAction::OpenMenu);
   }
 
   // decideTrayClick: itemIsMenu = false, focusExistingWindow = false, matching window present
@@ -195,7 +339,7 @@ int main() {
     const auto item = makeItem("regular-app-no-focus-feature");
     const auto window = makeWindow("regular-app-window", 1);
     const tray::WindowLookup lookup = [&](const std::string&) { return std::vector<ToplevelInfo>{window}; };
-    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, false);
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", false);
     TEST_CHECK(decision.action == tray::TrayClickAction::ActivateItem);
     TEST_CHECK(!decision.window.has_value());
   }
@@ -217,8 +361,132 @@ int main() {
       }
       return std::vector<ToplevelInfo>{};
     };
-    const auto result = tray::findNewestWindowForTrayItem(item, lookup);
-    TEST_CHECK(result.has_value());
-    TEST_CHECK(result->identifier == processWindow.identifier);
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup, noRunningApps);
+    TEST_CHECK(result.newest.has_value());
+    TEST_CHECK(result.newest->identifier == processWindow.identifier);
+  }
+
+  // decideTrayClick end-to-end: no exact match, tail-resolved window present -> FocusWindow
+  // with the tail-matched window.
+  {
+    const auto item = makeItem("keepassxc");
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto window = makeWindow("keepassxc-window", 1, handle);
+    const tray::RunningAppIds runningAppIds = [] { return std::vector<std::string>{"org.keepassxc.KeePassXC"}; };
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "org.keepassxc.keepassxc") {
+        return std::vector<ToplevelInfo>{window};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto decision = tray::decideTrayClick(item, lookup, runningAppIds, std::nullopt, "", true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::FocusWindow);
+    TEST_CHECK(decision.window.has_value());
+    TEST_CHECK(decision.window->identifier == window.identifier);
+  }
+
+  // sniActivateMethodPresent: Activate exported on the SNI interface itself -> true.
+  {
+    const std::string xml = "<node><interface name=\"org.kde.StatusNotifierItem\">"
+                            "<method name=\"Activate\"><arg name=\"x\" type=\"i\"/></method>"
+                            "<method name=\"ContextMenu\"/></interface></node>";
+    TEST_CHECK(sniActivateMethodPresent(xml));
+  }
+
+  // sniActivateMethodPresent: nm-applet-shaped item — SecondaryActivate and the ayatana
+  // variant only, no Activate -> false.
+  {
+    const std::string xml = "<node><interface name=\"org.kde.StatusNotifierItem\">"
+                            "<method name=\"SecondaryActivate\"/>"
+                            "<method name=\"XAyatanaSecondaryActivate\"/>"
+                            "<method name=\"Scroll\"/></interface></node>";
+    TEST_CHECK(!sniActivateMethodPresent(xml));
+  }
+
+  // sniActivateMethodPresent: Activate on a different interface at the same path does not
+  // count for the SNI interface.
+  {
+    const std::string xml = "<node><interface name=\"org.kde.StatusNotifierItem\">"
+                            "<method name=\"ContextMenu\"/></interface>"
+                            "<interface name=\"org.freedesktop.Application\">"
+                            "<method name=\"Activate\"/></interface></node>";
+    TEST_CHECK(!sniActivateMethodPresent(xml));
+  }
+
+  // sniActivateMethodPresent: empty / SNI interface absent -> false.
+  {
+    TEST_CHECK(!sniActivateMethodPresent(""));
+    TEST_CHECK(!sniActivateMethodPresent("<node><interface name=\"org.other\"/></node>"));
+  }
+
+  // sniActivateMethodPresent: single-quoted attributes (GDBus-style XML) -> same results
+  // as double-quoted.
+  {
+    const std::string withActivate = "<node><interface name='org.kde.StatusNotifierItem'>"
+                                     "<method name='Activate'><arg name='x' type='i'/></method>"
+                                     "</interface></node>";
+    TEST_CHECK(sniActivateMethodPresent(withActivate));
+    const std::string withoutActivate = "<node><interface name='org.kde.StatusNotifierItem'>"
+                                        "<method name='SecondaryActivate'/>"
+                                        "</interface></node>";
+    TEST_CHECK(!sniActivateMethodPresent(withoutActivate));
+  }
+
+  // trayItemPrefersMenu: no Activate method + real DBusMenu -> menu, without ItemIsMenu.
+  {
+    auto item = makeItem("no-activate-with-menu");
+    item.hasActivateMethod = false;
+    item.menuObjectPath = "/MenuBar";
+    TEST_CHECK(trayItemPrefersMenu(item));
+  }
+
+  // trayItemPrefersMenu: no Activate method but no menu either -> not menu.
+  {
+    auto item = makeItem("no-activate-no-menu");
+    item.hasActivateMethod = false;
+    TEST_CHECK(!trayItemPrefersMenu(item));
+  }
+
+  // trayItemPrefersMenu: default item (Activate assumed present, not menu-only) -> not menu.
+  {
+    auto item = makeItem("regular");
+    item.menuObjectPath = "/MenuBar";
+    TEST_CHECK(!trayItemPrefersMenu(item));
+  }
+
+  // decideTrayClick: no Activate method + menu -> OpenMenu even when a window would match
+  // and even with the focus feature disabled.
+  {
+    auto item = makeItem("no-activate-menu-app");
+    item.hasActivateMethod = false;
+    item.menuObjectPath = "/MenuBar";
+    const auto window = makeWindow("no-activate-window", 1);
+    bool lookupCalled = false;
+    const tray::WindowLookup lookup = [&](const std::string&) {
+      lookupCalled = true;
+      return std::vector<ToplevelInfo>{window};
+    };
+    const auto onDecision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
+    TEST_CHECK(onDecision.action == tray::TrayClickAction::OpenMenu);
+    const auto offDecision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", false);
+    TEST_CHECK(offDecision.action == tray::TrayClickAction::OpenMenu);
+    TEST_CHECK(!lookupCalled);
+  }
+
+  // decideTrayClick: no Activate method, no menu, matching window, feature on -> FocusWindow.
+  {
+    auto item = makeItem("no-activate-windowed-app");
+    item.hasActivateMethod = false;
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto window = makeWindow("no-activate-windowed", 1, handle);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "no-activate-windowed-app") {
+        return std::vector<ToplevelInfo>{window};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto decision = tray::decideTrayClick(item, lookup, noRunningApps, std::nullopt, "", true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::FocusWindow);
+    TEST_CHECK(decision.window.has_value());
   }
 }

--- a/tests/tray_window_match_test.cpp
+++ b/tests/tray_window_match_test.cpp
@@ -1,0 +1,224 @@
+#include "dbus/tray/tray_service.h"
+#include "shell/tray/tray_window_match.h"
+#include "tests/test_check.h"
+#include "util/string_utils.h"
+#include "wayland/wayland_toplevels.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+  TrayItemInfo makeItem(std::string id) {
+    TrayItemInfo item;
+    item.id = std::move(id);
+    return item;
+  }
+
+  ToplevelInfo
+  makeWindow(std::string identifier, std::uint64_t order = 0, zwlr_foreign_toplevel_handle_v1* handle = nullptr) {
+    ToplevelInfo window;
+    window.identifier = std::move(identifier);
+    window.order = order;
+    window.handle = handle;
+    return window;
+  }
+
+} // namespace
+
+int main() {
+  {
+    const auto item = makeItem("firefox-app");
+    const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
+    TEST_CHECK(!tray::findNewestWindowForTrayItem(item, lookup).has_value());
+  }
+
+  {
+    const auto item = makeItem("Slack_status_icon_1");
+    const auto older = makeWindow("slack-window-a", 1);
+    const auto newer = makeWindow("slack-window-b", 2);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (StringUtils::toLower(candidate).contains("slack")) {
+        return std::vector<ToplevelInfo>{newer, older};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup);
+    TEST_CHECK(result.has_value());
+    TEST_CHECK(result->identifier == newer.identifier);
+  }
+
+  {
+    const auto item = makeItem("RegularApp");
+    const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{ToplevelInfo{}}; };
+    TEST_CHECK(!tray::findNewestWindowForTrayItem(item, lookup).has_value());
+  }
+
+  {
+    const auto item = makeItem(":1.234/org/status/electron");
+    TEST_CHECK(tray::isTransientUniqueIdentifier(item.id));
+    TEST_CHECK(tray::pinMatchCandidates(item).empty());
+    bool lookupCalled = false;
+    const tray::WindowLookup lookup = [&](const std::string&) {
+      lookupCalled = true;
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup);
+    TEST_CHECK(!lookupCalled);
+    TEST_CHECK(!result.has_value());
+  }
+
+  {
+    auto* sharedHandle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto window = makeWindow("window-a", 0, sharedHandle);
+    ActiveToplevel active;
+    active.handle = sharedHandle;
+    active.identifier = "window-b";
+    TEST_CHECK(tray::trayWindowIsFocused(window, active));
+  }
+
+  {
+    const auto window = makeWindow("shared-identifier");
+    ActiveToplevel active;
+    active.identifier = "shared-identifier";
+    TEST_CHECK(tray::trayWindowIsFocused(window, active));
+  }
+
+  {
+    const auto window = makeWindow("window-a");
+    TEST_CHECK(!tray::trayWindowIsFocused(window, std::nullopt));
+  }
+
+  {
+    const auto window = makeWindow("");
+    ActiveToplevel active;
+    TEST_CHECK(!tray::trayWindowIsFocused(window, active));
+  }
+
+  // decideTrayClick: no matched window -> ActivateItem, no window.
+  {
+    const auto item = makeItem("firefox-app");
+    const tray::WindowLookup lookup = [](const std::string&) { return std::vector<ToplevelInfo>{}; };
+    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::ActivateItem);
+    TEST_CHECK(!decision.window.has_value());
+  }
+
+  // decideTrayClick: matched window, no active window -> FocusWindow with the newest match.
+  {
+    const auto item = makeItem("Slack_status_icon_1");
+    const auto older = makeWindow("slack-window-a", 1);
+    const auto newer = makeWindow("slack-window-b", 2);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (StringUtils::toLower(candidate).contains("slack")) {
+        return std::vector<ToplevelInfo>{newer, older};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::FocusWindow);
+    TEST_CHECK(decision.window.has_value());
+    TEST_CHECK(decision.window->identifier == newer.identifier);
+  }
+
+  // decideTrayClick: matched window is the active one by handle -> Ignore, no window.
+  {
+    auto* sharedHandle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x2);
+    const auto item = makeItem("someapp");
+    const auto window = makeWindow("window-x", 1, sharedHandle);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "someapp") {
+        return std::vector<ToplevelInfo>{window};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    ActiveToplevel active;
+    active.handle = sharedHandle;
+    const auto decision = tray::decideTrayClick(item, lookup, active, true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::Ignore);
+    TEST_CHECK(!decision.window.has_value());
+  }
+
+  // decideTrayClick: matched window is the active one by identifier -> Ignore, no window.
+  {
+    const auto item = makeItem("otherapp");
+    const auto window = makeWindow("shared-id", 1);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "otherapp") {
+        return std::vector<ToplevelInfo>{window};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    ActiveToplevel active;
+    active.identifier = "shared-id";
+    const auto decision = tray::decideTrayClick(item, lookup, active, true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::Ignore);
+    TEST_CHECK(!decision.window.has_value());
+  }
+
+  // decideTrayClick: itemIsMenu -> OpenMenu, no window, lookup never called.
+  {
+    auto item = makeItem("menu-only-app");
+    item.itemIsMenu = true;
+    bool lookupCalled = false;
+    const tray::WindowLookup lookup = [&](const std::string&) {
+      lookupCalled = true;
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::OpenMenu);
+    TEST_CHECK(!decision.window.has_value());
+    TEST_CHECK(!lookupCalled);
+  }
+
+  // decideTrayClick: itemIsMenu wins even when a window would otherwise match.
+  {
+    auto item = makeItem("menu-only-with-window");
+    item.itemIsMenu = true;
+    const auto window = makeWindow("menu-only-window", 1);
+    bool lookupCalled = false;
+    const tray::WindowLookup lookup = [&](const std::string&) {
+      lookupCalled = true;
+      return std::vector<ToplevelInfo>{window};
+    };
+    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, true);
+    TEST_CHECK(decision.action == tray::TrayClickAction::OpenMenu);
+    TEST_CHECK(!decision.window.has_value());
+    TEST_CHECK(!lookupCalled);
+  }
+
+  // decideTrayClick: itemIsMenu = false, focusExistingWindow = false, matching window present
+  // -> ActivateItem (focus feature disabled short-circuits before any window lookup outcome).
+  {
+    const auto item = makeItem("regular-app-no-focus-feature");
+    const auto window = makeWindow("regular-app-window", 1);
+    const tray::WindowLookup lookup = [&](const std::string&) { return std::vector<ToplevelInfo>{window}; };
+    const auto decision = tray::decideTrayClick(item, lookup, std::nullopt, false);
+    TEST_CHECK(decision.action == tray::TrayClickAction::ActivateItem);
+    TEST_CHECK(!decision.window.has_value());
+  }
+
+  // windowMatchCandidates ordering: processName is tried before title, so a processName match
+  // wins even when a different window would match on title.
+  {
+    TrayItemInfo item;
+    item.processName = "myproc";
+    item.title = "mytitle";
+    const auto processWindow = makeWindow("process-window", 1);
+    const auto titleWindow = makeWindow("title-window", 2);
+    const tray::WindowLookup lookup = [&](const std::string& candidate) {
+      if (candidate == "myproc") {
+        return std::vector<ToplevelInfo>{processWindow};
+      }
+      if (candidate == "mytitle") {
+        return std::vector<ToplevelInfo>{titleWindow};
+      }
+      return std::vector<ToplevelInfo>{};
+    };
+    const auto result = tray::findNewestWindowForTrayItem(item, lookup);
+    TEST_CHECK(result.has_value());
+    TEST_CHECK(result->identifier == processWindow.identifier);
+  }
+}

--- a/tests/window_activation_test.cpp
+++ b/tests/window_activation_test.cpp
@@ -85,4 +85,77 @@ int main() {
     TEST_CHECK(result != nullptr);
     TEST_CHECK(result->identifier == second.identifier);
   }
+
+  // lastActivatableWindow picks the last vector element even when an earlier one has a
+  // higher `order`, which is exactly what distinguishes it from newestActivatableWindow.
+  {
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto highOrderFirst = makeWindow("high-order-first", 9, handle);
+    const auto lowOrderLast = makeWindow("low-order-last", 1, handle);
+    const std::vector<ToplevelInfo> windows{highOrderFirst, lowOrderLast};
+    const auto* last = shell::lastActivatableWindow(windows);
+    const auto* newest = shell::newestActivatableWindow(windows);
+    TEST_CHECK(last != nullptr);
+    TEST_CHECK(last->identifier == lowOrderLast.identifier);
+    TEST_CHECK(newest != nullptr);
+    TEST_CHECK(newest->identifier == highOrderFirst.identifier);
+    TEST_CHECK(last != newest);
+  }
+
+  {
+    const std::vector<ToplevelInfo> windows;
+    TEST_CHECK(shell::lastActivatableWindow(windows) == nullptr);
+  }
+
+  {
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    auto notActivatable = ToplevelInfo{};
+    notActivatable.order = 5;
+    const auto activatable = makeWindow("activatable", 1, handle);
+    const std::vector<ToplevelInfo> windows{activatable, notActivatable};
+    const auto* result = shell::lastActivatableWindow(windows);
+    TEST_CHECK(result != nullptr);
+    TEST_CHECK(result->identifier == activatable.identifier);
+  }
+
+  // matchesActiveWindow: handle equality wins regardless of identifier.
+  {
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto window = makeWindow("window-a", 0, handle);
+    ActiveToplevel active;
+    active.handle = handle;
+    active.identifier = "window-b";
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(shell::matchesActiveWindow(window, active, "", windows));
+  }
+
+  // matchesActiveWindow: exactIdentity window matches by focusedCompositorWindowId.
+  {
+    ToplevelInfo window;
+    window.identifier = "compositor-window-id";
+    window.exactIdentity = true;
+    ActiveToplevel active;
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(shell::matchesActiveWindow(window, active, "compositor-window-id", windows));
+  }
+
+  // matchesActiveWindow: ambiguity guard returns false when two windows share the
+  // active identifier, even though the identifiers themselves match.
+  {
+    const auto windowOne = makeWindow("shared-identifier", 0);
+    const auto windowTwo = makeWindow("shared-identifier", 0);
+    ActiveToplevel active;
+    active.identifier = "shared-identifier";
+    const std::vector<ToplevelInfo> windows{windowOne, windowTwo};
+    TEST_CHECK(!shell::matchesActiveWindow(windowOne, active, "", windows));
+  }
+
+  // matchesActiveWindow: identifier match is accepted when it is unique in the vector.
+  {
+    const auto window = makeWindow("unique-identifier", 0);
+    ActiveToplevel active;
+    active.identifier = "unique-identifier";
+    const std::vector<ToplevelInfo> windows{window};
+    TEST_CHECK(shell::matchesActiveWindow(window, active, "", windows));
+  }
 }

--- a/tests/window_activation_test.cpp
+++ b/tests/window_activation_test.cpp
@@ -1,0 +1,88 @@
+#include "shell/common/window_activation.h"
+#include "tests/test_check.h"
+#include "wayland/wayland_toplevels.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+  ToplevelInfo makeWindow(
+      std::string identifier, std::uint64_t order, zwlr_foreign_toplevel_handle_v1* handle = nullptr,
+      ext_foreign_toplevel_handle_v1* extHandle = nullptr
+  ) {
+    ToplevelInfo window;
+    window.identifier = std::move(identifier);
+    window.order = order;
+    window.handle = handle;
+    window.extHandle = extHandle;
+    return window;
+  }
+
+} // namespace
+
+int main() {
+  {
+    const std::vector<ToplevelInfo> windows;
+    TEST_CHECK(shell::newestActivatableWindow(windows) == nullptr);
+  }
+
+  {
+    const std::vector<ToplevelInfo> windows{ToplevelInfo{}};
+    TEST_CHECK(shell::newestActivatableWindow(windows) == nullptr);
+  }
+
+  {
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto three = makeWindow("window-three", 3, handle);
+    const auto one = makeWindow("window-one", 1, handle);
+    const auto two = makeWindow("window-two", 2, handle);
+    const std::vector<ToplevelInfo> windows{three, one, two};
+    const auto* result = shell::newestActivatableWindow(windows);
+    TEST_CHECK(result != nullptr);
+    TEST_CHECK(result->identifier == three.identifier);
+  }
+
+  {
+    auto notActivatable = ToplevelInfo{};
+    notActivatable.order = 5;
+    const auto activatable = makeWindow("activatable", 2, reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1));
+    const std::vector<ToplevelInfo> windows{notActivatable, activatable};
+    const auto* result = shell::newestActivatableWindow(windows);
+    TEST_CHECK(result != nullptr);
+    TEST_CHECK(result->identifier == activatable.identifier);
+  }
+
+  {
+    auto* wlrHandle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    auto* extHandle = reinterpret_cast<ext_foreign_toplevel_handle_v1*>(0x10);
+    const auto wlrOne = makeWindow("wlr-one", 1, wlrHandle);
+    const auto wlrTwo = makeWindow("wlr-two", 2, wlrHandle);
+    const auto extOnly = makeWindow("ext-only", 9, nullptr, extHandle);
+    const std::vector<ToplevelInfo> windows{wlrOne, wlrTwo, extOnly};
+    const auto* result = shell::newestActivatableWindow(windows);
+    TEST_CHECK(result != nullptr);
+    TEST_CHECK(result->identifier == wlrTwo.identifier);
+  }
+
+  {
+    auto* extHandle = reinterpret_cast<ext_foreign_toplevel_handle_v1*>(0x10);
+    const auto extSeven = makeWindow("ext-seven", 7, nullptr, extHandle);
+    const auto extFour = makeWindow("ext-four", 4, nullptr, extHandle);
+    const std::vector<ToplevelInfo> windows{extSeven, extFour};
+    const auto* result = shell::newestActivatableWindow(windows);
+    TEST_CHECK(result != nullptr);
+    TEST_CHECK(result->identifier == extSeven.identifier);
+  }
+
+  {
+    auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
+    const auto first = makeWindow("first", 0, handle);
+    const auto second = makeWindow("second", 0, handle);
+    const std::vector<ToplevelInfo> windows{first, second};
+    const auto* result = shell::newestActivatableWindow(windows);
+    TEST_CHECK(result != nullptr);
+    TEST_CHECK(result->identifier == second.identifier);
+  }
+}


### PR DESCRIPTION
## Summary

Left-clicking a tray icon now raises the application's already-open window instead of relying solely on the StatusNotifierItem `Activate()` call.

- New tray widget option `focus_existing_window` (default `true`, label "Focus Existing Window").
- On left click the widget resolves the item to a toplevel, and:
  - a matching window that is not focused is activated through `CompositorPlatform::activateToplevelInfo()`, and `Activate()` is not sent;
  - a matching window that is already focused is a deliberate no-op (no `Activate()` fallthrough, so apps that toggle visibility on `Activate` do not hide the window the user just clicked towards);
  - no matching window means the previous behavior, `TrayService::activateItem()`.
- The SNI `ItemIsMenu` property is now read into `TrayItemInfo`. Items that declare themselves menu-only never receive `Activate()`; a left click opens their menu through the same path right click already uses. This rule applies regardless of the new option's value.
- Item-to-window matching lives in a new header `src/shell/tray/tray_window_match.h` behind a `WindowLookup` seam so the decision logic is unit-testable without a live compositor. The click decision is a pure function, `tray::decideTrayClick()`.
- `tray::windowMatchCandidates()` is added next to the existing `pinMatchCandidates()` in `src/shell/tray/tray_identifier.h`. It reuses the same variant expansion but orders identity-strong fields first (`Id`, bus name, process name, item name, object path, icon names) and descriptive fields last (`Title`, tooltip title/description), then lowercases and deduplicates. Descriptive fields collide with unrelated applications' windows far more easily, and compositor lookups compare against a lowercased app id verbatim. `pinMatchCandidates()` is untouched, so pinning behavior is unchanged.
- `canActivateWindow()` and `newestActivatableWindow()` moved from the anonymous namespace in `src/shell/dock/dock.cpp` to a shared `src/shell/common/window_activation.h` (namespace `shell`) so the tray and the dock apply the same activatability rule. `matchesActiveWindow()` and `nextActivatableWindow()` stay in `dock.cpp` — they encode dock-specific cycling that the tray does not need.

## Motivation

On Wayland an application usually cannot raise itself. When a tray icon is clicked, the SNI `Activate()` call reaches the app, but the app's own attempt to focus its window has no activation token behind it, so nothing visible happens. The common expectation — click the tray icon, get the window — silently fails for a large set of applications.

Doing the activation shell-side fixes this: the shell holds the compositor connection and can activate the toplevel directly. `Activate()` remains the fallback for the case where no window exists yet (the icon is the app's only entry point and the app must create the window itself).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

Refactoring covers the `window_activation.h` extraction out of `dock.cpp`; the dock's behavior is unchanged.

## Related Issue

Closes #3859

## Testing

Commands run from the repository root:

- `just format` (clang-format v22)
- `meson setup --reconfigure build-debug`
- `ninja -C build-debug noctalia` — links clean, no new warnings
- `meson test -C build-debug` — 81 passed, 0 failed
- `just lint` — clang-tidy with `-warnings-as-errors=*` over 561 files, clean

New unit test `tests/tray_window_match_test.cpp` (registered in `meson.build`) covers:

- no candidate matches any window;
- newest window wins, asserted through explicit `ToplevelInfo::order` values rather than list position;
- windows that cannot be activated are rejected;
- transient unique bus names produce no candidates and trigger no compositor lookup;
- focus detection by handle and by identifier, plus the "no active toplevel" case;
- candidate ordering: an item whose process name matches one window and whose title matches a different window resolves to the process-name window;
- the click decision for every action — activate, focus, already-focused no-op, and menu-only.

## Manual Coverage

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

Manual verification on a live session is still outstanding; see Additional Notes.

## Screenshots / Videos

No visual change. The only UI addition is a toggle in the tray widget settings, rendered by the existing widget settings generator.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Default value: `focus_existing_window` defaults to `true`, which changes left-click behavior for existing users on upgrade. The reasoning is that the broken case is the common one — an `Activate()` that the compositor renders inert — and users hitting it would have to discover a setting to get working behavior. Happy to flip the default to opt-in if maintainers prefer no behavior change on upgrade; it is a one-line change.
- Menu-only items: honoring `ItemIsMenu` on left click also corrects a pre-existing deviation from the SNI specification, where `Activate()` was sent to items that declare they only support their menu.
- Matching limits: an application whose tray item advertises neither its app id nor a process name matching its toplevel `app_id` will not resolve to a window and falls back to `Activate()`, exactly as before. Matching is exact on normalized identity keys, not substring based, to avoid focusing the wrong application.
- Window selection: the newest activatable window is used. There is no cycling between multiple windows of the same application, unlike the dock — the tray icon is a single-target affordance and cycling would need its own UX decision.
- Manual matrix: still to be run on a live session; I will fill in the Manual Coverage boxes before marking this ready for review.
