### PR TITLE
fix(brightness): disambiguate ddcutil buses for identical monitors

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -277,6 +277,8 @@ enable_ddcutil = false
 # backlight_device = "intel_backlight"  # explicit sysfs device name or path; run: noctalia msg brightness-list-backlight-devices
 # [brightness.monitor.DP-1]
 # backend = "ddcutil"
+# [brightness.monitor.DP-2]
+# ddc_bus = "i2c-6"                 # pin the I2C bus when monitors share an EDID
 
 # ── Night Light ───────────────────────────────────────────────────────────────
 

--- a/example.toml
+++ b/example.toml
@@ -278,7 +278,7 @@ enable_ddcutil = false
 # [brightness.monitor.DP-1]
 # backend = "ddcutil"
 # [brightness.monitor.DP-2]
-# ddc_bus = "i2c-6"                 # pin the I2C bus when monitors share an EDID
+# ddc_bus = 6                       # pin the I2C bus when monitors share an EDID
 
 # ── Night Light ───────────────────────────────────────────────────────────────
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1269,6 +1269,7 @@ struct BrightnessMonitorOverride {
   std::string match;
   std::optional<BrightnessBackendPreference> backend;
   std::optional<std::string> backlightDevice; // sysfs device name or path, e.g. "intel_backlight"
+  std::optional<std::string> ddcBus;          // DDC bus name, e.g. "i2c-0"
 
   bool operator==(const BrightnessMonitorOverride&) const = default;
 };

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1269,7 +1269,7 @@ struct BrightnessMonitorOverride {
   std::string match;
   std::optional<BrightnessBackendPreference> backend;
   std::optional<std::string> backlightDevice; // sysfs device name or path, e.g. "intel_backlight"
-  std::optional<std::string> ddcBus;          // DDC bus name, e.g. "i2c-0"
+  std::optional<std::int32_t> ddcBus;         // DDC bus number, e.g. 6 for i2c-6
 
   bool operator==(const BrightnessMonitorOverride&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -422,6 +422,7 @@ namespace noctalia::config::schema {
           field(&BrightnessMonitorOverride::match, "match"),
           optionalEnumField(&BrightnessMonitorOverride::backend, "backend", kBrightnessBackendPreferences),
           field(&BrightnessMonitorOverride::backlightDevice, "backlight_device"),
+          field(&BrightnessMonitorOverride::ddcBus, "ddc_bus"),
       };
       return s;
     }

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -421,19 +421,7 @@ namespace noctalia::config::schema {
       static const Schema<BrightnessMonitorOverride> s = {
           field(&BrightnessMonitorOverride::match, "match"),
           optionalEnumField(&BrightnessMonitorOverride::backend, "backend", kBrightnessBackendPreferences),
-          custom<BrightnessMonitorOverride>(
-              "backlight_device",
-              [](const toml::table& tbl, BrightnessMonitorOverride& out, std::string_view, Diagnostics&) {
-                if (auto v = tbl["backlight_device"].value<std::string>()) {
-                  out.backlightDevice = *v;
-                }
-              },
-              [](toml::table& tbl, const BrightnessMonitorOverride& in) {
-                if (in.backlightDevice.has_value()) {
-                  tbl.insert_or_assign("backlight_device", *in.backlightDevice);
-                }
-              }
-          ),
+          field(&BrightnessMonitorOverride::backlightDevice, "backlight_device"),
       };
       return s;
     }
@@ -1949,24 +1937,8 @@ namespace noctalia::config::schema {
       );
     }
 
