### PR TITLE
feat(wallpaper): sync wallpaper with light/dark theme

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3126,7 +3126,7 @@
           "placeholder": "~/Pictures/Wallpapers"
         },
         "theme-sync": {
-          "description": "Automatically switch wallpaper when the resolved light or dark theme changes. Pick a wallpaper under the Dark or Light tab in the wallpaper panel to assign it.",
+          "description": "Automatically switch wallpaper when the resolved light or dark theme changes. Enable this, then pick wallpapers under the Dark or Light tab in the wallpaper panel to assign bindings.",
           "label": "Sync Wallpaper with Theme"
         },
         "edge-smoothness": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3125,6 +3125,10 @@
           "label": "Light Mode Directory",
           "placeholder": "~/Pictures/Wallpapers"
         },
+        "theme-sync": {
+          "description": "Automatically switch wallpaper when the resolved light or dark theme changes. Pick a wallpaper under the Dark or Light tab in the wallpaper panel to assign it.",
+          "label": "Sync Wallpaper with Theme"
+        },
         "edge-smoothness": {
           "description": "Feathering of transition edges between wallpapers",
           "label": "Edge Smoothness"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3245,7 +3245,7 @@
           "placeholder": "~/Pictures/Wallpapers"
         },
         "theme-sync": {
-          "description": "Automatically switch wallpaper when the resolved light or dark theme changes. Pick a wallpaper under the Dark or Light tab in the wallpaper panel to assign it.",
+          "description": "Automatically switch wallpaper when the resolved light or dark theme changes. Enable this, then pick wallpapers under the Dark or Light tab in the wallpaper panel to assign bindings.",
           "label": "Sync Wallpaper with Theme"
         },
         "edge-smoothness": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3244,6 +3244,10 @@
           "label": "Light Mode Directory",
           "placeholder": "~/Pictures/Wallpapers"
         },
+        "theme-sync": {
+          "description": "Automatically switch wallpaper when the resolved light or dark theme changes. Pick a wallpaper under the Dark or Light tab in the wallpaper panel to assign it.",
+          "label": "Sync Wallpaper with Theme"
+        },
         "edge-smoothness": {
           "description": "Feathering of transition edges between wallpapers",
           "label": "Edge Smoothness"

--- a/meson.build
+++ b/meson.build
@@ -1201,6 +1201,7 @@ if build_tests
     'widget_action',
     'widget_definition',
     'wallpaper_shuffle_state',
+    'wallpaper_theme_sync_paths',
     'workspace_alert_service',
   ]
 

--- a/meson.build
+++ b/meson.build
@@ -1243,12 +1243,13 @@ if build_tests
     'upower_device_catalog',
     'vdir_reader',
     'virtual_grid_view_gesture',
-    'wallpaper_shuffle_state',
     'wayland_output_scale',
     'wayland_toplevels_identity',
     'webp_decoder',
     'widget_action',
     'widget_definition',
+    'wallpaper_shuffle_state',
+    'wallpaper_theme_sync_paths',
     'workspace_alert_service',
   ]
 

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -661,6 +661,7 @@ void Application::initStyleThemeAndWayland() {
       );
     }
     syncGSettingsColorScheme(resolvedMode);
+    m_wallpaper.onResolvedThemeModeChanged(resolvedMode);
   });
   m_themeService.apply();
   syncGSettingsColorScheme(m_themeService.resolvedMode());

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -668,6 +668,8 @@ void Application::initStyleThemeAndWayland() {
            {"NOCTALIA_THEME_MODE_CONFIGURED", configuredMode}}
       );
     }
+    syncGSettingsColorScheme(resolvedMode);
+    m_wallpaper.onResolvedThemeModeChanged(resolvedMode);
   });
   m_themeService.apply();
   syncGSettingsColorScheme(m_themeService.resolvedMode());

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -498,6 +498,23 @@ struct WallpaperAutomationConfig {
   bool operator==(const WallpaperAutomationConfig&) const = default;
 };
 
