### PR TITLE
fix(shell): allow attached placement for panels with fill sizing

### DIFF
--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -634,9 +634,19 @@ void PanelManager::openPanel(const std::string& panelId, PanelOpenRequest reques
     return static_cast<std::int32_t>(std::clamp(desired, static_cast<float>(padding), static_cast<float>(maxValue)));
   };
 
-  PanelPlacement activePlacement = m_activePanel->panelPlacement();
-  const bool fillWidth = m_activePanel->fillsWidth() && activePlacement == PanelPlacement::Floating;
-  const bool fillHeight = m_activePanel->fillsHeight() && activePlacement == PanelPlacement::Floating;
+  const PanelPlacement activePlacement = m_activePanel->panelPlacement();
+  // Fill sizing is floating-only (see Panel::fillsWidth): every other placement sizes the
+  // surface from the panel's preferred extent.
+  const bool floatingPlacement = activePlacement == PanelPlacement::Floating;
+  const bool fillWidth = m_activePanel->fillsWidth() && floatingPlacement;
+  const bool fillHeight = m_activePanel->fillsHeight() && floatingPlacement;
+  if (!floatingPlacement && (m_activePanel->fillsWidth() || m_activePanel->fillsHeight())) {
+    kLog.warn(
+        "panel manager: \"{}\" uses fill sizing, which only applies to floating placement — opening at its preferred "
+        "size",
+        panelId
+    );
+  }
   m_panelFillWidth = fillWidth;
   m_panelFillHeight = fillHeight;
   const bool pluginPanel = m_activePanelId.contains(':');

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -635,12 +635,8 @@ void PanelManager::openPanel(const std::string& panelId, PanelOpenRequest reques
   };
 
   PanelPlacement activePlacement = m_activePanel->panelPlacement();
-  const bool fillWidth = m_activePanel->fillsWidth();
-  const bool fillHeight = m_activePanel->fillsHeight();
-  if ((fillWidth || fillHeight) && activePlacement != PanelPlacement::Floating) {
-    kLog.warn("panel manager: \"{}\" uses fill sizing, which requires floating placement — opening floating", panelId);
-    activePlacement = PanelPlacement::Floating;
-  }
+  const bool fillWidth = m_activePanel->fillsWidth() && activePlacement == PanelPlacement::Floating;
+  const bool fillHeight = m_activePanel->fillsHeight() && activePlacement == PanelPlacement::Floating;
   m_panelFillWidth = fillWidth;
   m_panelFillHeight = fillHeight;
   const bool pluginPanel = m_activePanelId.contains(':');


### PR DESCRIPTION
## Summary

Scopes `fillWidth` and `fillHeight` surface constraints to `Floating` placement mode and removes the forced fallback to floating in `PanelManager::openPanel`.

## Motivation

For plugins using fill sizing such as the `Notes` plugin (`height = "fill"`), setting the panel placement to **"Attached"** in settings had no effect because `PanelManager::openPanel` forced `activePlacement = PanelPlacement::Floating`. Scoping fill sizing to floating mode allows the Notes panel (and any other fill-sized panel) to attach cleanly to the bar when configured as attached, while preserving full-height sidebar behavior when configured as floating.

## Type of Change

- [x] Bug fix

## Testing

- `just build` - compiled successfully
- `just test` - all 89 test suites passed
- `python3 tools/i18n-check.py` - verified 892 translation keys
- `just lint` - 563 files checked with 0 warnings / errors

## Manual Coverage

- [x] Tested on Hyprland

## Screenshots / Videos

**Before:**

https://github.com/user-attachments/assets/85d2f62c-9695-457a-9691-9132d477001d

**After:**

https://github.com/user-attachments/assets/ba006b35-409a-4a09-a061-82be14ff6461

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build and test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not change user-facing configuration schemas.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I haven't faced any edge cases with this as I tested other panels in floating mode and they respect their panel sizes correctly without any conflicts