### PR TITLE
feat(workspaces): add option to disable focus hint icons

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -4243,6 +4243,10 @@
           "description": "Show the widget glyph or custom image",
           "label": "Show Glyph"
         },
+        "show-icons": {
+          "description": "Show the focused app icon on the active pill",
+          "label": "Show Icons"
+        },
         "show-label": {
           "description": "Show the widget's text label",
           "label": "Show Label"

--- a/docs/user/bar/widgets/workspaces.mdx
+++ b/docs/user/bar/widgets/workspaces.mdx
@@ -9,6 +9,7 @@ Workspace switcher with three styles: regular animated pills, minimal labels wit
 
 Labels are controlled by two independent settings: `show_labels` turns them on or off, and `label_source` picks what they say.
 With `show_labels = false`, regular draws unlabeled pills and Focus Hint shows just the focused app icon. Minimal draws no pill backgrounds at all, so its workspaces become blank slots.
+Focus Hint's app icon has its own switch, `show_icons`; turning both off leaves an empty expanded pill for the active workspace.
 
 Workspace pills use the workspaces widget's resolved `capsule_radius`.
 Set `[widget.workspaces].capsule_radius` for just the workspace switcher, or `[bar.<name>].capsule_radius` as the bar default.
@@ -18,6 +19,7 @@ Pill styling and `capsule_radius` apply only when `style = "regular"`.
 |---------|------|---------|-------------|
 | `style` | string | `"regular"` | Pill style: `"regular"` (animated pills), `"minimal"` (labels drawn without pill backgrounds), or `"focus_hint"` (inactive dots + expanded active pill with focused app icon). |
 | `show_labels` | bool | `true` | Draw text labels on workspaces. Minimal renders labels and nothing else, so turning them off leaves its workspaces as empty slots. |
+| `show_icons` | bool | `true` | Draw the focused app icon on the active pill. Focus Hint only; the other styles never draw app icons. |
 | `label_source` | string | `"id"` | What labels show: `"id"` (workspace number, falling back to its name when no numeric identity exists) or `"name"` (workspace name). |
 | `max_label_chars` | int | `1` | Maximum characters for non-numeric workspace labels, including names used as the `"id"` fallback. Numeric labels such as `10` and `11` are never truncated. |
 | `pill_scale` | float | `1.0` | Scale workspace pill thickness (cross-axis size; regular style only). |
@@ -37,6 +39,7 @@ Pill styling and `capsule_radius` apply only when `style = "regular"`.
 [widget.workspaces]
 style = "regular"       # regular | minimal | focus_hint
 show_labels = true      # false = unlabeled pills (Focus Hint: app icon only)
+show_icons = true       # focus_hint only; false = active pill without the focused app icon
 label_source = "id"     # id | name
 max_label_chars = 2     # truncate long workspace names (e.g. "VESKTOP" → "VE")
 labels_only_when_occupied = true  # (1) (2*) ( ) (4) - occupied tags and the active tag show labels (*active but empty)

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -86,12 +86,13 @@ WorkspacesWidget::WorkspacesWidget(
 // Precedence: the master switch wins everywhere, then the style's own annotation
 // rule, then label content, then the occupied filter. FocusHint annotates only the
 // focused workspace, so the occupied filter never applies to it.
+// An empty label still annotates when the focused app icon fills the pill.
 bool WorkspacesWidget::shouldShowWorkspaceLabel(const Workspace& workspace, std::string_view label) const noexcept {
   if (!m_showLabels) {
     return false;
   }
   if (isFocusHint()) {
-    return workspace.active && (!label.empty() || !activeWindowAppId().empty());
+    return workspace.active && (!label.empty() || (m_showIcons && !activeWindowAppId().empty()));
   }
   if (label.empty()) {
     return false;
@@ -111,10 +112,12 @@ void WorkspacesWidget::create() {
   m_container = container.get();
   setRoot(std::move(container));
 
-  m_appIconColorizeConn = shellAppIconColorizationChanged().connect([this]() {
-    m_iconColorizeRefreshPending = true;
-    requestUpdate();
-  });
+  if (showsActiveIcon()) {
+    m_appIconColorizeConn = shellAppIconColorizationChanged().connect([this]() {
+      m_iconColorizeRefreshPending = true;
+      requestUpdate();
+    });
+  }
 }
 
 void WorkspacesWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
@@ -181,7 +184,7 @@ bool WorkspacesWidget::releaseHeldVisualStyles() {
 }
 
 void WorkspacesWidget::doUpdate(Renderer& renderer) {
-  if (m_iconColorizeRefreshPending && isFocusHint() && m_showIcons) {
+  if (m_iconColorizeRefreshPending && showsActiveIcon()) {
     for (auto& item : m_items) {
       syncActiveWindowIcon(renderer, item);
     }
@@ -261,7 +264,7 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
   bool structuralChange = current.size() != m_cachedState.size();
   bool activeChange = false;
   bool hideWhenEmptyTransition = false;
-  if (isFocusHint() && m_showIcons) {
+  if (showsActiveIcon()) {
     const auto desktopVersion = desktopEntriesVersion();
     if (desktopVersion != m_desktopEntriesVersion) {
       buildDesktopIconIndex();
@@ -591,7 +594,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
       item.text->measure(renderer);
     }
 
-    if (isFocusHint() && m_showIcons && ws.active) {
+    if (showsActiveIcon() && ws.active) {
       item.showIcon = true;
       item.icon = static_cast<Image*>(area->addChild(
           ui::image({
@@ -893,7 +896,7 @@ void WorkspacesWidget::recalculateItemMetrics(
   }
 
   ensureItemLabel(renderer, item, workspace);
-  if (isFocusHint() && m_showIcons && workspace.active && item.icon == nullptr && item.area != nullptr) {
+  if (showsActiveIcon() && workspace.active && item.icon == nullptr && item.area != nullptr) {
     item.showIcon = true;
     item.icon = static_cast<Image*>(item.area->addChild(
         ui::image({
@@ -1134,7 +1137,7 @@ void WorkspacesWidget::applyItemLayout(Item& it) {
       && it.currentWidth + 0.5F >= it.inactiveWidth
       && (!isFocusHint() || it.workspace.active);
   const bool showIcon =
-      isFocusHint() && m_showIcons && it.workspace.active && it.showIcon && it.icon != nullptr && it.icon->hasImage();
+      showsActiveIcon() && it.workspace.active && it.showIcon && it.icon != nullptr && it.icon->hasImage();
   if (it.text != nullptr) {
     it.text->setVisible(showText);
   }
@@ -1370,7 +1373,7 @@ std::string WorkspacesWidget::resolveIconPath(const std::string& appId) {
 }
 
 void WorkspacesWidget::syncActiveWindowIcon(Renderer& renderer, Item& item) {
-  if (!isFocusHint() || !m_showIcons || item.icon == nullptr) {
+  if (!showsActiveIcon() || item.icon == nullptr) {
     return;
   }
 

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -73,8 +73,8 @@ WorkspacesWidget::WorkspacesWidget(
 )
     : m_platform(platform), m_configService(config), m_output(output), m_labelSource(options.labelSource),
       m_showLabels(options.showLabels), m_maxLabelChars(options.maxLabelChars),
-      m_labelsOnlyWhenOccupied(options.labelsOnlyWhenOccupied), m_hideWhenEmpty(options.hideWhenEmpty),
-      m_showAllOutputs(options.showAllOutputs), m_pillScale(options.pillScale),
+      m_labelsOnlyWhenOccupied(options.labelsOnlyWhenOccupied), m_showIcons(options.showIcons),
+      m_hideWhenEmpty(options.hideWhenEmpty), m_showAllOutputs(options.showAllOutputs), m_pillScale(options.pillScale),
       m_activePillSize(std::clamp(options.activePillSize, 0.25F, 8.0F)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25F, 8.0F)), m_style(options.style),
       m_focusedOutputOnly(options.focusedOutputOnly), m_changeColorOnHover(options.changeColorOnHover),
@@ -181,7 +181,7 @@ bool WorkspacesWidget::releaseHeldVisualStyles() {
 }
 
 void WorkspacesWidget::doUpdate(Renderer& renderer) {
-  if (m_iconColorizeRefreshPending && isFocusHint()) {
+  if (m_iconColorizeRefreshPending && isFocusHint() && m_showIcons) {
     for (auto& item : m_items) {
       syncActiveWindowIcon(renderer, item);
     }
@@ -261,7 +261,7 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
   bool structuralChange = current.size() != m_cachedState.size();
   bool activeChange = false;
   bool hideWhenEmptyTransition = false;
-  if (isFocusHint()) {
+  if (isFocusHint() && m_showIcons) {
     const auto desktopVersion = desktopEntriesVersion();
     if (desktopVersion != m_desktopEntriesVersion) {
       buildDesktopIconIndex();
@@ -502,7 +502,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
 
     if (isFocusHint()) {
       const float dotSize = focusedPillDotSize();
-      const bool hasIcon = entry.workspace.active && !activeWindowAppId().empty();
+      const bool hasIcon = m_showIcons && entry.workspace.active && !activeWindowAppId().empty();
       if (!entry.workspace.active) {
         slot.inactiveWidth = dotSize;
         slot.activeWidth = dotSize;
@@ -591,7 +591,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
       item.text->measure(renderer);
     }
 
-    if (isFocusHint() && ws.active) {
+    if (isFocusHint() && m_showIcons && ws.active) {
       item.showIcon = true;
       item.icon = static_cast<Image*>(area->addChild(
           ui::image({
@@ -870,7 +870,7 @@ void WorkspacesWidget::recalculateItemMetrics(
     }
   } else if (isFocusHint()) {
     const float dotSize = focusedPillDotSize();
-    const bool hasIcon = workspace.active && !activeWindowAppId().empty();
+    const bool hasIcon = m_showIcons && workspace.active && !activeWindowAppId().empty();
     if (!workspace.active) {
       item.inactiveWidth = dotSize;
       item.activeWidth = dotSize;
@@ -893,7 +893,7 @@ void WorkspacesWidget::recalculateItemMetrics(
   }
 
   ensureItemLabel(renderer, item, workspace);
-  if (isFocusHint() && workspace.active && item.icon == nullptr && item.area != nullptr) {
+  if (isFocusHint() && m_showIcons && workspace.active && item.icon == nullptr && item.area != nullptr) {
     item.showIcon = true;
     item.icon = static_cast<Image*>(item.area->addChild(
         ui::image({
@@ -1134,7 +1134,7 @@ void WorkspacesWidget::applyItemLayout(Item& it) {
       && it.currentWidth + 0.5F >= it.inactiveWidth
       && (!isFocusHint() || it.workspace.active);
   const bool showIcon =
-      isFocusHint() && it.workspace.active && it.showIcon && it.icon != nullptr && it.icon->hasImage();
+      isFocusHint() && m_showIcons && it.workspace.active && it.showIcon && it.icon != nullptr && it.icon->hasImage();
   if (it.text != nullptr) {
     it.text->setVisible(showText);
   }
@@ -1370,7 +1370,7 @@ std::string WorkspacesWidget::resolveIconPath(const std::string& appId) {
 }
 
 void WorkspacesWidget::syncActiveWindowIcon(Renderer& renderer, Item& item) {
-  if (!isFocusHint() || item.icon == nullptr) {
+  if (!isFocusHint() || !m_showIcons || item.icon == nullptr) {
     return;
   }
 

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -93,6 +93,8 @@ private:
   [[nodiscard]] bool shouldShowWorkspaceLabel(const Workspace& workspace, std::string_view label) const noexcept;
   [[nodiscard]] bool isMinimal() const noexcept { return m_style == WorkspacesStyle::Minimal; }
   [[nodiscard]] bool isFocusHint() const noexcept { return m_style == WorkspacesStyle::FocusHint; }
+  // FocusHint is the only style that draws the focused app icon.
+  [[nodiscard]] bool showsActiveIcon() const noexcept { return isFocusHint() && m_showIcons; }
   [[nodiscard]] bool isWorkspaceHidden(const Workspace& workspace) const noexcept;
   void syncWidgetVisibility(bool showWidget);
   void recalculateItemMetrics(Renderer& renderer, Item& item, const Workspace& workspace, std::size_t displayIndex);

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -37,6 +37,7 @@ public:
     WorkspacesStyle style = WorkspacesStyle::Regular;
     WorkspacesLabelSource labelSource = WorkspacesLabelSource::Id;
     bool showLabels = true;
+    bool showIcons = true;
     ColorSpec focusedColor = colorSpecFromRole(ColorRole::Primary);
     ColorSpec occupiedColor = colorSpecFromRole(ColorRole::Secondary);
     ColorSpec emptyColor = colorSpecFromRole(ColorRole::Secondary);
@@ -160,6 +161,7 @@ private:
   bool m_showLabels = true;
   std::size_t m_maxLabelChars = 1;
   bool m_labelsOnlyWhenOccupied = false;
+  bool m_showIcons = true;
   bool m_hideWhenEmpty = false;
   bool m_showAllOutputs = false;
   float m_pillScale = 1.0F;

--- a/src/shell/bar/widgets/workspaces_widget_definition.cpp
+++ b/src/shell/bar/widgets/workspaces_widget_definition.cpp
@@ -24,6 +24,12 @@ namespace {
     return visibility;
   }
 
+  settings::WidgetSettingVisibility focusHintStyleOnly() {
+    settings::WidgetSettingVisibility visibility;
+    visibility.all = {{"style", {"focus_hint"}}};
+    return visibility;
+  }
+
 } // namespace
 
 const noctalia::bar::WidgetDefinition<WorkspacesWidget::Options>& workspacesWidgetDefinition() {
@@ -100,6 +106,14 @@ const noctalia::bar::WidgetDefinition<WorkspacesWidget::Options>& workspacesWidg
                           .descriptionKey = "settings.widgets.settings.max-label-chars.workspaces-description",
                           .group = "workspaces.list",
                           .visibleWhen = labelsShown(),
+                      },
+              }),
+              field<&Options::showIcons>({
+                  .key = "show_icons",
+                  .presentation =
+                      settings::WidgetSettingPresentation{
+                          .group = "workspaces.list",
+                          .visibleWhen = focusHintStyleOnly(),
                       },
               }),
               field<&Options::style>({


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

Added a "Show Icons" toggle to the workspaces widget to control whether icons are drawn in focus hint mode.

## Motivation

<!-- What problem does this solve? -->

I prefer the way inactive workspaces pills are drawn in the focus hint style but don't want the focused app icon to be shown in the active pill. I tried using the regular style and lowering the inactive pill size, but this only affects the width of the inactive pills and leaves them full height. I figured the best way to solve this would be to add a "show icons" setting, similar to the existing "show labels" setting, to allow for the focus hint style pills without showing app icons.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

I made sure both the gui setting and the "show_icons" toml key toggled the app icon, and that the gui setting was only visible when in focus hint mode. I also made sure that icons are shown by default to be consistent with existing behavior.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

https://github.com/user-attachments/assets/b2a9ce96-eac1-4478-a973-80c198fc9189

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
