### PR TITLE
feat(settings): add configurable scrollbar width

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1594,6 +1594,10 @@
           "description": "Scale corner radius across shell UI containers and controls",
           "label": "Corner Roundness"
         },
+        "scrollbar-width": {
+          "description": "Scrollbar thickness in pixels, before UI scale",
+          "label": "Scrollbar Width"
+        },
         "custom-palette": {
           "description": "Choose a palette from ~/.config/noctalia/palettes/",
           "label": "Custom Palette",

--- a/example.toml
+++ b/example.toml
@@ -10,6 +10,7 @@ high_contrast         = false
 
 [shell]
 corner_radius_scale   = 1.0          # 0 = square, 1 = default, 2 = extra rounded
+scrollbar_width       = 6            # scrollbar thickness in pixels (before accessibility.ui_scale)
 font_family           = "sans-serif"
 time_format           = "{:%H:%M}"  # default shell UI time format
 date_format           = "%A, %x"    # default shell UI date format

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -477,20 +477,32 @@ void Application::initStyleThemeAndWayland() {
     motion.setSpeed(m_configService.config().shell.animation.speed);
     motion.setEnabled(m_configService.config().shell.animation.enabled);
   };
-  auto applyStyleConfig = [this, lastCornerRadiusScale = std::numeric_limits<float>::quiet_NaN()]() mutable {
+  auto applyStyleConfig = [this, lastCornerRadiusScale = std::numeric_limits<float>::quiet_NaN(),
+                           lastScrollbarWidth = std::numeric_limits<float>::quiet_NaN()]() mutable {
     const float corner = m_configService.config().shell.cornerRadiusScale;
     const bool cornerChanged =
         std::isfinite(lastCornerRadiusScale) && std::abs(corner - lastCornerRadiusScale) > 1.0e-4F;
+    const float scrollbarWidth = static_cast<float>(m_configService.config().shell.scrollbarWidth)
+        * m_configService.config().accessibility.uiScale;
+    const bool scrollbarWidthChanged =
+        std::isfinite(lastScrollbarWidth) && std::abs(scrollbarWidth - lastScrollbarWidth) > 1.0e-4F;
     Style::setCornerRadiusScale(corner);
+    Style::setScrollbarWidth(scrollbarWidth);
     Style::setButtonBordersEnabled(m_configService.config().shell.buttonBorders);
     Style::setInputBordersEnabled(m_configService.config().shell.inputBorders);
     Style::setPopupBordersEnabled(m_configService.config().shell.popupBorders);
     Style::setPopupShadowsEnabled(m_configService.config().shell.popupShadows);
     Style::setCardBordersEnabled(m_configService.config().shell.cardBorders);
     lastCornerRadiusScale = corner;
+    lastScrollbarWidth = scrollbarWidth;
     if (cornerChanged) {
       m_notificationToast.requestLayout();
       m_panelManager.requestLayout();
+    }
+    if (scrollbarWidthChanged) {
+      m_notificationToast.requestLayout();
+      m_panelManager.requestLayout();
+      m_settingsWindow.onExternalOptionsChanged();
     }
   };
   auto applyPasswordMaskStyle = [this]() {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1057,6 +1057,7 @@ struct ShellConfig {
   };
 
   float cornerRadiusScale = 1.0F;
+  std::int32_t scrollbarWidth = 6;
   bool buttonBorders = true;
   bool inputBorders = true;
   bool popupBorders = true;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1487,6 +1487,7 @@ namespace noctalia::config::schema {
   const Schema<ShellConfig>& shellSchema() {
     static const Schema<ShellConfig> s = {
         field(&ShellConfig::cornerRadiusScale, "corner_radius_scale", kCornerRadiusScaleRange),
+        field(&ShellConfig::scrollbarWidth, "scrollbar_width", kScrollbarWidthRange),
         field(&ShellConfig::buttonBorders, "button_borders"),
         field(&ShellConfig::inputBorders, "input_borders"),
         field(&ShellConfig::popupBorders, "popup_borders"),

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -17,6 +17,7 @@ namespace noctalia::config::schema {
   // Shell.
   inline constexpr Range<float> kAnimationSpeedRange{0.1F, 4.0F, 0.05F};
   inline constexpr Range<float> kCornerRadiusScaleRange{0.0F, 2.0F, 0.05F};
+  inline constexpr Range<std::int64_t> kScrollbarWidthRange{2, 32, 1};
   inline constexpr Range<std::int64_t> kControlCenterWidthRange{600, 1200, 10};
   inline constexpr Range<std::int64_t> kScreenCornersSizeRange{1, 100, 1};
   inline constexpr Range<std::int64_t> kHotCornersDelayMsRange{0, 2000, 50};

--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -884,7 +884,7 @@ void ControlCenterPanel::layoutFullSidebarWidth(Renderer& renderer) {
     navConstraints.setExactWidth(contentWidth);
     const float navHeight = m_sidebarNav->measure(renderer, navConstraints).height;
     if (navHeight > scrollHeight + 0.5F) {
-      targetWidth = contentWidth + Style::scrollbarWidth + Style::scrollbarGap;
+      targetWidth = contentWidth + Style::scrollbarWidth() + Style::scrollbarGap;
     }
   }
 

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -534,6 +534,11 @@ namespace settings {
         "rounded corners radius"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.scrollbar-width.label"),
+        tr("settings.schema.appearance.scrollbar-width.description"), {"shell", "scrollbar_width"},
+        sliderFor(cfg.shell.scrollbarWidth, noctalia::config::schema::kScrollbarWidthRange, true), "scrollbar width"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-colorize.label"),
         tr("settings.schema.appearance.app-icon-colorize.description"), {"shell", "app_icon_colorize"},
         ToggleSetting{cfg.shell.appIconColorize}, "tint all application icons"

--- a/src/ui/controls/scroll_view.cpp
+++ b/src/ui/controls/scroll_view.cpp
@@ -315,14 +315,14 @@ void ScrollView::setViewportPaddingV(float padding) {
 
 float ScrollView::contentViewportWidth(bool reserveScrollbarGutter) const noexcept {
   const float gutter = m_orientation == ScrollOrientation::Vertical && (m_scrollbarShown || reserveScrollbarGutter)
-      ? (Style::scrollbarWidth + Style::scrollbarGap)
+      ? (Style::scrollbarWidth() + Style::scrollbarGap)
       : 0.0F;
   return std::max(0.0F, width() - m_viewportPaddingH * 2.0F - gutter);
 }
 
 float ScrollView::contentViewportHeight() const noexcept {
   const float gutter = m_orientation == ScrollOrientation::Horizontal && m_scrollbarShown
-      ? (Style::scrollbarWidth + Style::scrollbarGap)
+      ? (Style::scrollbarWidth() + Style::scrollbarGap)
       : 0.0F;
   return std::max(0.0F, height() - m_viewportPaddingV * 2.0F - gutter);
 }
@@ -361,7 +361,7 @@ void ScrollView::doLayout(Renderer& renderer) {
   if (m_orientation == ScrollOrientation::Horizontal) {
     LayoutSize contentSize = m_content->measure(renderer, {});
     m_scrollbarShown = m_showScrollbar && contentSize.width > availableW + 0.5F;
-    const float gutter = m_scrollbarShown ? (Style::scrollbarWidth + Style::scrollbarGap) : 0.0F;
+    const float gutter = m_scrollbarShown ? (Style::scrollbarWidth() + Style::scrollbarGap) : 0.0F;
     const float contentWidth = std::max(availableW, contentSize.width);
 
     LayoutConstraints contentConstraints;
@@ -404,7 +404,7 @@ void ScrollView::doLayout(Renderer& renderer) {
     m_viewportArea->setFrameSize(availableW, viewportH);
 
     m_scrollbarShown = m_showScrollbar && m_content->height() > viewportH + 0.5F;
-    const float gutter = m_scrollbarShown ? (Style::scrollbarWidth + Style::scrollbarGap) : 0.0F;
+    const float gutter = m_scrollbarShown ? (Style::scrollbarWidth() + Style::scrollbarGap) : 0.0F;
     const float contentWidth = std::max(0.0F, availableW - gutter);
     if (std::abs(m_content->width() - contentWidth) >= 0.5F) {
       contentConstraints = {};
@@ -418,7 +418,7 @@ void ScrollView::doLayout(Renderer& renderer) {
     const float contentHeight = m_content->height();
     m_maxScrollOffset = std::max(0.0F, contentHeight - viewportH);
     const float scrollbarX =
-        Style::rtl() ? m_viewportPaddingH : m_viewportPaddingH + m_viewportWidth - Style::scrollbarWidth;
+        Style::rtl() ? m_viewportPaddingH : m_viewportPaddingH + m_viewportWidth - Style::scrollbarWidth();
     m_scrollbar->setPosition(scrollbarX, m_viewportPaddingV);
     m_scrollbar->setVisible(m_showScrollbar);
     m_scrollbar->update(viewportH, contentHeight, m_scrollOffset);
@@ -464,7 +464,7 @@ void ScrollView::applyScrollOffset() {
     if (m_orientation == ScrollOrientation::Horizontal) {
       m_content->setPosition(-m_scrollOffset, 0.0F);
     } else {
-      const float gutter = Style::rtl() && m_scrollbarShown ? Style::scrollbarWidth + Style::scrollbarGap : 0.0F;
+      const float gutter = Style::rtl() && m_scrollbarShown ? Style::scrollbarWidth() + Style::scrollbarGap : 0.0F;
       m_content->setPosition(gutter, -m_scrollOffset);
     }
   }

--- a/src/ui/controls/scrollbar.cpp
+++ b/src/ui/controls/scrollbar.cpp
@@ -19,7 +19,7 @@ namespace {
         .fill = fill,
         .border = fill,
         .fillMode = FillMode::Solid,
-        .radius = Style::scrollbarWidth * 0.5F,
+        .radius = Style::scrollbarWidth() * 0.5F,
         .softness = 1.0F,
         .borderWidth = 0.0F,
     };
@@ -125,7 +125,7 @@ void Scrollbar::update(float viewportExtent, float contentExtent, float scrollOf
   }
 
   const float trackExtent = std::max(0.0F, viewportExtent - m_trackInset * 2.0F);
-  const float thickness = Style::scrollbarWidth;
+  const float thickness = Style::scrollbarWidth();
   if (m_orientation == ScrollOrientation::Horizontal) {
     m_track->setPosition(m_trackInset, 0.0F);
     m_track->setFrameSize(trackExtent, thickness);

--- a/src/ui/controls/virtual_grid_view.cpp
+++ b/src/ui/controls/virtual_grid_view.cpp
@@ -233,7 +233,7 @@ void VirtualGridView::doLayout(Renderer& renderer) {
   const float padV = m_scroll->viewportPaddingV();
   const float innerW = std::max(0.0F, ourW - 2.0F * padH);
   const float viewportH = std::max(0.0F, ourH - 2.0F * padV);
-  const float scrollbarGutter = Style::scrollbarWidth + Style::scrollbarGap;
+  const float scrollbarGutter = Style::scrollbarWidth() + Style::scrollbarGap;
 
   m_itemCount = m_adapter->itemCount();
 

--- a/src/ui/controls/virtual_list_view.cpp
+++ b/src/ui/controls/virtual_list_view.cpp
@@ -172,7 +172,7 @@ void VirtualListView::doLayout(Renderer& renderer) {
   const float padV = m_scroll->viewportPaddingV();
   const float innerW = std::max(0.0F, ourW - 2.0F * padH);
   const float viewportH = std::max(0.0F, ourH - 2.0F * padV);
-  const float scrollbarGutter = Style::scrollbarWidth + Style::scrollbarGap;
+  const float scrollbarGutter = Style::scrollbarWidth() + Style::scrollbarGap;
 
   // Match ScrollView: only reserve the scrollbar gutter when content overflows vertically.
   recomputeMetrics(renderer, innerW);

--- a/src/ui/style.cpp
+++ b/src/ui/style.cpp
@@ -5,6 +5,7 @@
 namespace {
 
   float g_cornerRadiusScale = 1.0F;
+  float g_scrollbarWidth = 6.0F;
   bool g_buttonBordersEnabled = true;
   bool g_inputBordersEnabled = true;
   bool g_popupBordersEnabled = true;
@@ -19,6 +20,10 @@ namespace Style {
   float cornerRadiusScale() noexcept { return g_cornerRadiusScale; }
 
   void setCornerRadiusScale(float scale) noexcept { g_cornerRadiusScale = std::clamp(scale, 0.0F, 2.0F); }
+
+  float scrollbarWidth() noexcept { return g_scrollbarWidth; }
+
+  void setScrollbarWidth(float width) noexcept { g_scrollbarWidth = std::clamp(width, 1.0F, 128.0F); }
 
   bool buttonBordersEnabled() noexcept { return g_buttonBordersEnabled; }
 

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -45,7 +45,6 @@ namespace Style {
   // Pointer distance in logical px before an armed drag becomes active.
   inline constexpr float dragStartThreshold = 6.0F;
 
-  inline constexpr float scrollbarWidth = 6.0F;
   inline constexpr float scrollbarGap = spaceSm;
   inline constexpr float scrollbarMinThumbHeight = 24.0F;
 
@@ -71,6 +70,9 @@ namespace Style {
 
   [[nodiscard]] float cornerRadiusScale() noexcept;
   void setCornerRadiusScale(float scale) noexcept;
+
+  [[nodiscard]] float scrollbarWidth() noexcept;
+  void setScrollbarWidth(float width) noexcept;
 
   [[nodiscard]] bool buttonBordersEnabled() noexcept;
   void setButtonBordersEnabled(bool enabled);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added a configurable scrollbar width setting `shell.scrollbar_width`, ranging from 2 to 32, defaulting to 6 to match the original width, and respecting `accessibility.ui_scale` scaling.
<!-- What changed and why? -->

## Motivation

As mentioned in #3963, the thin scrollbar makes it difficult to grab with the mouse in some cases, and the hardcoded width does not respect `accessibility.ui_scale` scaling, making the scrollbar even harder to grab at higher scaling values.
<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3963
<!-- Example: Closes #123 -->

## Testing

`just test` and manual visual inspection of the displayed result

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
<img width="2116" height="1414" alt="screenshot" src="https://github.com/user-attachments/assets/6d1ab2c4-e0eb-4a63-a086-88f3a2a5ef49" />

<img width="2116" height="1414" alt="screenshot" src="https://github.com/user-attachments/assets/d82ac006-a4dd-44ad-827a-10a8e237af4b" />

<img width="2116" height="1414" alt="screenshot" src="https://github.com/user-attachments/assets/c09e2357-3c20-4689-8fea-daa7fb2207ce" />

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->