+struct WallpaperThemeSyncMonitorOverride {
+  std::string match;
+  std::string pathLight;
+  std::string pathDark;
+
+  bool operator==(const WallpaperThemeSyncMonitorOverride&) const = default;
+};
+
+struct WallpaperThemeSyncConfig {
+  bool enabled = false;
+  std::string pathLight;
+  std::string pathDark;
+  std::vector<WallpaperThemeSyncMonitorOverride> monitorOverrides;
+
+  bool operator==(const WallpaperThemeSyncConfig&) const = default;
+};
+
 struct WallpaperConfig {
   bool enabled = true;
   WallpaperFillMode fillMode = WallpaperFillMode::Crop;
@@ -513,6 +530,7 @@ struct WallpaperConfig {
   std::string directoryDark;  // empty = directory
   bool perMonitorDirectories = false;
   WallpaperAutomationConfig automation;
+  WallpaperThemeSyncConfig themeSync;
   std::vector<WallpaperMonitorOverride> monitorOverrides;
 
   bool operator==(const WallpaperConfig&) const = default;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "config/color_spec.h"
 #include "config/config_limits.h"
 #include "config/widget_setting_value.h"
 #include "core/input/key_chord.h"
 #include "system/sysmon_threshold_profile.h"
+#include "ui/palette.h"
 #include "ui/style.h"
 
 #include <array>

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -505,6 +505,23 @@ struct WallpaperAutomationConfig {
   bool operator==(const WallpaperAutomationConfig&) const = default;
 };
 
+struct WallpaperThemeSyncMonitorOverride {
+  std::string match;
+  std::string pathLight;
+  std::string pathDark;
+
+  bool operator==(const WallpaperThemeSyncMonitorOverride&) const = default;
+};
+
+struct WallpaperThemeSyncConfig {
+  bool enabled = false;
+  std::string pathLight;
+  std::string pathDark;
+  std::vector<WallpaperThemeSyncMonitorOverride> monitorOverrides;
+
+  bool operator==(const WallpaperThemeSyncConfig&) const = default;
+};
+
 struct WallpaperConfig {
   bool enabled = true;
   WallpaperFillMode fillMode = WallpaperFillMode::Crop;
@@ -520,6 +537,7 @@ struct WallpaperConfig {
   std::string directoryDark;  // empty = directory
   bool perMonitorDirectories = false;
   WallpaperAutomationConfig automation;
+  WallpaperThemeSyncConfig themeSync;
   std::vector<WallpaperMonitorOverride> monitorOverrides;
 
   bool operator==(const WallpaperConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -816,6 +816,29 @@ namespace noctalia::config::schema {
       return s;
     }
 
+    const Schema<WallpaperThemeSyncMonitorOverride>& wallpaperThemeSyncMonitorSchema() {
+      static const Schema<WallpaperThemeSyncMonitorOverride> s = {
+          field(&WallpaperThemeSyncMonitorOverride::match, "match"),
+          pathStringField(&WallpaperThemeSyncMonitorOverride::pathLight, "path_light"),
+          pathStringField(&WallpaperThemeSyncMonitorOverride::pathDark, "path_dark"),
+      };
+      return s;
+    }
+
+    const Schema<WallpaperThemeSyncConfig>& wallpaperThemeSyncSchema() {
+      static const Schema<WallpaperThemeSyncConfig> s = {
+          field(&WallpaperThemeSyncConfig::enabled, "enabled"),
+          pathStringField(&WallpaperThemeSyncConfig::pathLight, "path_light"),
+          pathStringField(&WallpaperThemeSyncConfig::pathDark, "path_dark"),
+          namedMap<WallpaperThemeSyncConfig, WallpaperThemeSyncMonitorOverride>(
+              &WallpaperThemeSyncConfig::monitorOverrides, "monitor", wallpaperThemeSyncMonitorSchema(),
+              [](WallpaperThemeSyncMonitorOverride& o, std::string_view name) { o.match = std::string(name); },
+              [](const WallpaperThemeSyncMonitorOverride& o) { return o.match; }
+          ),
+      };
+      return s;
+    }
+
     // One keybind action: reads a single chord string or an array of them
     // (warning on an unparseable chord, rethrowing on a hard parse exception);
     // writes the configured chords, or the built-in defaults when none are set.
@@ -1599,6 +1622,7 @@ namespace noctalia::config::schema {
         pathStringField(&WallpaperConfig::directoryDark, "directory_dark"),
         field(&WallpaperConfig::perMonitorDirectories, "per_monitor_directories"),
         subTable(&WallpaperConfig::automation, "automation", wallpaperAutomationSchema()),
+        subTable(&WallpaperConfig::themeSync, "theme_sync", wallpaperThemeSyncSchema()),
         namedMap<WallpaperConfig, WallpaperMonitorOverride>(
             &WallpaperConfig::monitorOverrides, "monitor", wallpaperMonitorSchema(),
             [](WallpaperMonitorOverride& o, std::string_view name) { o.match = std::string(name); },

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -8,7 +8,6 @@
 #include "core/input/key_chord.h"
 #include "notification/notification_filter.h"
 #include "scripting/plugin_id.h"
-#include "util/file_utils.h"
 
 #include <algorithm>
 #include <filesystem>

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -823,6 +823,29 @@ namespace noctalia::config::schema {
       return s;
     }
 
+    const Schema<WallpaperThemeSyncMonitorOverride>& wallpaperThemeSyncMonitorSchema() {
+      static const Schema<WallpaperThemeSyncMonitorOverride> s = {
+          field(&WallpaperThemeSyncMonitorOverride::match, "match"),
+          pathStringField(&WallpaperThemeSyncMonitorOverride::pathLight, "path_light"),
+          pathStringField(&WallpaperThemeSyncMonitorOverride::pathDark, "path_dark"),
+      };
+      return s;
+    }
+
+    const Schema<WallpaperThemeSyncConfig>& wallpaperThemeSyncSchema() {
+      static const Schema<WallpaperThemeSyncConfig> s = {
+          field(&WallpaperThemeSyncConfig::enabled, "enabled"),
+          pathStringField(&WallpaperThemeSyncConfig::pathLight, "path_light"),
+          pathStringField(&WallpaperThemeSyncConfig::pathDark, "path_dark"),
+          namedMap<WallpaperThemeSyncConfig, WallpaperThemeSyncMonitorOverride>(
+              &WallpaperThemeSyncConfig::monitorOverrides, "monitor", wallpaperThemeSyncMonitorSchema(),
+              [](WallpaperThemeSyncMonitorOverride& o, std::string_view name) { o.match = std::string(name); },
+              [](const WallpaperThemeSyncMonitorOverride& o) { return o.match; }
+          ),
+      };
+      return s;
+    }
+
     // One keybind action: reads a single chord string or an array of them
     // (warning on an unparseable chord, rethrowing on a hard parse exception);
     // writes the configured chords, or the built-in defaults when none are set.
@@ -1618,6 +1641,7 @@ namespace noctalia::config::schema {
         pathStringField(&WallpaperConfig::directoryDark, "directory_dark"),
         field(&WallpaperConfig::perMonitorDirectories, "per_monitor_directories"),
         subTable(&WallpaperConfig::automation, "automation", wallpaperAutomationSchema()),
+        subTable(&WallpaperConfig::themeSync, "theme_sync", wallpaperThemeSyncSchema()),
         namedMap<WallpaperConfig, WallpaperMonitorOverride>(
             &WallpaperConfig::monitorOverrides, "monitor", wallpaperMonitorSchema(),
             [](WallpaperMonitorOverride& o, std::string_view name) { o.match = std::string(name); },

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -658,6 +658,11 @@ namespace settings {
         "folder path dark theme", true
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Wallpaper, "theme-sync", tr("settings.schema.wallpaper.theme-sync.label"),
+        tr("settings.schema.wallpaper.theme-sync.description"), {"wallpaper", "theme_sync", "enabled"},
+        ToggleSetting{cfg.wallpaper.themeSync.enabled}, "theme wallpaper light dark sync"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Wallpaper, "directories", tr("settings.schema.wallpaper.per-monitor-directories.label"),
         tr("settings.schema.wallpaper.per-monitor-directories.description"), {"wallpaper", "per_monitor_directories"},
         ToggleSetting{cfg.wallpaper.perMonitorDirectories}, "per display folder"

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -684,6 +684,11 @@ namespace settings {
         "folder path dark theme", true
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Wallpaper, "theme-sync", tr("settings.schema.wallpaper.theme-sync.label"),
+        tr("settings.schema.wallpaper.theme-sync.description"), {"wallpaper", "theme_sync", "enabled"},
+        ToggleSetting{cfg.wallpaper.themeSync.enabled}, "theme wallpaper light dark sync"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Wallpaper, "directories", tr("settings.schema.wallpaper.per-monitor-directories.label"),
         tr("settings.schema.wallpaper.per-monitor-directories.description"), {"wallpaper", "per_monitor_directories"},
         ToggleSetting{cfg.wallpaper.perMonitorDirectories}, "per display folder"

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -27,7 +27,6 @@
 #include "wayland/wayland_connection.h"
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <memory>

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -1032,17 +1032,6 @@ ThemeMode WallpaperPanel::browseThemeMode() const {
   return wallpaper::effectiveThemeMode(configured, isLight);
 }
 
-std::optional<ThemeMode> WallpaperPanel::themeSyncBindingMode() const {
-  if (m_favoriteThemeSegmented == nullptr) {
-    return std::nullopt;
-  }
-  const ThemeMode mode = themeModeFromSegmentIndex(m_favoriteThemeSegmented->selectedIndex());
-  if (mode == ThemeMode::Light || mode == ThemeMode::Dark) {
-    return mode;
-  }
-  return std::nullopt;
-}
-
 std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
   if (m_config == nullptr || m_selectedMonitorIndex >= m_monitorChoices.size()) {
     return {};
@@ -1471,9 +1460,7 @@ void WallpaperPanel::applyWallpaperPath(const std::string& path, const Wallpaper
       choice.connector.empty() ? std::optional<std::string>{} : std::optional<std::string>{choice.connector};
 
   if (!path.empty() && !path.starts_with("color:")) {
-    if (const std::optional<ThemeMode> mode = themeSyncBindingMode(); mode.has_value()) {
-      wallpaper::setThemeSyncBinding(*m_config, connector, *mode, path);
-    }
+    wallpaper::setThemeSyncBinding(*m_config, connector, browseThemeMode(), path);
   }
 
   m_config->applyWallpaperSelection(connector, path, applyTheme, allMonitorConnectors());

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -1008,17 +1008,6 @@ ThemeMode WallpaperPanel::browseThemeMode() const {
   return wallpaper::effectiveThemeMode(configured, isLight);
 }
 
-std::optional<ThemeMode> WallpaperPanel::themeSyncBindingMode() const {
-  if (m_favoriteThemeSegmented == nullptr) {
-    return std::nullopt;
-  }
-  const ThemeMode mode = themeModeFromSegmentIndex(m_favoriteThemeSegmented->selectedIndex());
-  if (mode == ThemeMode::Light || mode == ThemeMode::Dark) {
-    return mode;
-  }
-  return std::nullopt;
-}
-
 std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
   if (m_config == nullptr || m_selectedMonitorIndex >= m_monitorChoices.size()) {
     return {};
@@ -1436,9 +1425,7 @@ void WallpaperPanel::applyWallpaperPath(const std::string& path, const Wallpaper
       choice.connector.empty() ? std::optional<std::string>{} : std::optional<std::string>{choice.connector};
 
   if (!path.empty() && !path.starts_with("color:")) {
-    if (const std::optional<ThemeMode> mode = themeSyncBindingMode(); mode.has_value()) {
-      wallpaper::setThemeSyncBinding(*m_config, connector, *mode, path);
-    }
+    wallpaper::setThemeSyncBinding(*m_config, connector, browseThemeMode(), path);
   }
 
   m_config->applyWallpaperSelection(connector, path, applyTheme, allMonitorConnectors());

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -1425,7 +1425,7 @@ void WallpaperPanel::applyWallpaperPath(const std::string& path, const Wallpaper
       choice.connector.empty() ? std::optional<std::string>{} : std::optional<std::string>{choice.connector};
 
   if (!path.empty() && !path.starts_with("color:")) {
-    wallpaper::setThemeSyncBinding(*m_config, connector, browseThemeMode(), path);
+    wallpaper::setThemeSyncBinding(*m_config, connector, browseThemeMode(), path, allMonitorConnectors());
   }
 
   m_config->applyWallpaperSelection(connector, path, applyTheme, allMonitorConnectors());

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -1460,7 +1460,7 @@ void WallpaperPanel::applyWallpaperPath(const std::string& path, const Wallpaper
       choice.connector.empty() ? std::optional<std::string>{} : std::optional<std::string>{choice.connector};
 
   if (!path.empty() && !path.starts_with("color:")) {
-    wallpaper::setThemeSyncBinding(*m_config, connector, browseThemeMode(), path);
+    wallpaper::setThemeSyncBinding(*m_config, connector, browseThemeMode(), path, allMonitorConnectors());
   }
 
   m_config->applyWallpaperSelection(connector, path, applyTheme, allMonitorConnectors());

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -252,6 +252,7 @@ public:
   void setEntries(const std::vector<WallpaperEntry>* entries) { m_entries = entries; }
   void setRenderer(Renderer* renderer) { m_renderer = renderer; }
   void setConfig(ConfigService* config) { m_config = config; }
+  void setMonitorConnector(std::optional<std::string> connector) { m_monitorConnector = std::move(connector); }
   void setCurrentWallpaperPath(std::string path) { m_currentWallpaperPath = std::move(path); }
   void setThumbnailService(ThumbnailService* service) {
     m_thumbnails = service;
@@ -294,9 +295,11 @@ public:
       wt->setEntry(entry, *m_renderer);
       if (m_config != nullptr && !entry.isDir) {
         const std::string path = entry.absPath.string();
-        wt->setFavoriteState(
-            m_config->isWallpaperFavorite(path), favoriteThemeBadge(m_config->wallpaperFavorite(path))
-        );
+        std::optional<ThemeMode> badge = favoriteThemeBadge(m_config->wallpaperFavorite(path));
+        if (!badge.has_value() && m_config->config().wallpaper.themeSync.enabled) {
+          badge = wallpaper::themeSyncModeForPath(m_config->config().wallpaper, path, m_monitorConnector);
+        }
+        wt->setFavoriteState(m_config->isWallpaperFavorite(path), badge);
       } else {
         wt->setFavoriteState(false, std::nullopt);
       }
@@ -359,6 +362,7 @@ private:
   Renderer* m_renderer = nullptr;
   ThumbnailService* m_thumbnails = nullptr;
   ConfigService* m_config = nullptr;
+  std::optional<std::string> m_monitorConnector;
 
   std::vector<WallpaperTile*> m_pool;
   ActivateCallback m_onActivate;
@@ -705,7 +709,7 @@ void WallpaperPanel::create() {
               return;
             }
             applyThemeFromControls();
-            rebindGrid();
+            refreshBrowseDirectory();
             m_dirty = true;
             PanelManager::instance().refresh();
           },
@@ -1013,6 +1017,30 @@ void WallpaperPanel::populateMonitorChoices() {
     m_monitorSelect->setOptions(std::move(labels));
     m_monitorSelect->setSelectedIndex(m_selectedMonitorIndex);
   }
+}
+
+ThemeMode WallpaperPanel::browseThemeMode() const {
+  if (m_favoriteThemeSegmented != nullptr) {
+    const ThemeMode selected = themeModeFromSegmentIndex(m_favoriteThemeSegmented->selectedIndex());
+    if (selected != ThemeMode::Auto) {
+      return selected;
+    }
+  }
+
+  const ThemeMode configured = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
+  const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
+  return wallpaper::effectiveThemeMode(configured, isLight);
+}
+
+std::optional<ThemeMode> WallpaperPanel::themeSyncBindingMode() const {
+  if (m_favoriteThemeSegmented == nullptr) {
+    return std::nullopt;
+  }
+  const ThemeMode mode = themeModeFromSegmentIndex(m_favoriteThemeSegmented->selectedIndex());
+  if (mode == ThemeMode::Light || mode == ThemeMode::Dark) {
+    return mode;
+  }
+  return std::nullopt;
 }
 
 std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
@@ -1391,6 +1419,7 @@ void WallpaperPanel::rebindGrid(bool resetScroll) {
     return;
   }
   if (m_adapter != nullptr) {
+    m_adapter->setMonitorConnector(selectedMonitorConnector());
     m_adapter->setCurrentWallpaperPath(currentWallpaperPathForSelection());
   }
   m_grid->notifyDataChanged();
@@ -1440,8 +1469,35 @@ void WallpaperPanel::applyWallpaperPath(const std::string& path, const Wallpaper
   const auto& choice = m_monitorChoices[m_selectedMonitorIndex];
   const std::optional<std::string> connector =
       choice.connector.empty() ? std::optional<std::string>{} : std::optional<std::string>{choice.connector};
+
+  if (!path.empty() && !path.starts_with("color:")) {
+    if (const std::optional<ThemeMode> mode = themeSyncBindingMode(); mode.has_value()) {
+      wallpaper::setThemeSyncBinding(*m_config, connector, *mode, path);
+    }
+  }
+
   m_config->applyWallpaperSelection(connector, path, applyTheme, allMonitorConnectors());
   rebindGrid();
+  syncBrowseChrome();
+}
+
+std::optional<std::string> WallpaperPanel::selectedMonitorConnector() const {
+  if (m_selectedMonitorIndex >= m_monitorChoices.size()) {
+    return std::nullopt;
+  }
+  const auto& choice = m_monitorChoices[m_selectedMonitorIndex];
+  if (choice.connector.empty()) {
+    return std::nullopt;
+  }
+  return choice.connector;
+}
+
+void WallpaperPanel::refreshBrowseDirectory() {
+  m_navStack.clear();
+  refreshVisibleEntries();
+  resetSelection();
+  rebindGrid();
+  syncBackButton();
   syncBrowseChrome();
 }
 

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -26,7 +26,6 @@
 #include "wayland/wayland_connection.h"
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <memory>

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -251,6 +251,7 @@ public:
   void setEntries(const std::vector<WallpaperEntry>* entries) { m_entries = entries; }
   void setRenderer(Renderer* renderer) { m_renderer = renderer; }
   void setConfig(ConfigService* config) { m_config = config; }
+  void setMonitorConnector(std::optional<std::string> connector) { m_monitorConnector = std::move(connector); }
   void setCurrentWallpaperPath(std::string path) { m_currentWallpaperPath = std::move(path); }
   void setThumbnailService(ThumbnailService* service) {
     m_thumbnails = service;
@@ -293,9 +294,11 @@ public:
       wt->setEntry(entry, *m_renderer);
       if (m_config != nullptr && !entry.isDir) {
         const std::string path = entry.absPath.string();
-        wt->setFavoriteState(
-            m_config->isWallpaperFavorite(path), favoriteThemeBadge(m_config->wallpaperFavorite(path))
-        );
+        std::optional<ThemeMode> badge = favoriteThemeBadge(m_config->wallpaperFavorite(path));
+        if (!badge.has_value() && m_config->config().wallpaper.themeSync.enabled) {
+          badge = wallpaper::themeSyncModeForPath(m_config->config().wallpaper, path, m_monitorConnector);
+        }
+        wt->setFavoriteState(m_config->isWallpaperFavorite(path), badge);
       } else {
         wt->setFavoriteState(false, std::nullopt);
       }
@@ -358,6 +361,7 @@ private:
   Renderer* m_renderer = nullptr;
   ThumbnailService* m_thumbnails = nullptr;
   ConfigService* m_config = nullptr;
+  std::optional<std::string> m_monitorConnector;
 
   std::vector<WallpaperTile*> m_pool;
   ActivateCallback m_onActivate;
@@ -684,7 +688,7 @@ void WallpaperPanel::create() {
               return;
             }
             applyThemeFromControls();
-            rebindGrid();
+            refreshBrowseDirectory();
             m_dirty = true;
             PanelManager::instance().refresh();
           },
@@ -991,14 +995,36 @@ void WallpaperPanel::populateMonitorChoices() {
   }
 }
 
+ThemeMode WallpaperPanel::browseThemeMode() const {
+  if (m_favoriteThemeSegmented != nullptr) {
+    const ThemeMode selected = themeModeFromSegmentIndex(m_favoriteThemeSegmented->selectedIndex());
+    if (selected != ThemeMode::Auto) {
+      return selected;
+    }
+  }
+
+  const ThemeMode configured = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
+  const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
+  return wallpaper::effectiveThemeMode(configured, isLight);
+}
+
+std::optional<ThemeMode> WallpaperPanel::themeSyncBindingMode() const {
+  if (m_favoriteThemeSegmented == nullptr) {
+    return std::nullopt;
+  }
+  const ThemeMode mode = themeModeFromSegmentIndex(m_favoriteThemeSegmented->selectedIndex());
+  if (mode == ThemeMode::Light || mode == ThemeMode::Dark) {
+    return mode;
+  }
+  return std::nullopt;
+}
+
 std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
   if (m_config == nullptr || m_selectedMonitorIndex >= m_monitorChoices.size()) {
     return {};
   }
   const auto& wp = m_config->config().wallpaper;
-  const ThemeMode configured = m_config->config().theme.mode;
-  const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
-  const ThemeMode mode = wallpaper::effectiveThemeMode(configured, isLight);
+  const ThemeMode mode = browseThemeMode();
 
   const auto& choice = m_monitorChoices[m_selectedMonitorIndex];
   if (choice.connector.empty() || !wp.perMonitorDirectories) {
@@ -1358,6 +1384,7 @@ void WallpaperPanel::rebindGrid(bool resetScroll) {
     return;
   }
   if (m_adapter != nullptr) {
+    m_adapter->setMonitorConnector(selectedMonitorConnector());
     m_adapter->setCurrentWallpaperPath(currentWallpaperPathForSelection());
   }
   m_grid->notifyDataChanged();
@@ -1407,8 +1434,35 @@ void WallpaperPanel::applyWallpaperPath(const std::string& path, const Wallpaper
   const auto& choice = m_monitorChoices[m_selectedMonitorIndex];
   const std::optional<std::string> connector =
       choice.connector.empty() ? std::optional<std::string>{} : std::optional<std::string>{choice.connector};
+
+  if (!path.empty() && !path.starts_with("color:")) {
+    if (const std::optional<ThemeMode> mode = themeSyncBindingMode(); mode.has_value()) {
+      wallpaper::setThemeSyncBinding(*m_config, connector, *mode, path);
+    }
+  }
+
   m_config->applyWallpaperSelection(connector, path, applyTheme, allMonitorConnectors());
   rebindGrid();
+}
+
+std::optional<std::string> WallpaperPanel::selectedMonitorConnector() const {
+  if (m_selectedMonitorIndex >= m_monitorChoices.size()) {
+    return std::nullopt;
+  }
+  const auto& choice = m_monitorChoices[m_selectedMonitorIndex];
+  if (choice.connector.empty()) {
+    return std::nullopt;
+  }
+  return choice.connector;
+}
+
+void WallpaperPanel::refreshBrowseDirectory() {
+  m_navStack.clear();
+  refreshVisibleEntries();
+  resetSelection();
+  rebindGrid();
+  syncBackButton();
+  syncBrowseChrome();
 }
 
 const WallpaperFavorite* WallpaperPanel::favoriteThemeToApply(std::string_view path) const {

--- a/src/shell/wallpaper/panel/wallpaper_panel.h
+++ b/src/shell/wallpaper/panel/wallpaper_panel.h
@@ -83,7 +83,6 @@ private:
   void refreshBrowseDirectory();
   [[nodiscard]] std::optional<std::string> selectedMonitorConnector() const;
   [[nodiscard]] ThemeMode browseThemeMode() const;
-  [[nodiscard]] std::optional<ThemeMode> themeSyncBindingMode() const;
   void applyWallpaperFromEntry(const WallpaperEntry& entry);
   void applyWallpaperPath(const std::string& path, const WallpaperFavorite* applyTheme);
   [[nodiscard]] const WallpaperFavorite* favoriteThemeToApply(std::string_view path) const;

--- a/src/shell/wallpaper/panel/wallpaper_panel.h
+++ b/src/shell/wallpaper/panel/wallpaper_panel.h
@@ -80,6 +80,10 @@ private:
   void syncBackButton();
   void navigateInto(const std::filesystem::path& dir);
   void navigateUp();
+  void refreshBrowseDirectory();
+  [[nodiscard]] std::optional<std::string> selectedMonitorConnector() const;
+  [[nodiscard]] ThemeMode browseThemeMode() const;
+  [[nodiscard]] std::optional<ThemeMode> themeSyncBindingMode() const;
   void applyWallpaperFromEntry(const WallpaperEntry& entry);
   void applyWallpaperPath(const std::string& path, const WallpaperFavorite* applyTheme);
   [[nodiscard]] const WallpaperFavorite* favoriteThemeToApply(std::string_view path) const;

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -27,7 +27,6 @@
 #include "wayland/wayland_seat.h"
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <filesystem>

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -1008,7 +1008,17 @@ void Wallpaper::updateThemeSyncBindingForManualPick(
   }
 
   const ThemeMode mode = m_themeService->isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
-  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path);
+  std::vector<std::string> connectors;
+  if (!connector.has_value() || connector->empty()) {
+    if (m_wayland != nullptr) {
+      for (const auto& out : m_wayland->outputs()) {
+        if (!out.connectorName.empty()) {
+          connectors.push_back(out.connectorName);
+        }
+      }
+    }
+  }
+  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path, connectors);
 }
 
 void Wallpaper::seedThemeSyncBindingForCurrentMode() {
@@ -1030,7 +1040,18 @@ void Wallpaper::seedThemeSyncBindingForCurrentMode() {
     return;
   }
 
-  wallpaper::setThemeSyncBinding(*m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path);
+  std::vector<std::string> connectors;
+  if (m_wayland != nullptr) {
+    for (const auto& out : m_wayland->outputs()) {
+      if (!out.connectorName.empty()) {
+        connectors.push_back(out.connectorName);
+      }
+    }
+  }
+
+  wallpaper::setThemeSyncBinding(
+      *m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path, connectors
+  );
 }
 
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -1011,7 +1011,17 @@ void Wallpaper::updateThemeSyncBindingForManualPick(
   }
 
   const ThemeMode mode = m_themeService->isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
-  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path);
+  std::vector<std::string> connectors;
+  if (!connector.has_value() || connector->empty()) {
+    if (m_wayland != nullptr) {
+      for (const auto& out : m_wayland->outputs()) {
+        if (!out.connectorName.empty()) {
+          connectors.push_back(out.connectorName);
+        }
+      }
+    }
+  }
+  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path, connectors);
 }
 
 void Wallpaper::seedThemeSyncBindingForCurrentMode() {
@@ -1033,7 +1043,18 @@ void Wallpaper::seedThemeSyncBindingForCurrentMode() {
     return;
   }
 
-  wallpaper::setThemeSyncBinding(*m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path);
+  std::vector<std::string> connectors;
+  if (m_wayland != nullptr) {
+    for (const auto& out : m_wayland->outputs()) {
+      if (!out.connectorName.empty()) {
+        connectors.push_back(out.connectorName);
+      }
+    }
+  }
+
+  wallpaper::setThemeSyncBinding(
+      *m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path, connectors
+  );
 }
 
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -1010,36 +1010,19 @@ void Wallpaper::updateThemeSyncBindingForManualPick(
     return;
   }
 
-  const ThemeMode mode = m_themeService->isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
   std::vector<std::string> connectors;
-  if (!connector.has_value() || connector->empty()) {
-    if (m_wayland != nullptr) {
-      for (const auto& out : m_wayland->outputs()) {
-        if (!out.connectorName.empty()) {
-          connectors.push_back(out.connectorName);
-        }
+  if (m_wayland != nullptr) {
+    for (const auto& out : m_wayland->outputs()) {
+      if (!out.connectorName.empty()) {
+        connectors.push_back(out.connectorName);
       }
     }
   }
-  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path, connectors);
+  wallpaper::bindThemeSyncForManualPick(*m_config, connector, m_themeService->isLightMode(), path, connectors);
 }
 
 void Wallpaper::seedThemeSyncBindingForCurrentMode() {
   if (m_config == nullptr || m_themeService == nullptr) {
-    return;
-  }
-
-  const auto& themeSync = m_config->config().wallpaper.themeSync;
-  const bool isLight = m_themeService->isLightMode();
-  if (isLight && !themeSync.pathLight.empty()) {
-    return;
-  }
-  if (!isLight && !themeSync.pathDark.empty()) {
-    return;
-  }
-
-  const std::string path = m_config->getPaletteWallpaperPath();
-  if (path.empty()) {
     return;
   }
 
@@ -1052,8 +1035,8 @@ void Wallpaper::seedThemeSyncBindingForCurrentMode() {
     }
   }
 
-  wallpaper::setThemeSyncBinding(
-      *m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path, connectors
+  wallpaper::seedThemeSyncBindingIfNeeded(
+      *m_config, m_themeService->isLightMode(), m_config->getPaletteWallpaperPath(), connectors
   );
 }
 

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -29,6 +29,8 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <filesystem>
+#include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <optional>
@@ -40,6 +42,7 @@
 using Random::randomFloat;
 
 namespace {
+  constexpr auto kThemeSyncStartupDebounce = std::chrono::milliseconds(150);
 
   constexpr Easing kWallpaperTransitionEasing = Easing::EaseInOutCubic;
   constexpr std::string_view kGlobalShuffleScope = "global";
@@ -424,6 +427,7 @@ bool Wallpaper::initialize(
   if (!m_config->config().wallpaper.enabled) {
     m_wallpaperEnabled = false;
     m_lastWallpaperConfig = m_config->config().wallpaper;
+    m_initialized = true;
     kLog.info("disabled in config");
     return true;
   }
@@ -431,15 +435,26 @@ bool Wallpaper::initialize(
   resetAutomationState();
   m_wallpaperEnabled = true;
   m_lastWallpaperConfig = m_config->config().wallpaper;
+
+  if (m_config->config().wallpaper.themeSync.enabled && m_themeService != nullptr) {
+    {
+      ConfigService::WallpaperBatch batch(*m_config);
+      applyThemeSync(m_themeService->resolvedMode());
+    }
+    scheduleThemeSync(m_themeService->resolvedMode());
+  }
+
   applyStartupAutomation(
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count()
   );
+  m_initialized = true;
   return true;
 }
 
 void Wallpaper::reload() {
   const auto& wallpaperConfig = m_config->config().wallpaper;
   const bool nowEnabled = wallpaperConfig.enabled;
+  const bool themeSyncJustEnabled = !m_lastWallpaperConfig.themeSync.enabled && wallpaperConfig.themeSync.enabled;
 
   if (nowEnabled && m_wallpaperEnabled && wallpaperConfig == m_lastWallpaperConfig) {
     return;
@@ -465,7 +480,26 @@ void Wallpaper::reload() {
     resetAutomationState();
   }
   m_wallpaperEnabled = true;
+
+  if (themeSyncJustEnabled) {
+    const auto& themeSyncBefore = m_config->config().wallpaper.themeSync;
+    seedThemeSyncBindingForCurrentMode();
+    const auto& themeSyncAfter = m_config->config().wallpaper.themeSync;
+    if (themeSyncBefore.pathLight != themeSyncAfter.pathLight
+        || themeSyncBefore.pathDark != themeSyncAfter.pathDark) {
+      return;
+    }
+  }
+
   m_lastWallpaperConfig = wallpaperConfig;
+
+  if (wallpaperConfig.themeSync.enabled && m_themeService != nullptr) {
+    {
+      ConfigService::WallpaperBatch batch(*m_config);
+      applyThemeSync(m_themeService->resolvedMode());
+    }
+    scheduleThemeSync(m_themeService->resolvedMode());
+  }
 
   // Wallpaper remains (or becomes) enabled — sync instances without teardown
   // to avoid flickering. syncInstances handles monitor override changes
@@ -485,6 +519,10 @@ void Wallpaper::onOutputChange() {
     return;
   }
   syncInstances();
+
+  if (m_config->config().wallpaper.themeSync.enabled && m_themeService != nullptr) {
+    scheduleThemeSync(m_themeService->resolvedMode());
+  }
 
   // Span fill mode maps a single image across the whole desktop, so a geometry
   // change on any output shifts the slice shown on every other output. Refresh
@@ -614,6 +652,8 @@ void Wallpaper::applyResolvedWallpaper(const std::optional<std::string>& connect
     }
   }
   notifyKdePlasmaWallpaper(resolvedPath, connector.value_or(""), output);
+
+  updateThemeSyncBindingForManualPick(connector, resolvedPath);
 
   if (const WallpaperFavorite* favorite = m_config->wallpaperFavorite(resolvedPath); favorite != nullptr) {
     if (connector.has_value()) {
@@ -879,6 +919,120 @@ void Wallpaper::setAutomationGate(std::function<bool()> gate) { m_automationGate
 
 bool Wallpaper::automationAllowed() const noexcept { return !m_automationGate || m_automationGate(); }
 
+void Wallpaper::onResolvedThemeModeChanged(std::string_view mode) {
+  if (!m_initialized || m_config == nullptr || !m_config->config().wallpaper.enabled
+      || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+  scheduleThemeSync(mode);
+}
+
+void Wallpaper::scheduleThemeSync(std::string_view mode) {
+  if (m_config == nullptr || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+
+  m_pendingThemeSyncMode = std::string(mode);
+  const auto delay = m_themeSyncStartupPhase ? kThemeSyncStartupDebounce : std::chrono::milliseconds(0);
+  m_themeSyncTimer.stop();
+  m_themeSyncTimer.start(delay, [this]() {
+    if (!m_pendingThemeSyncMode.has_value()) {
+      return;
+    }
+    const std::string resolvedMode = std::move(*m_pendingThemeSyncMode);
+    m_pendingThemeSyncMode.reset();
+    applyThemeSync(resolvedMode);
+    m_themeSyncStartupPhase = false;
+  });
+}
+
+bool Wallpaper::themeSyncPathExists(const std::string& path) const {
+  if (path.empty()) {
+    return false;
+  }
+  Color color{};
+  if (parseColorWallpaperPath(path, color)) {
+    return true;
+  }
+  std::error_code ec;
+  return std::filesystem::exists(path, ec);
+}
+
+void Wallpaper::applyThemeSync(std::string_view mode) {
+  if (m_config == nullptr || m_wayland == nullptr || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+
+  const ThemeMode themeMode = mode == "light" ? ThemeMode::Light : ThemeMode::Dark;
+  const auto& wallpaperConfig = m_config->config().wallpaper;
+  const auto& outputs = m_wayland->outputs();
+
+  ConfigService::WallpaperBatch batch(*m_config);
+  std::optional<std::string> defaultCandidate;
+
+  for (const auto& output : outputs) {
+    if (!output.done || output.connectorName.empty() || !output.hasUsableGeometry()
+        || !wallpaperOutputEnabled(wallpaperConfig, output)) {
+      continue;
+    }
+
+    const auto binding = wallpaper::resolveThemeSyncPath(wallpaperConfig, output, themeMode);
+    if (!binding.has_value() || binding->empty()) {
+      continue;
+    }
+    if (!themeSyncPathExists(*binding)) {
+      kLog.warn("theme sync: skip missing wallpaper for '{}': {}", output.connectorName, *binding);
+      continue;
+    }
+    const std::string currentPath = m_config->getWallpaperPath(output.connectorName);
+    if (currentPath == *binding) {
+      defaultCandidate = *binding;
+      continue;
+    }
+    m_config->setWallpaperPath(output.connectorName, *binding);
+    defaultCandidate = *binding;
+    kLog.info("theme sync set {} → {}", output.connectorName, *binding);
+  }
+
+  if (defaultCandidate.has_value() && m_config->getDefaultWallpaperPath() != *defaultCandidate) {
+    m_config->setWallpaperPath(std::nullopt, *defaultCandidate);
+  }
+}
+
+void Wallpaper::updateThemeSyncBindingForManualPick(
+    const std::optional<std::string>& connector, const std::string& path
+) {
+  if (m_config == nullptr || m_themeService == nullptr || path.empty()
+      || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+
+  const ThemeMode mode = m_themeService->isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
+  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path);
+}
+
+void Wallpaper::seedThemeSyncBindingForCurrentMode() {
+  if (m_config == nullptr || m_themeService == nullptr) {
+    return;
+  }
+
+  const auto& themeSync = m_config->config().wallpaper.themeSync;
+  const bool isLight = m_themeService->isLightMode();
+  if (isLight && !themeSync.pathLight.empty()) {
+    return;
+  }
+  if (!isLight && !themeSync.pathDark.empty()) {
+    return;
+  }
+
+  const std::string path = m_config->getPaletteWallpaperPath();
+  if (path.empty()) {
+    return;
+  }
+
+  wallpaper::setThemeSyncBinding(*m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path);
+}
+
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {
   const ThemeMode configured = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
   const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
@@ -922,6 +1076,9 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
           || !wallpaperOutputEnabled(wallpaper, output)) {
         continue;
       }
+      if (wallpaper::hasThemeSyncBinding(wallpaper, output, mode)) {
+        continue;
+      }
 
       attempted = true;
       const std::string dir = wallpaper::resolveWallpaperDirectory(wallpaper, output, mode);
@@ -947,6 +1104,10 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
       kLog.info("startup automation set {} → {}", output.connectorName, picked);
     }
   } else {
+    if (wallpaper::hasGlobalThemeSyncBinding(wallpaper, mode)) {
+      return;
+    }
+
     for (const auto& output : outputs) {
       if (output.done
           && !output.connectorName.empty()
@@ -1030,6 +1191,9 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
           }
         }
       }
+      if (output != nullptr && wallpaper::hasThemeSyncBinding(wallpaper, *output, mode)) {
+        continue;
+      }
       std::vector<std::string> candidates;
       const std::string dir = output != nullptr ? wallpaper::resolveWallpaperDirectory(wallpaper, *output, mode)
                                                 : wallpaper::resolveGlobalWallpaperDirectory(wallpaper, mode);
@@ -1052,6 +1216,10 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
       kLog.info("automation set {} → {}", inst->connectorName, picked);
     }
   } else {
+    if (wallpaper::hasGlobalThemeSyncBinding(wallpaper, mode)) {
+      return;
+    }
+
     std::vector<std::string> candidates;
     const std::string dir = wallpaper::resolveGlobalWallpaperDirectory(wallpaper, mode);
     collectWallpaperCandidates(dir, automation.recursive, candidates);

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -27,9 +27,6 @@
 #include "wayland/wayland_seat.h"
 
 #include <algorithm>
-#include <cctype>
-#include <chrono>
-#include <filesystem>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
@@ -485,8 +482,7 @@ void Wallpaper::reload() {
     const auto& themeSyncBefore = m_config->config().wallpaper.themeSync;
     seedThemeSyncBindingForCurrentMode();
     const auto& themeSyncAfter = m_config->config().wallpaper.themeSync;
-    if (themeSyncBefore.pathLight != themeSyncAfter.pathLight
-        || themeSyncBefore.pathDark != themeSyncAfter.pathDark) {
+    if (themeSyncBefore.pathLight != themeSyncAfter.pathLight || themeSyncBefore.pathDark != themeSyncAfter.pathDark) {
       return;
     }
   }
@@ -920,7 +916,9 @@ void Wallpaper::setAutomationGate(std::function<bool()> gate) { m_automationGate
 bool Wallpaper::automationAllowed() const noexcept { return !m_automationGate || m_automationGate(); }
 
 void Wallpaper::onResolvedThemeModeChanged(std::string_view mode) {
-  if (!m_initialized || m_config == nullptr || !m_config->config().wallpaper.enabled
+  if (!m_initialized
+      || m_config == nullptr
+      || !m_config->config().wallpaper.enabled
       || !m_config->config().wallpaper.themeSync.enabled) {
     return;
   }
@@ -971,7 +969,9 @@ void Wallpaper::applyThemeSync(std::string_view mode) {
   std::optional<std::string> defaultCandidate;
 
   for (const auto& output : outputs) {
-    if (!output.done || output.connectorName.empty() || !output.hasUsableGeometry()
+    if (!output.done
+        || output.connectorName.empty()
+        || !output.hasUsableGeometry()
         || !wallpaperOutputEnabled(wallpaperConfig, output)) {
       continue;
     }
@@ -1002,41 +1002,23 @@ void Wallpaper::applyThemeSync(std::string_view mode) {
 void Wallpaper::updateThemeSyncBindingForManualPick(
     const std::optional<std::string>& connector, const std::string& path
 ) {
-  if (m_config == nullptr || m_themeService == nullptr || path.empty()
-      || !m_config->config().wallpaper.themeSync.enabled) {
+  if (m_config == nullptr || m_themeService == nullptr || path.empty()) {
     return;
   }
 
-  const ThemeMode mode = m_themeService->isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
   std::vector<std::string> connectors;
-  if (!connector.has_value() || connector->empty()) {
-    if (m_wayland != nullptr) {
-      for (const auto& out : m_wayland->outputs()) {
-        if (!out.connectorName.empty()) {
-          connectors.push_back(out.connectorName);
-        }
+  if (m_wayland != nullptr) {
+    for (const auto& out : m_wayland->outputs()) {
+      if (!out.connectorName.empty()) {
+        connectors.push_back(out.connectorName);
       }
     }
   }
-  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path, connectors);
+  wallpaper::bindThemeSyncForManualPick(*m_config, connector, m_themeService->isLightMode(), path, connectors);
 }
 
 void Wallpaper::seedThemeSyncBindingForCurrentMode() {
   if (m_config == nullptr || m_themeService == nullptr) {
-    return;
-  }
-
-  const auto& themeSync = m_config->config().wallpaper.themeSync;
-  const bool isLight = m_themeService->isLightMode();
-  if (isLight && !themeSync.pathLight.empty()) {
-    return;
-  }
-  if (!isLight && !themeSync.pathDark.empty()) {
-    return;
-  }
-
-  const std::string path = m_config->getPaletteWallpaperPath();
-  if (path.empty()) {
     return;
   }
 
@@ -1049,8 +1031,8 @@ void Wallpaper::seedThemeSyncBindingForCurrentMode() {
     }
   }
 
-  wallpaper::setThemeSyncBinding(
-      *m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path, connectors
+  wallpaper::seedThemeSyncBindingIfNeeded(
+      *m_config, m_themeService->isLightMode(), m_config->getPaletteWallpaperPath(), connectors
   );
 }
 

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -40,6 +40,7 @@
 using Random::randomFloat;
 
 namespace {
+  constexpr auto kThemeSyncStartupDebounce = std::chrono::milliseconds(150);
 
   constexpr Easing kWallpaperTransitionEasing = Easing::EaseInOutCubic;
   constexpr std::string_view kGlobalShuffleScope = "global";
@@ -424,6 +425,7 @@ bool Wallpaper::initialize(
   if (!m_config->config().wallpaper.enabled) {
     m_wallpaperEnabled = false;
     m_lastWallpaperConfig = m_config->config().wallpaper;
+    m_initialized = true;
     kLog.info("disabled in config");
     return true;
   }
@@ -431,15 +433,26 @@ bool Wallpaper::initialize(
   resetAutomationState();
   m_wallpaperEnabled = true;
   m_lastWallpaperConfig = m_config->config().wallpaper;
+
+  if (m_config->config().wallpaper.themeSync.enabled && m_themeService != nullptr) {
+    {
+      ConfigService::WallpaperBatch batch(*m_config);
+      applyThemeSync(m_themeService->resolvedMode());
+    }
+    scheduleThemeSync(m_themeService->resolvedMode());
+  }
+
   applyStartupAutomation(
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count()
   );
+  m_initialized = true;
   return true;
 }
 
 void Wallpaper::reload() {
   const auto& wallpaperConfig = m_config->config().wallpaper;
   const bool nowEnabled = wallpaperConfig.enabled;
+  const bool themeSyncJustEnabled = !m_lastWallpaperConfig.themeSync.enabled && wallpaperConfig.themeSync.enabled;
 
   if (nowEnabled && m_wallpaperEnabled && wallpaperConfig == m_lastWallpaperConfig) {
     return;
@@ -465,7 +478,25 @@ void Wallpaper::reload() {
     resetAutomationState();
   }
   m_wallpaperEnabled = true;
+
+  if (themeSyncJustEnabled) {
+    const auto& themeSyncBefore = m_config->config().wallpaper.themeSync;
+    seedThemeSyncBindingForCurrentMode();
+    const auto& themeSyncAfter = m_config->config().wallpaper.themeSync;
+    if (themeSyncBefore.pathLight != themeSyncAfter.pathLight || themeSyncBefore.pathDark != themeSyncAfter.pathDark) {
+      return;
+    }
+  }
+
   m_lastWallpaperConfig = wallpaperConfig;
+
+  if (wallpaperConfig.themeSync.enabled && m_themeService != nullptr) {
+    {
+      ConfigService::WallpaperBatch batch(*m_config);
+      applyThemeSync(m_themeService->resolvedMode());
+    }
+    scheduleThemeSync(m_themeService->resolvedMode());
+  }
 
   // Wallpaper remains (or becomes) enabled, sync instances without teardown
   // to avoid flickering. syncInstances handles monitor override changes
@@ -485,6 +516,10 @@ void Wallpaper::onOutputChange() {
     return;
   }
   syncInstances();
+
+  if (m_config->config().wallpaper.themeSync.enabled && m_themeService != nullptr) {
+    scheduleThemeSync(m_themeService->resolvedMode());
+  }
 
   // Span fill mode maps a single image across the whole desktop, so a geometry
   // change on any output shifts the slice shown on every other output. Refresh
@@ -614,6 +649,8 @@ void Wallpaper::applyResolvedWallpaper(const std::optional<std::string>& connect
     }
   }
   notifyKdePlasmaWallpaper(resolvedPath, connector.value_or(""), output);
+
+  updateThemeSyncBindingForManualPick(connector, resolvedPath);
 
   if (const WallpaperFavorite* favorite = m_config->wallpaperFavorite(resolvedPath); favorite != nullptr) {
     if (connector.has_value()) {
@@ -879,6 +916,126 @@ void Wallpaper::setAutomationGate(std::function<bool()> gate) { m_automationGate
 
 bool Wallpaper::automationAllowed() const noexcept { return !m_automationGate || m_automationGate(); }
 
+void Wallpaper::onResolvedThemeModeChanged(std::string_view mode) {
+  if (!m_initialized
+      || m_config == nullptr
+      || !m_config->config().wallpaper.enabled
+      || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+  scheduleThemeSync(mode);
+}
+
+void Wallpaper::scheduleThemeSync(std::string_view mode) {
+  if (m_config == nullptr || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+
+  m_pendingThemeSyncMode = std::string(mode);
+  const auto delay = m_themeSyncStartupPhase ? kThemeSyncStartupDebounce : std::chrono::milliseconds(0);
+  m_themeSyncTimer.stop();
+  m_themeSyncTimer.start(delay, [this]() {
+    if (!m_pendingThemeSyncMode.has_value()) {
+      return;
+    }
+    const std::string resolvedMode = std::move(*m_pendingThemeSyncMode);
+    m_pendingThemeSyncMode.reset();
+    applyThemeSync(resolvedMode);
+    m_themeSyncStartupPhase = false;
+  });
+}
+
+bool Wallpaper::themeSyncPathExists(const std::string& path) const {
+  if (path.empty()) {
+    return false;
+  }
+  Color color{};
+  if (parseColorWallpaperPath(path, color)) {
+    return true;
+  }
+  std::error_code ec;
+  return std::filesystem::exists(path, ec);
+}
+
+void Wallpaper::applyThemeSync(std::string_view mode) {
+  if (m_config == nullptr || m_wayland == nullptr || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+
+  const ThemeMode themeMode = mode == "light" ? ThemeMode::Light : ThemeMode::Dark;
+  const auto& wallpaperConfig = m_config->config().wallpaper;
+  const auto& outputs = m_wayland->outputs();
+
+  ConfigService::WallpaperBatch batch(*m_config);
+  std::optional<std::string> defaultCandidate;
+
+  for (const auto& output : outputs) {
+    if (!output.done
+        || output.connectorName.empty()
+        || !output.hasUsableGeometry()
+        || !wallpaperOutputEnabled(wallpaperConfig, output)) {
+      continue;
+    }
+
+    const auto binding = wallpaper::resolveThemeSyncPath(wallpaperConfig, output, themeMode);
+    if (!binding.has_value() || binding->empty()) {
+      continue;
+    }
+    if (!themeSyncPathExists(*binding)) {
+      kLog.warn("theme sync: skip missing wallpaper for '{}': {}", output.connectorName, *binding);
+      continue;
+    }
+    const std::string currentPath = m_config->getWallpaperPath(output.connectorName);
+    if (currentPath == *binding) {
+      defaultCandidate = *binding;
+      continue;
+    }
+    m_config->setWallpaperPath(output.connectorName, *binding);
+    defaultCandidate = *binding;
+    kLog.info("theme sync set {} → {}", output.connectorName, *binding);
+  }
+
+  if (defaultCandidate.has_value() && m_config->getDefaultWallpaperPath() != *defaultCandidate) {
+    m_config->setWallpaperPath(std::nullopt, *defaultCandidate);
+  }
+}
+
+void Wallpaper::updateThemeSyncBindingForManualPick(
+    const std::optional<std::string>& connector, const std::string& path
+) {
+  if (m_config == nullptr
+      || m_themeService == nullptr
+      || path.empty()
+      || !m_config->config().wallpaper.themeSync.enabled) {
+    return;
+  }
+
+  const ThemeMode mode = m_themeService->isLightMode() ? ThemeMode::Light : ThemeMode::Dark;
+  wallpaper::setThemeSyncBinding(*m_config, connector, mode, path);
+}
+
+void Wallpaper::seedThemeSyncBindingForCurrentMode() {
+  if (m_config == nullptr || m_themeService == nullptr) {
+    return;
+  }
+
+  const auto& themeSync = m_config->config().wallpaper.themeSync;
+  const bool isLight = m_themeService->isLightMode();
+  if (isLight && !themeSync.pathLight.empty()) {
+    return;
+  }
+  if (!isLight && !themeSync.pathDark.empty()) {
+    return;
+  }
+
+  const std::string path = m_config->getPaletteWallpaperPath();
+  if (path.empty()) {
+    return;
+  }
+
+  wallpaper::setThemeSyncBinding(*m_config, std::nullopt, isLight ? ThemeMode::Light : ThemeMode::Dark, path);
+}
+
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {
   const ThemeMode configured = m_config != nullptr ? shellThemeMode(m_config->config().theme) : ThemeMode::Dark;
   const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
@@ -922,6 +1079,9 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
           || !wallpaperOutputEnabled(wallpaper, output)) {
         continue;
       }
+      if (wallpaper::hasThemeSyncBinding(wallpaper, output, mode)) {
+        continue;
+      }
 
       attempted = true;
       const std::string dir = wallpaper::resolveWallpaperDirectory(wallpaper, output, mode);
@@ -947,6 +1107,10 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
       kLog.info("startup automation set {} → {}", output.connectorName, picked);
     }
   } else {
+    if (wallpaper::hasGlobalThemeSyncBinding(wallpaper, mode)) {
+      return;
+    }
+
     for (const auto& output : outputs) {
       if (output.done
           && !output.connectorName.empty()
@@ -1030,6 +1194,9 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
           }
         }
       }
+      if (output != nullptr && wallpaper::hasThemeSyncBinding(wallpaper, *output, mode)) {
+        continue;
+      }
       std::vector<std::string> candidates;
       const std::string dir = output != nullptr ? wallpaper::resolveWallpaperDirectory(wallpaper, *output, mode)
                                                 : wallpaper::resolveGlobalWallpaperDirectory(wallpaper, mode);
@@ -1052,6 +1219,10 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
       kLog.info("automation set {} → {}", inst->connectorName, picked);
     }
   } else {
+    if (wallpaper::hasGlobalThemeSyncBinding(wallpaper, mode)) {
+      return;
+    }
+
     std::vector<std::string> candidates;
     const std::string dir = wallpaper::resolveGlobalWallpaperDirectory(wallpaper, mode);
     collectWallpaperCandidates(dir, automation.recursive, candidates);

--- a/src/shell/wallpaper/wallpaper.h
+++ b/src/shell/wallpaper/wallpaper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config/config_types.h"
+#include "core/timer_manager.h"
 #include "shell/wallpaper/wallpaper_shuffle_state.h"
 #include "ui/signal.h"
 
@@ -43,6 +44,9 @@ public:
       noctalia::theme::ThemeService* themeService = nullptr
   );
   void onOutputChange();
+  // Called when ThemeService resolves a light/dark appearance. Applies theme-bound
+  // wallpaper paths when theme sync is enabled (debounced during startup).
+  void onResolvedThemeModeChanged(std::string_view mode);
   // Mark an output as driven by an external wallpaper source (e.g. an mpvpaper plugin):
   // its Background surface is torn down so the external surface shows through. Runtime-only
   // (not persisted) — it clears on restart and is re-asserted by the owner.
@@ -90,6 +94,11 @@ private:
   // Persist a resolved image path to a single connector, or to every connected
   // output plus the default when no connector is given.
   void applyResolvedWallpaper(const std::optional<std::string>& connector, const std::string& resolvedPath);
+  void updateThemeSyncBindingForManualPick(const std::optional<std::string>& connector, const std::string& path);
+  void seedThemeSyncBindingForCurrentMode();
+  void scheduleThemeSync(std::string_view mode);
+  void applyThemeSync(std::string_view mode);
+  [[nodiscard]] bool themeSyncPathExists(const std::string& path) const;
   void reload();
   void syncInstances();
   void applyStartupAutomation(std::int64_t secondStamp);
@@ -134,6 +143,10 @@ private:
   wallpaper::ShuffleState m_shuffleState;
   Signal<>::ScopedConnection m_paletteConn;
   Signal<> m_changed;
+  bool m_initialized = false;
+  bool m_themeSyncStartupPhase = true;
+  std::optional<std::string> m_pendingThemeSyncMode;
+  Timer m_themeSyncTimer;
   std::vector<std::unique_ptr<WallpaperInstance>> m_instances;
   std::unordered_set<std::string> m_externallyManagedOutputs;
 };

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -1,7 +1,12 @@
 #include "shell/wallpaper/wallpaper_paths.h"
 
+#include "config/config_service.h"
 #include "config/config_types.h"
 #include "util/file_utils.h"
+
+#include <optional>
+#include <utility>
+#include <vector>
 
 ThemeMode wallpaper::effectiveThemeMode(ThemeMode mode, bool isLight) noexcept {
   if (mode == ThemeMode::Auto) {
@@ -49,4 +54,114 @@ std::string wallpaper::resolveGlobalWallpaperDirectory(const WallpaperConfig& co
     return config.directory;
   }
   return FileUtils::defaultPicturesDirectory().string();
+}
+
+namespace {
+
+  [[nodiscard]] const WallpaperThemeSyncMonitorOverride*
+  findThemeSyncMonitorOverride(const WallpaperConfig& config, const WaylandOutput& output) {
+    for (const auto& ovr : config.themeSync.monitorOverrides) {
+      if (outputMatchesSelector(ovr.match, output)) {
+        return &ovr;
+      }
+    }
+    return nullptr;
+  }
+
+  [[nodiscard]] std::optional<std::string>
+  pickThemeSyncPath(const std::string& pathLight, const std::string& pathDark, ThemeMode mode) {
+    if (mode == ThemeMode::Light) {
+      return pathLight.empty() ? std::nullopt : std::make_optional(pathLight);
+    }
+    return pathDark.empty() ? std::nullopt : std::make_optional(pathDark);
+  }
+
+} // namespace
+
+std::optional<std::string>
+wallpaper::resolveThemeSyncPath(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode) {
+  if (!config.themeSync.enabled) {
+    return std::nullopt;
+  }
+
+  if (const auto* ovr = findThemeSyncMonitorOverride(config, output)) {
+    if (auto path = pickThemeSyncPath(ovr->pathLight, ovr->pathDark, mode)) {
+      return path;
+    }
+  }
+
+  return pickThemeSyncPath(config.themeSync.pathLight, config.themeSync.pathDark, mode);
+}
+
+bool wallpaper::hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode) {
+  const auto path = resolveThemeSyncPath(config, output, mode);
+  return path.has_value() && !path->empty();
+}
+
+bool wallpaper::hasGlobalThemeSyncBinding(const WallpaperConfig& config, ThemeMode mode) {
+  if (!config.themeSync.enabled) {
+    return false;
+  }
+  if (mode == ThemeMode::Light) {
+    return !config.themeSync.pathLight.empty();
+  }
+  return !config.themeSync.pathDark.empty();
+}
+
+std::optional<ThemeMode> wallpaper::themeSyncModeForPath(
+    const WallpaperConfig& config, std::string_view path, const std::optional<std::string>& connector
+) {
+  if (!config.themeSync.enabled || path.empty()) {
+    return std::nullopt;
+  }
+
+  const std::string normalized = FileUtils::normalizeWallpaperPath(path);
+  const auto matches = [&](const std::string& bound) {
+    return !bound.empty() && FileUtils::normalizeWallpaperPath(bound) == normalized;
+  };
+
+  if (connector.has_value() && !connector->empty()) {
+    for (const auto& ovr : config.themeSync.monitorOverrides) {
+      if (ovr.match != *connector) {
+        continue;
+      }
+      if (matches(ovr.pathLight)) {
+        return ThemeMode::Light;
+      }
+      if (matches(ovr.pathDark)) {
+        return ThemeMode::Dark;
+      }
+      return std::nullopt;
+    }
+  }
+
+  if (matches(config.themeSync.pathLight)) {
+    return ThemeMode::Light;
+  }
+  if (matches(config.themeSync.pathDark)) {
+    return ThemeMode::Dark;
+  }
+  return std::nullopt;
+}
+
+void wallpaper::setThemeSyncBinding(
+    ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+) {
+  if (path.empty() || (mode != ThemeMode::Light && mode != ThemeMode::Dark)) {
+    return;
+  }
+
+  const std::string key = mode == ThemeMode::Light ? "path_light" : "path_dark";
+  std::vector<std::pair<std::vector<std::string>, ConfigOverrideValue>> overrides;
+  if (!config.config().wallpaper.themeSync.enabled) {
+    overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true);
+  }
+  if (connector.has_value() && !connector->empty()) {
+    overrides.emplace_back(
+        std::vector<std::string>{"wallpaper", "theme_sync", "monitor", *connector, key}, std::string(path)
+    );
+  } else {
+    overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", key}, std::string(path));
+  }
+  (void)config.setOverrides(std::move(overrides));
 }

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -148,7 +148,8 @@ void wallpaper::setThemeSyncBinding(
     ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
     std::span<const std::string> allConnectors
 ) {
-  if (path.empty() || (mode != ThemeMode::Light && mode != ThemeMode::Dark)
+  if (path.empty()
+      || (mode != ThemeMode::Light && mode != ThemeMode::Dark)
       || !config.config().wallpaper.themeSync.enabled) {
     return;
   }

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -145,7 +145,8 @@ std::optional<ThemeMode> wallpaper::themeSyncModeForPath(
 }
 
 void wallpaper::setThemeSyncBinding(
-    ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+    ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
+    std::span<const std::string> allConnectors
 ) {
   if (path.empty() || (mode != ThemeMode::Light && mode != ThemeMode::Dark)) {
     return;
@@ -162,6 +163,14 @@ void wallpaper::setThemeSyncBinding(
     );
   } else {
     overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", key}, std::string(path));
+    for (const auto& mon : allConnectors) {
+      if (mon.empty()) {
+        continue;
+      }
+      overrides.emplace_back(
+          std::vector<std::string>{"wallpaper", "theme_sync", "monitor", mon, key}, std::string(path)
+      );
+    }
   }
   (void)config.setOverrides(std::move(overrides));
 }

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -157,12 +157,12 @@ void wallpaper::setThemeSyncBinding(
   if (!config.config().wallpaper.themeSync.enabled) {
     overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true);
   }
+  overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", key}, std::string(path));
   if (connector.has_value() && !connector->empty()) {
     overrides.emplace_back(
         std::vector<std::string>{"wallpaper", "theme_sync", "monitor", *connector, key}, std::string(path)
     );
   } else {
-    overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", key}, std::string(path));
     for (const auto& mon : allConnectors) {
       if (mon.empty()) {
         continue;

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -148,15 +148,13 @@ void wallpaper::setThemeSyncBinding(
     ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
     std::span<const std::string> allConnectors
 ) {
-  if (path.empty() || (mode != ThemeMode::Light && mode != ThemeMode::Dark)) {
+  if (path.empty() || (mode != ThemeMode::Light && mode != ThemeMode::Dark)
+      || !config.config().wallpaper.themeSync.enabled) {
     return;
   }
 
   const std::string key = mode == ThemeMode::Light ? "path_light" : "path_dark";
   std::vector<std::pair<std::vector<std::string>, ConfigOverrideValue>> overrides;
-  if (!config.config().wallpaper.themeSync.enabled) {
-    overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true);
-  }
   overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", key}, std::string(path));
   if (connector.has_value() && !connector->empty()) {
     overrides.emplace_back(
@@ -173,4 +171,57 @@ void wallpaper::setThemeSyncBinding(
     }
   }
   (void)config.setOverrides(std::move(overrides));
+}
+
+std::vector<std::string> wallpaper::themeSyncConnectorsForGlobalBinding(
+    const std::optional<std::string>& connector, std::span<const std::string> allOutputConnectors
+) {
+  if (connector.has_value() && !connector->empty()) {
+    return {};
+  }
+  std::vector<std::string> connectors;
+  connectors.reserve(allOutputConnectors.size());
+  for (const auto& name : allOutputConnectors) {
+    if (!name.empty()) {
+      connectors.push_back(name);
+    }
+  }
+  return connectors;
+}
+
+bool wallpaper::shouldSeedThemeSyncBinding(const WallpaperThemeSyncConfig& themeSync, bool resolvedIsLight) noexcept {
+  if (!themeSync.enabled) {
+    return false;
+  }
+  return resolvedIsLight ? themeSync.pathLight.empty() : themeSync.pathDark.empty();
+}
+
+ThemeMode wallpaper::themeSyncModeForResolvedAppearance(bool resolvedIsLight) noexcept {
+  return resolvedIsLight ? ThemeMode::Light : ThemeMode::Dark;
+}
+
+void wallpaper::bindThemeSyncForManualPick(
+    ConfigService& config, const std::optional<std::string>& connector, bool resolvedIsLight, std::string_view path,
+    std::span<const std::string> allOutputConnectors
+) {
+  if (path.empty()) {
+    return;
+  }
+  setThemeSyncBinding(
+      config, connector, themeSyncModeForResolvedAppearance(resolvedIsLight), path,
+      themeSyncConnectorsForGlobalBinding(connector, allOutputConnectors)
+  );
+}
+
+void wallpaper::seedThemeSyncBindingIfNeeded(
+    ConfigService& config, bool resolvedIsLight, std::string_view wallpaperPath,
+    std::span<const std::string> allOutputConnectors
+) {
+  if (wallpaperPath.empty() || !shouldSeedThemeSyncBinding(config.config().wallpaper.themeSync, resolvedIsLight)) {
+    return;
+  }
+  setThemeSyncBinding(
+      config, std::nullopt, themeSyncModeForResolvedAppearance(resolvedIsLight), wallpaperPath,
+      themeSyncConnectorsForGlobalBinding(std::nullopt, allOutputConnectors)
+  );
 }

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -1,7 +1,12 @@
 #include "shell/wallpaper/wallpaper_paths.h"
 
+#include "config/config_service.h"
 #include "config/config_types.h"
 #include "util/file_utils.h"
+
+#include <optional>
+#include <utility>
+#include <vector>
 
 ThemeMode wallpaper::effectiveThemeMode(ThemeMode mode, bool isLight) noexcept {
   if (mode == ThemeMode::Auto) {
@@ -49,4 +54,114 @@ std::string wallpaper::resolveGlobalWallpaperDirectory(const WallpaperConfig& co
     return config.directory;
   }
   return FileUtils::expandUserPath(std::string(kDefaultWallpaperDirectory)).string();
+}
+
+namespace {
+
+  [[nodiscard]] const WallpaperThemeSyncMonitorOverride*
+  findThemeSyncMonitorOverride(const WallpaperConfig& config, const WaylandOutput& output) {
+    for (const auto& ovr : config.themeSync.monitorOverrides) {
+      if (outputMatchesSelector(ovr.match, output)) {
+        return &ovr;
+      }
+    }
+    return nullptr;
+  }
+
+  [[nodiscard]] std::optional<std::string>
+  pickThemeSyncPath(const std::string& pathLight, const std::string& pathDark, ThemeMode mode) {
+    if (mode == ThemeMode::Light) {
+      return pathLight.empty() ? std::nullopt : std::make_optional(pathLight);
+    }
+    return pathDark.empty() ? std::nullopt : std::make_optional(pathDark);
+  }
+
+} // namespace
+
+std::optional<std::string>
+wallpaper::resolveThemeSyncPath(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode) {
+  if (!config.themeSync.enabled) {
+    return std::nullopt;
+  }
+
+  if (const auto* ovr = findThemeSyncMonitorOverride(config, output)) {
+    if (auto path = pickThemeSyncPath(ovr->pathLight, ovr->pathDark, mode)) {
+      return path;
+    }
+  }
+
+  return pickThemeSyncPath(config.themeSync.pathLight, config.themeSync.pathDark, mode);
+}
+
+bool wallpaper::hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode) {
+  const auto path = resolveThemeSyncPath(config, output, mode);
+  return path.has_value() && !path->empty();
+}
+
+bool wallpaper::hasGlobalThemeSyncBinding(const WallpaperConfig& config, ThemeMode mode) {
+  if (!config.themeSync.enabled) {
+    return false;
+  }
+  if (mode == ThemeMode::Light) {
+    return !config.themeSync.pathLight.empty();
+  }
+  return !config.themeSync.pathDark.empty();
+}
+
+std::optional<ThemeMode> wallpaper::themeSyncModeForPath(
+    const WallpaperConfig& config, std::string_view path, const std::optional<std::string>& connector
+) {
+  if (!config.themeSync.enabled || path.empty()) {
+    return std::nullopt;
+  }
+
+  const std::string normalized = FileUtils::normalizeWallpaperPath(path);
+  const auto matches = [&](const std::string& bound) {
+    return !bound.empty() && FileUtils::normalizeWallpaperPath(bound) == normalized;
+  };
+
+  if (connector.has_value() && !connector->empty()) {
+    for (const auto& ovr : config.themeSync.monitorOverrides) {
+      if (ovr.match != *connector) {
+        continue;
+      }
+      if (matches(ovr.pathLight)) {
+        return ThemeMode::Light;
+      }
+      if (matches(ovr.pathDark)) {
+        return ThemeMode::Dark;
+      }
+      return std::nullopt;
+    }
+  }
+
+  if (matches(config.themeSync.pathLight)) {
+    return ThemeMode::Light;
+  }
+  if (matches(config.themeSync.pathDark)) {
+    return ThemeMode::Dark;
+  }
+  return std::nullopt;
+}
+
+void wallpaper::setThemeSyncBinding(
+    ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+) {
+  if (path.empty() || (mode != ThemeMode::Light && mode != ThemeMode::Dark)) {
+    return;
+  }
+
+  const std::string key = mode == ThemeMode::Light ? "path_light" : "path_dark";
+  std::vector<std::pair<std::vector<std::string>, ConfigOverrideValue>> overrides;
+  if (!config.config().wallpaper.themeSync.enabled) {
+    overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true);
+  }
+  if (connector.has_value() && !connector->empty()) {
+    overrides.emplace_back(
+        std::vector<std::string>{"wallpaper", "theme_sync", "monitor", *connector, key}, std::string(path)
+    );
+  } else {
+    overrides.emplace_back(std::vector<std::string>{"wallpaper", "theme_sync", key}, std::string(path));
+  }
+  (void)config.setOverrides(std::move(overrides));
 }

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -43,7 +44,8 @@ namespace wallpaper {
   );
 
   void setThemeSyncBinding(
-      ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+      ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
+      std::span<const std::string> allConnectors = {}
   );
 
 } // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -35,8 +35,7 @@ namespace wallpaper {
   [[nodiscard]] std::optional<std::string>
   resolveThemeSyncPath(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
 
-  [[nodiscard]] bool
-  hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
+  [[nodiscard]] bool hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
 
   [[nodiscard]] bool hasGlobalThemeSyncBinding(const WallpaperConfig& config, ThemeMode mode);
 

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -33,8 +33,7 @@ namespace wallpaper {
   [[nodiscard]] std::optional<std::string>
   resolveThemeSyncPath(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
 
-  [[nodiscard]] bool
-  hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
+  [[nodiscard]] bool hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
 
   [[nodiscard]] bool hasGlobalThemeSyncBinding(const WallpaperConfig& config, ThemeMode mode);
 

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -4,11 +4,14 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
+#include <vector>
 
 class ConfigService;
 
 struct WallpaperConfig;
 struct WallpaperMonitorOverride;
+struct WallpaperThemeSyncConfig;
 struct WaylandOutput;
 enum class ThemeMode : std::uint8_t;
 
@@ -43,6 +46,26 @@ namespace wallpaper {
   void setThemeSyncBinding(
       ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
       std::span<const std::string> allConnectors = {}
+  );
+
+  // Returns output connectors to mirror when binding for all outputs; empty for a single monitor.
+  [[nodiscard]] std::vector<std::string> themeSyncConnectorsForGlobalBinding(
+      const std::optional<std::string>& connector, std::span<const std::string> allOutputConnectors
+  );
+
+  [[nodiscard]] bool
+  shouldSeedThemeSyncBinding(const WallpaperThemeSyncConfig& themeSync, bool resolvedIsLight) noexcept;
+
+  [[nodiscard]] ThemeMode themeSyncModeForResolvedAppearance(bool resolvedIsLight) noexcept;
+
+  void bindThemeSyncForManualPick(
+      ConfigService& config, const std::optional<std::string>& connector, bool resolvedIsLight, std::string_view path,
+      std::span<const std::string> allOutputConnectors
+  );
+
+  void seedThemeSyncBindingIfNeeded(
+      ConfigService& config, bool resolvedIsLight, std::string_view wallpaperPath,
+      std::span<const std::string> allOutputConnectors
   );
 
 } // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 
 class ConfigService;
@@ -40,7 +41,8 @@ namespace wallpaper {
   );
 
   void setThemeSyncBinding(
-      ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+      ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
+      std::span<const std::string> allConnectors = {}
   );
 
 } // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -5,11 +5,13 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 class ConfigService;
 
 struct WallpaperConfig;
 struct WallpaperMonitorOverride;
+struct WallpaperThemeSyncConfig;
 struct WaylandOutput;
 enum class ThemeMode : std::uint8_t;
 
@@ -46,6 +48,26 @@ namespace wallpaper {
   void setThemeSyncBinding(
       ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path,
       std::span<const std::string> allConnectors = {}
+  );
+
+  // Returns output connectors to mirror when binding for all outputs; empty for a single monitor.
+  [[nodiscard]] std::vector<std::string> themeSyncConnectorsForGlobalBinding(
+      const std::optional<std::string>& connector, std::span<const std::string> allOutputConnectors
+  );
+
+  [[nodiscard]] bool
+  shouldSeedThemeSyncBinding(const WallpaperThemeSyncConfig& themeSync, bool resolvedIsLight) noexcept;
+
+  [[nodiscard]] ThemeMode themeSyncModeForResolvedAppearance(bool resolvedIsLight) noexcept;
+
+  void bindThemeSyncForManualPick(
+      ConfigService& config, const std::optional<std::string>& connector, bool resolvedIsLight, std::string_view path,
+      std::span<const std::string> allOutputConnectors
+  );
+
+  void seedThemeSyncBindingIfNeeded(
+      ConfigService& config, bool resolvedIsLight, std::string_view wallpaperPath,
+      std::span<const std::string> allOutputConnectors
   );
 
 } // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
+
+class ConfigService;
 
 struct WallpaperConfig;
 struct WallpaperMonitorOverride;
@@ -23,5 +26,24 @@ namespace wallpaper {
   resolveWallpaperDirectory(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
 
   [[nodiscard]] std::string resolveGlobalWallpaperDirectory(const WallpaperConfig& config, ThemeMode mode);
+
+  // Returns a bound wallpaper path for the resolved theme mode, or nullopt when theme sync
+  // is disabled or no binding exists for this output/mode.
+  [[nodiscard]] std::optional<std::string>
+  resolveThemeSyncPath(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
+
+  [[nodiscard]] bool
+  hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
+
+  [[nodiscard]] bool hasGlobalThemeSyncBinding(const WallpaperConfig& config, ThemeMode mode);
+
+  // Returns light/dark when path is bound for theme sync on the given output scope.
+  [[nodiscard]] std::optional<ThemeMode> themeSyncModeForPath(
+      const WallpaperConfig& config, std::string_view path, const std::optional<std::string>& connector
+  );
+
+  void setThemeSyncBinding(
+      ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+  );
 
 } // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
+
+class ConfigService;
 
 struct WallpaperConfig;
 struct WallpaperMonitorOverride;
@@ -20,5 +23,24 @@ namespace wallpaper {
   resolveWallpaperDirectory(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
 
   [[nodiscard]] std::string resolveGlobalWallpaperDirectory(const WallpaperConfig& config, ThemeMode mode);
+
+  // Returns a bound wallpaper path for the resolved theme mode, or nullopt when theme sync
+  // is disabled or no binding exists for this output/mode.
+  [[nodiscard]] std::optional<std::string>
+  resolveThemeSyncPath(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
+
+  [[nodiscard]] bool
+  hasThemeSyncBinding(const WallpaperConfig& config, const WaylandOutput& output, ThemeMode mode);
+
+  [[nodiscard]] bool hasGlobalThemeSyncBinding(const WallpaperConfig& config, ThemeMode mode);
+
+  // Returns light/dark when path is bound for theme sync on the given output scope.
+  [[nodiscard]] std::optional<ThemeMode> themeSyncModeForPath(
+      const WallpaperConfig& config, std::string_view path, const std::optional<std::string>& connector
+  );
+
+  void setThemeSyncBinding(
+      ConfigService& config, const std::optional<std::string>& connector, ThemeMode mode, std::string_view path
+  );
 
 } // namespace wallpaper

--- a/tests/wallpaper_theme_sync_paths_test.cpp
+++ b/tests/wallpaper_theme_sync_paths_test.cpp
@@ -1,10 +1,13 @@
 #include "shell/wallpaper/wallpaper_paths.h"
 
+#include "config/config_service.h"
 #include "config/config_types.h"
 #include "wayland/wayland_connection.h"
 
 #include <cstdio>
+#include <filesystem>
 #include <string>
+#include <unistd.h>
 
 namespace {
 
@@ -99,6 +102,66 @@ int main() {
            "dark tab always binds to dark"
        )
       && ok;
+
+  {
+    WallpaperConfig monitorOnly{};
+    monitorOnly.themeSync.enabled = true;
+    monitorOnly.themeSync.monitorOverrides.push_back(
+        WallpaperThemeSyncMonitorOverride{.match = "DP-1", .pathDark = "/wallpapers/dp-dark.jpg"}
+    );
+    const WaylandOutput dp1 = makeOutput("DP-1");
+
+    ok = expect(
+             wallpaper::resolveThemeSyncPath(monitorOnly, dp1, ThemeMode::Dark) == "/wallpapers/dp-dark.jpg",
+             "monitor-only dark binding resolves for that output"
+         )
+        && ok;
+    ok = expect(
+             !wallpaper::hasGlobalThemeSyncBinding(monitorOnly, ThemeMode::Dark),
+             "monitor-only binding is invisible to global automation guard"
+         )
+        && ok;
+    ok = expect(
+             !wallpaper::themeSyncModeForPath(monitorOnly, "/wallpapers/dp-dark.jpg", std::nullopt).has_value(),
+             "all-monitors badge lookup ignores monitor-only bindings"
+         )
+        && ok;
+  }
+
+  {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("noctalia-theme-sync-bind-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config" / "noctalia");
+    std::filesystem::create_directories(root / "state" / "noctalia");
+    ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+    ::setenv("XDG_STATE_HOME", (root / "state").c_str(), 1);
+
+    ConfigService config;
+    constexpr std::string_view kPath = "/wallpapers/dp-dark.jpg";
+    wallpaper::setThemeSyncBinding(config, std::string{"DP-1"}, ThemeMode::Dark, kPath, {});
+
+    ok = expect(
+             config.config().wallpaper.themeSync.pathDark == kPath,
+             "single-monitor bind also updates global path_dark"
+         )
+        && ok;
+    ok = expect(config.config().wallpaper.themeSync.monitorOverrides.size() == 1, "monitor override stored")
+        && ok;
+    ok = expect(
+             config.config().wallpaper.themeSync.monitorOverrides.front().match == "DP-1"
+                 && config.config().wallpaper.themeSync.monitorOverrides.front().pathDark == kPath,
+             "monitor override matches single-monitor bind"
+         )
+        && ok;
+    ok = expect(
+             wallpaper::hasGlobalThemeSyncBinding(config.config().wallpaper, ThemeMode::Dark),
+             "global automation guard sees single-monitor bind"
+         )
+        && ok;
+
+    std::filesystem::remove_all(root);
+  }
 
   return ok ? 0 : 1;
 }

--- a/tests/wallpaper_theme_sync_paths_test.cpp
+++ b/tests/wallpaper_theme_sync_paths_test.cpp
@@ -77,5 +77,28 @@ int main() {
        )
       && ok;
 
+  const auto bindingModeForTab = [](ThemeMode tab, ThemeMode configured, bool isLight) {
+    if (tab == ThemeMode::Light || tab == ThemeMode::Dark) {
+      return tab;
+    }
+    return wallpaper::effectiveThemeMode(configured, isLight);
+  };
+
+  ok = expect(
+           bindingModeForTab(ThemeMode::Auto, ThemeMode::Auto, false) == ThemeMode::Dark,
+           "auto tab binds wallpaper picks to resolved dark"
+       )
+      && ok;
+  ok = expect(
+           bindingModeForTab(ThemeMode::Auto, ThemeMode::Auto, true) == ThemeMode::Light,
+           "auto tab binds wallpaper picks to resolved light"
+       )
+      && ok;
+  ok = expect(
+           bindingModeForTab(ThemeMode::Dark, ThemeMode::Auto, true) == ThemeMode::Dark,
+           "dark tab always binds to dark"
+       )
+      && ok;
+
   return ok ? 0 : 1;
 }

--- a/tests/wallpaper_theme_sync_paths_test.cpp
+++ b/tests/wallpaper_theme_sync_paths_test.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <string>
 #include <unistd.h>
+#include <vector>
 
 namespace {
 
@@ -139,6 +140,11 @@ int main() {
 
     ConfigService config;
     constexpr std::string_view kPath = "/wallpapers/dp-dark.jpg";
+    ok = expect(
+             config.setOverride(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true),
+             "enable theme sync for bind test"
+         )
+        && ok;
     wallpaper::setThemeSyncBinding(config, std::string{"DP-1"}, ThemeMode::Dark, kPath, {});
 
     ok = expect(
@@ -157,6 +163,135 @@ int main() {
     ok = expect(
              wallpaper::hasGlobalThemeSyncBinding(config.config().wallpaper, ThemeMode::Dark),
              "global automation guard sees single-monitor bind"
+         )
+        && ok;
+
+    std::filesystem::remove_all(root);
+  }
+
+  {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("noctalia-theme-sync-bind-off-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config" / "noctalia");
+    std::filesystem::create_directories(root / "state" / "noctalia");
+    ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+    ::setenv("XDG_STATE_HOME", (root / "state").c_str(), 1);
+
+    ConfigService config;
+    wallpaper::setThemeSyncBinding(config, std::string{"DP-1"}, ThemeMode::Dark, "/wallpapers/dp-dark.jpg", {});
+
+    ok = expect(config.config().wallpaper.themeSync.pathDark.empty(), "bind skipped when theme sync disabled")
+        && ok;
+    ok = expect(!config.config().wallpaper.themeSync.enabled, "theme sync stays disabled") && ok;
+
+    std::filesystem::remove_all(root);
+  }
+
+  ok = expect(
+           wallpaper::themeSyncConnectorsForGlobalBinding(std::nullopt, std::vector<std::string>{"DP-1", "DP-2"})
+               == std::vector<std::string>{"DP-1", "DP-2"},
+           "global bind mirrors all output connectors"
+       )
+      && ok;
+  ok = expect(
+           wallpaper::themeSyncConnectorsForGlobalBinding("DP-1", std::vector<std::string>{"DP-1", "DP-2"}).empty(),
+           "single-monitor bind does not mirror other outputs"
+       )
+      && ok;
+  ok = expect(
+           wallpaper::themeSyncModeForResolvedAppearance(true) == ThemeMode::Light,
+           "resolved light maps to light binding"
+       )
+      && ok;
+  ok = expect(
+           wallpaper::shouldSeedThemeSyncBinding(WallpaperThemeSyncConfig{.enabled = true}, false),
+           "seed allowed when dark binding is empty"
+       )
+      && ok;
+  ok = expect(
+           !wallpaper::shouldSeedThemeSyncBinding(
+               WallpaperThemeSyncConfig{.enabled = true, .pathDark = "/wallpapers/night.jpg"}, false
+           ),
+           "seed skipped when dark binding already exists"
+       )
+      && ok;
+  ok = expect(
+           !wallpaper::shouldSeedThemeSyncBinding(WallpaperThemeSyncConfig{.enabled = false}, false),
+           "seed skipped when theme sync disabled"
+       )
+      && ok;
+
+  {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("noctalia-theme-sync-manual-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config" / "noctalia");
+    std::filesystem::create_directories(root / "state" / "noctalia");
+    ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+    ::setenv("XDG_STATE_HOME", (root / "state").c_str(), 1);
+
+    ConfigService config;
+    constexpr std::string_view kPath = "/wallpapers/manual-dark.jpg";
+    ok = expect(
+             config.setOverride(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true),
+             "enable theme sync for manual-pick test"
+         )
+        && ok;
+
+    const std::vector<std::string> outputs{"DP-1", "DP-2"};
+    wallpaper::bindThemeSyncForManualPick(config, std::nullopt, false, kPath, outputs);
+    ok = expect(config.config().wallpaper.themeSync.pathDark == kPath, "manual global pick updates global dark binding")
+        && ok;
+    ok = expect(config.config().wallpaper.themeSync.monitorOverrides.size() == 2, "manual global pick mirrors monitors")
+        && ok;
+
+    wallpaper::bindThemeSyncForManualPick(config, std::string{"DP-1"}, true, "/wallpapers/manual-light.jpg", outputs);
+    ok = expect(
+             config.config().wallpaper.themeSync.pathLight == "/wallpapers/manual-light.jpg",
+             "manual single-monitor pick updates global light binding"
+         )
+        && ok;
+    const WallpaperThemeSyncMonitorOverride* dp1 = nullptr;
+    for (const auto& ovr : config.config().wallpaper.themeSync.monitorOverrides) {
+      if (ovr.match == "DP-1") {
+        dp1 = &ovr;
+        break;
+      }
+    }
+    ok = expect(dp1 != nullptr && dp1->pathLight == "/wallpapers/manual-light.jpg",
+                "manual single-monitor pick updates only that monitor light binding")
+        && ok;
+
+    std::filesystem::remove_all(root);
+  }
+
+  {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("noctalia-theme-sync-seed-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config" / "noctalia");
+    std::filesystem::create_directories(root / "state" / "noctalia");
+    ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+    ::setenv("XDG_STATE_HOME", (root / "state").c_str(), 1);
+
+    ConfigService config;
+    ok = expect(
+             config.setOverride(std::vector<std::string>{"wallpaper", "theme_sync", "enabled"}, true),
+             "enable theme sync for seed test"
+         )
+        && ok;
+
+    constexpr std::string_view kSeedPath = "/wallpapers/current.jpg";
+    const std::vector<std::string> seedOutputs{"DP-1"};
+    wallpaper::seedThemeSyncBindingIfNeeded(config, false, kSeedPath, seedOutputs);
+    ok = expect(config.config().wallpaper.themeSync.pathDark == kSeedPath, "seed writes dark binding from current wallpaper")
+        && ok;
+
+    wallpaper::seedThemeSyncBindingIfNeeded(config, false, "/wallpapers/other.jpg", seedOutputs);
+    ok = expect(
+             config.config().wallpaper.themeSync.pathDark == kSeedPath,
+             "seed does not overwrite existing dark binding"
          )
         && ok;
 

--- a/tests/wallpaper_theme_sync_paths_test.cpp
+++ b/tests/wallpaper_theme_sync_paths_test.cpp
@@ -1,0 +1,81 @@
+#include "shell/wallpaper/wallpaper_paths.h"
+
+#include "config/config_types.h"
+#include "wayland/wayland_connection.h"
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::fprintf(stderr, "wallpaper_theme_sync_paths_test: %s\n", message);
+      return false;
+    }
+    return true;
+  }
+
+  WaylandOutput makeOutput(std::string connector) {
+    return WaylandOutput{.connectorName = std::move(connector), .description = "test"};
+  }
+
+} // namespace
+
+int main() {
+  WallpaperConfig config{};
+  config.themeSync.enabled = true;
+  config.themeSync.pathLight = "/wallpapers/day.jpg";
+  config.themeSync.pathDark = "/wallpapers/night.jpg";
+
+  const WaylandOutput output = makeOutput("eDP-1");
+  bool ok = true;
+
+  ok = expect(
+           wallpaper::resolveThemeSyncPath(config, output, ThemeMode::Light) == "/wallpapers/day.jpg",
+           "global light binding resolves"
+       )
+      && ok;
+  ok = expect(
+           wallpaper::resolveThemeSyncPath(config, output, ThemeMode::Dark) == "/wallpapers/night.jpg",
+           "global dark binding resolves"
+       )
+      && ok;
+  ok = expect(
+           !wallpaper::resolveThemeSyncPath(config, output, ThemeMode::Light).has_value()
+           || wallpaper::hasThemeSyncBinding(config, output, ThemeMode::Light),
+           "hasThemeSyncBinding matches global light binding"
+       )
+      && ok;
+  ok = expect(wallpaper::hasGlobalThemeSyncBinding(config, ThemeMode::Light), "global light binding detected")
+      && ok;
+
+  config.themeSync.monitorOverrides.push_back(
+      WallpaperThemeSyncMonitorOverride{.match = "eDP-1", .pathLight = "/wallpapers/edp-day.jpg", .pathDark = ""}
+  );
+
+  ok = expect(
+           wallpaper::resolveThemeSyncPath(config, output, ThemeMode::Light) == "/wallpapers/edp-day.jpg",
+           "monitor override wins for light mode"
+       )
+      && ok;
+  ok = expect(
+           wallpaper::resolveThemeSyncPath(config, output, ThemeMode::Dark) == "/wallpapers/night.jpg",
+           "empty monitor override falls back to global dark binding"
+       )
+      && ok;
+  ok = expect(
+           wallpaper::themeSyncModeForPath(config, "/wallpapers/edp-day.jpg", "eDP-1") == ThemeMode::Light,
+           "theme sync badge resolves light binding for monitor"
+       )
+      && ok;
+
+  config.themeSync.enabled = false;
+  ok = expect(
+           !wallpaper::resolveThemeSyncPath(config, output, ThemeMode::Light).has_value(),
+           "disabled theme sync returns no binding"
+       )
+      && ok;
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Add `[wallpaper.theme_sync]` config with global and per-monitor `path_light` / `path_dark` bindings, plus a settings toggle
- Switch wallpapers when the resolved theme changes, with a 150ms startup debounce to avoid double transitions on login
- Assign bindings from the wallpaper panel Dark/Light tabs (and Auto via resolved appearance); theme sync must be enabled in settings first

Closes #1612

## Test plan

- [x] Unit tests (`wallpaper_theme_sync_paths_test`)
- [x] Desktop: `wallpaper-set` updates bindings for resolved mode; theme mode switch applies bound wallpapers
- [x] Global bindings always updated alongside per-monitor overrides
- [x] Manual: wallpaper panel picks on Dark/Light/Auto tabs with theme sync enabled
- [x] Manual: verify startup debounce when theme flips shortly after login


https://github.com/user-attachments/assets/dfb9d412-8148-4492-87a4-68b6edf9a116


Made with [Cursor](https://cursor.com)