-    template <typename Struct>
-    Field<Struct> optionalStringField(std::optional<std::string> Struct::* member, std::string_view key) {
-      return custom<Struct>(
-          key,
-          [member, key](const toml::table& tbl, Struct& out, std::string_view, Diagnostics&) {
-            if (auto v = tbl[key].value<std::string>()) {
-              out.*member = *v;
-            }
-          },
-          [member, key](toml::table& tbl, const Struct& in) {
-            if ((in.*member).has_value()) {
-              tbl.insert_or_assign(key, *(in.*member));
-            }
-          }
-      );
-    }
-
-    // Like optionalStringField but trims; a present-but-empty value stays unset so it inherits the parent.
+    // Like field(std::optional<std::string>…) but trims; a present-but-empty value stays unset so it inherits the
+    // parent.
     template <typename Struct>
     Field<Struct> optionalTrimmedStringField(std::optional<std::string> Struct::* member, std::string_view key) {
       return custom<Struct>(
@@ -2223,7 +2195,7 @@ namespace noctalia::config::schema {
   const Schema<BarMonitorOverride>& barMonitorOverrideSchema() {
     static const Schema<BarMonitorOverride> s = {
         field(&BarMonitorOverride::match, "match"),
-        optionalStringField(&BarMonitorOverride::position, "position"),
+        field(&BarMonitorOverride::position, "position"),
         optionalBoolField(&BarMonitorOverride::enabled, "enabled"),
         optionalBoolField(&BarMonitorOverride::autoHide, "auto_hide"),
         optionalBoolField(&BarMonitorOverride::smartAutoHide, "smart_auto_hide"),

--- a/src/config/schema/field.h
+++ b/src/config/schema/field.h
@@ -185,6 +185,22 @@ namespace noctalia::config::schema {
     };
   }
 
+  template <typename Struct> Field<Struct> field(std::optional<std::string> Struct::* member, std::string_view key) {
+    return Field<Struct>{
+        key,
+        [member, key](const toml::table& tbl, Struct& out, std::string_view, Diagnostics&) {
+          if (auto v = tbl[key].value<std::string>()) {
+            out.*member = *v;
+          }
+        },
+        [member, key](toml::table& tbl, const Struct& in) {
+          if ((in.*member).has_value()) {
+            tbl.insert_or_assign(key, *(in.*member));
+          }
+        }
+    };
+  }
+
   template <typename Struct> Field<Struct> field(std::vector<std::string> Struct::* member, std::string_view key) {
     return Field<Struct>{
         key,

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -23,12 +23,15 @@
 #include <dirent.h>
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <ranges>
 #include <sdbus-c++/IProxy.h>
 #include <sdbus-c++/Types.h>
+#include <set>
 #include <string>
 #include <string_view>
 #include <sys/epoll.h>
@@ -620,6 +623,53 @@ namespace {
     }
     kLog.info("ddcutil detect parsed {} candidate display(s)", candidates.size());
     return candidates;
+  }
+
+  std::map<int, std::string> getBusOverrides(const BrightnessConfig& config, const WaylandConnection& wayland) {
+    std::map<int, std::string> busOverrides;
+    std::set<int> contestedBuses;
+
+    for (const auto& output : wayland.outputs()) {
+      if (output.connectorName.empty()) {
+        continue;
+      }
+
+      const auto override = std::ranges::find_if(config.monitorOverrides, [&output](const auto& entry) {
+        return !entry.match.empty() && outputMatchesSelector(entry.match, output);
+      });
+      if (override == config.monitorOverrides.end() || !override->ddcBus.has_value()) {
+        continue;
+      }
+
+      const BrightnessBackendPreference preference = backendPreferenceForOutput(config, &output);
+      if (preference == BrightnessBackendPreference::None || preference == BrightnessBackendPreference::Backlight) {
+        kLog.debug(
+            "ignoring ddc_bus '{}' for connector {} because backend is not set to 'ddcutil'", *override->ddcBus,
+            output.connectorName
+        );
+        continue;
+      }
+
+      const auto parsedBus = parseI2cBus(*override->ddcBus);
+      if (!parsedBus.has_value()) {
+        kLog.warn("ddc_bus '{}' for connector {} could not be parsed", *override->ddcBus, output.connectorName);
+        continue;
+      }
+
+      if (const auto [it, inserted] = busOverrides.try_emplace(*parsedBus, output.connectorName); !inserted) {
+        kLog.warn(
+            "ignoring ddc_bus {} because both '{}' and '{}' pin it; only one connector can own a bus", *parsedBus,
+            it->second, output.connectorName
+        );
+        contestedBuses.insert(*parsedBus);
+      }
+    }
+
+    for (const int contestedBus : contestedBuses) {
+      busOverrides.erase(contestedBus);
+    }
+
+    return busOverrides;
   }
 
 } // namespace
@@ -1263,7 +1313,21 @@ struct BrightnessService::Impl {
 
     std::erase_if(internals, [](const DisplayInternal& display) { return display.backend == RuntimeBackend::Ddcutil; });
 
-    for (const auto& candidate : completion.candidates) {
+    const std::map<int, std::string> busOverrides = getBusOverrides(activeConfig, wayland);
+    const auto resolvedCandidates =
+        completion.candidates | std::views::transform([&busOverrides](auto candidate) {
+          const auto override = busOverrides.find(candidate.bus);
+          if (override != busOverrides.end()) {
+            kLog.info(
+                "ddcutil: bus {} reporting connector '{}', pinning it to '{}' as per config ", candidate.bus,
+                candidate.connectorName, override->second
+            );
+            candidate.connectorName = override->second;
+          }
+          return candidate;
+        });
+
+    for (const auto& candidate : resolvedCandidates) {
       const WaylandOutput* output = findOutputByConnector(wayland, candidate.connectorName);
       if (output == nullptr) {
         kLog.debug(
@@ -1285,6 +1349,11 @@ struct BrightnessService::Impl {
       }
 
       if (findInternal(candidate.connectorName) != nullptr) {
+        kLog.warn(
+            "ddcutil: ignoring bus {} because connector '{}' is already controlled; identical EDIDs hide which monitor "
+            "this is, so pin it with [brightness.monitor.<connector>] ddc_bus = \"i2c-{}\"",
+            candidate.bus, candidate.connectorName, candidate.bus
+        );
         continue;
       }
 

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -28,7 +28,6 @@
 #include <mutex>
 #include <optional>
 #include <queue>
-#include <ranges>
 #include <sdbus-c++/IProxy.h>
 #include <sdbus-c++/Types.h>
 #include <set>
@@ -625,8 +624,8 @@ namespace {
     return candidates;
   }
 
-  std::map<int, std::string> getBusOverrides(const BrightnessConfig& config, const WaylandConnection& wayland) {
-    std::map<int, std::string> busOverrides;
+  std::map<int, std::string> pinnedConnectorByBus(const BrightnessConfig& config, const WaylandConnection& wayland) {
+    std::map<int, std::string> pins;
     std::set<int> contestedBuses;
 
     for (const auto& output : wayland.outputs()) {
@@ -644,32 +643,26 @@ namespace {
       const BrightnessBackendPreference preference = backendPreferenceForOutput(config, &output);
       if (preference == BrightnessBackendPreference::None || preference == BrightnessBackendPreference::Backlight) {
         kLog.debug(
-            "ignoring ddc_bus '{}' for connector {} because backend is not set to 'ddcutil'", *override->ddcBus,
+            "ignoring ddc_bus {} for connector '{}' because backend is not set to 'ddcutil'", *override->ddcBus,
             output.connectorName
         );
         continue;
       }
 
-      const auto parsedBus = parseI2cBus(*override->ddcBus);
-      if (!parsedBus.has_value()) {
-        kLog.warn("ddc_bus '{}' for connector {} could not be parsed", *override->ddcBus, output.connectorName);
-        continue;
-      }
-
-      if (const auto [it, inserted] = busOverrides.try_emplace(*parsedBus, output.connectorName); !inserted) {
+      if (const auto [it, inserted] = pins.try_emplace(*override->ddcBus, output.connectorName); !inserted) {
         kLog.warn(
-            "ignoring ddc_bus {} because both '{}' and '{}' pin it; only one connector can own a bus", *parsedBus,
-            it->second, output.connectorName
+            "ignoring ddc_bus {} because both '{}' and '{}' pin it; only one connector can own a bus",
+            *override->ddcBus, it->second, output.connectorName
         );
-        contestedBuses.insert(*parsedBus);
+        contestedBuses.insert(*override->ddcBus);
       }
     }
 
     for (const int contestedBus : contestedBuses) {
-      busOverrides.erase(contestedBus);
+      pins.erase(contestedBus);
     }
 
-    return busOverrides;
+    return pins;
   }
 
 } // namespace
@@ -1313,21 +1306,36 @@ struct BrightnessService::Impl {
 
     std::erase_if(internals, [](const DisplayInternal& display) { return display.backend == RuntimeBackend::Ddcutil; });
 
-    const std::map<int, std::string> busOverrides = getBusOverrides(activeConfig, wayland);
-    const auto resolvedCandidates =
-        completion.candidates | std::views::transform([&busOverrides](auto candidate) {
-          const auto override = busOverrides.find(candidate.bus);
-          if (override != busOverrides.end()) {
-            kLog.info(
-                "ddcutil: bus {} reporting connector '{}', pinning it to '{}' as per config ", candidate.bus,
-                candidate.connectorName, override->second
-            );
-            candidate.connectorName = override->second;
-          }
-          return candidate;
-        });
+    const std::map<int, std::string> pins = pinnedConnectorByBus(activeConfig, wayland);
 
-    for (const auto& candidate : resolvedCandidates) {
+    if (!completion.candidates.empty()) {
+      for (const auto& [b, connectorName] : pins) {
+        if (std::ranges::none_of(completion.candidates, [b](const DdcCandidate& candidate) {
+              return candidate.bus == b;
+            })) {
+          kLog.warn("ddc_bus {} is pinned to connector '{}' but ddcutil did not report that bus", b, connectorName);
+        }
+      }
+    }
+
+    for (auto candidate : completion.candidates) {
+      if (const auto pin = pins.find(candidate.bus); pin != pins.end()) {
+        kLog.info(
+            "ddcutil: bus {} reports connector '{}', pinned to '{}' as per config", candidate.bus,
+            candidate.connectorName, pin->second
+        );
+        candidate.connectorName = pin->second;
+      } else if (std::ranges::any_of(pins, [&candidate](const auto& entry) {
+                   return entry.second == candidate.connectorName;
+                 })) {
+        kLog.warn(
+            "ddcutil: ignoring bus {} because connector '{}' is pinned to another bus; pin this bus to its own "
+            "connector with [brightness.monitor.<connector>] ddc_bus = {}",
+            candidate.bus, candidate.connectorName, candidate.bus
+        );
+        continue;
+      }
+
       const WaylandOutput* output = findOutputByConnector(wayland, candidate.connectorName);
       if (output == nullptr) {
         kLog.debug(
@@ -1348,10 +1356,13 @@ struct BrightnessService::Impl {
         continue;
       }
 
-      if (findInternal(candidate.connectorName) != nullptr) {
+      const auto alreadyControlled = std::ranges::any_of(internals, [&candidate](const DisplayInternal& display) {
+        return display.backend == RuntimeBackend::Ddcutil && display.connectorName == candidate.connectorName;
+      });
+      if (alreadyControlled) {
         kLog.warn(
-            "ddcutil: ignoring bus {} because connector '{}' is already controlled; identical EDIDs hide which monitor "
-            "this is, so pin it with [brightness.monitor.<connector>] ddc_bus = \"i2c-{}\"",
+            "ddcutil: ignoring bus {} because connector '{}' is already controlled; identical EDIDs hide which "
+            "monitor this is, so pin it with [brightness.monitor.<connector>] ddc_bus = {}",
             candidate.bus, candidate.connectorName, candidate.bus
         );
         continue;

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -1284,6 +1284,10 @@ struct BrightnessService::Impl {
         continue;
       }
 
+      if (findInternal(candidate.connectorName) != nullptr) {
+        continue;
+      }
+
       DisplayInternal display;
       display.backend = RuntimeBackend::Ddcutil;
       display.connectorName = candidate.connectorName;

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -405,8 +405,8 @@ location = "https://example.invalid/bad"
     c.brightness.enableDdcutil = true;
     c.brightness.ddcutilIgnoreMmids = {"ABC123"};
     c.brightness.monitorOverrides = {
-        {"DP-1", BrightnessBackendPreference::Ddcutil},
-        {"eDP-1", std::nullopt},
+        {"DP-1", BrightnessBackendPreference::Ddcutil, std::nullopt, "i2c-7"},
+        {"eDP-1", std::nullopt, "intel_backlight", std::nullopt},
     };
     c.battery.warningThreshold = 15;
     c.battery.deviceThresholds = {{"BAT0", 10}, {"hidpp:1", 25}};

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -405,7 +405,7 @@ location = "https://example.invalid/bad"
     c.brightness.enableDdcutil = true;
     c.brightness.ddcutilIgnoreMmids = {"ABC123"};
     c.brightness.monitorOverrides = {
-        {"DP-1", BrightnessBackendPreference::Ddcutil, std::nullopt, "i2c-7"},
+        {"DP-1", BrightnessBackendPreference::Ddcutil, std::nullopt, 7},
         {"eDP-1", std::nullopt, "intel_backlight", std::nullopt},
     };
     c.battery.warningThreshold = 15;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
- Added duplicate detection so that there will never be multiple displays with the same id
-  Added config capability for pinning a monitor to a certain bus, example below
```
[brightness.monitor.DP-2]
ddc_bus = "i2c-6"
```

## Motivation

<!-- What problem does this solve? -->
Previously if multiple monitors had the same EDID then they would have the same display.pub.id, this caused an extra monitor card to show up in control centre for the first monitor, and the card for the second monitor was greyed out and uncontrollable. This resolves the extra card by adding a duplicate check, and resolves the second monitor being uncontrollable by letting the user override the connector to bus mapping in config.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Resolves #3974

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Added new monitor override with this option to config_schema_roundtrip_test.cpp, passed under `just test`.
Verified that without the bus pinning in config my machine does not show an extra instance of DP-1 as it did before this fix.
Verified that with the bus pinning in config then the monitor tab in control centre correctly shows DP-1 and DP-2 and both are controllable.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos
No UI changes

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I have moved the optional-string schema codec into `field.h` as a `field()` overload, replacing a file local `optionalStringField` in `config_schema.cpp` which was defined in an anonymous namespace below where I wanted to use it. I also noticed that there were other fields that don't seem specific to a particular config and could probably be moved to `field.h` too, for example `optionalIntField`, `optionalBoolField`, etc. I only moved `optionalStringField` because that was the only one I needed for this change, marking it as something that could probably be fixed in future.
