### PR TITLE
feat(screenshots): use `XDG_PICTURES_DIR` environment variable as default screenshot path

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3008,9 +3008,9 @@
           "label": "Copy to Clipboard"
         },
         "screenshot-directory": {
-          "description": "Folder for saved PNG files; leave empty to use ~/Pictures",
+          "description": "Folder for saved PNG files; leave empty to use the standard XDG Pictures directory",
           "label": "Output Directory",
-          "placeholder": "~/Pictures"
+          "placeholder": "XDG Pictures directory"
         },
         "screenshot-filename-pattern": {
           "description": "strftime pattern without extension (.png is added); use %s for unix epoch",
@@ -3112,7 +3112,7 @@
           "label": "Include Subfolders"
         },
         "directory": {
-          "description": "Folder containing wallpapers",
+          "description": "Folder containing wallpapers; leave empty to use the standard XDG Pictures directory",
           "label": "Wallpaper Directory"
         },
         "directory-dark": {

--- a/example.toml
+++ b/example.toml
@@ -114,7 +114,7 @@ transition          = ["fade", "wipe", "disc", "stripes", "zoom", "honeycomb"]
 transition_duration = 1500          # milliseconds
 edge_smoothness     = 0.3
 transition_on_startup = false       # animate the first wallpaper at shell startup (v4-style)
-directory           = "~/Pictures/Wallpapers"
+directory           = ""              # empty = XDG Pictures directory
 directory_light     = ""            # optional day-mode directory
 directory_dark      = ""            # optional night-mode directory
 

--- a/src/capture/screenshot_service.cpp
+++ b/src/capture/screenshot_service.cpp
@@ -1482,22 +1482,9 @@ void ScreenshotService::onCaptureComplete(
   startNextQueuedCapture();
 }
 
-std::filesystem::path ScreenshotService::defaultPicturesDirectory() const {
-  std::string rawPath;
-  if (const char* xdgPictures = std::getenv("XDG_PICTURES_DIR"); xdgPictures != nullptr && xdgPictures[0] != '\0') {
-    rawPath = xdgPictures;
-  } else if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0') {
-    rawPath = std::string(home) + "/Pictures";
-  } else {
-    return std::filesystem::path("/tmp");
-  }
-
-  return FileUtils::expandUserPath(FileUtils::expandEnvVars(rawPath));
-}
-
 std::filesystem::path ScreenshotService::outputDirectory(const OutputOptions& options) const {
   if (options.directory.empty()) {
-    return defaultPicturesDirectory();
+    return FileUtils::defaultPicturesDirectory();
   }
   return FileUtils::expandUserPath(options.directory);
 }

--- a/src/capture/screenshot_service.cpp
+++ b/src/capture/screenshot_service.cpp
@@ -1483,10 +1483,16 @@ void ScreenshotService::onCaptureComplete(
 }
 
 std::filesystem::path ScreenshotService::defaultPicturesDirectory() const {
-  if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0') {
-    return std::filesystem::path(home) / "Pictures";
+  std::string rawPath;
+  if (const char* xdgPictures = std::getenv("XDG_PICTURES_DIR"); xdgPictures != nullptr && xdgPictures[0] != '\0') {
+    rawPath = xdgPictures;
+  } else if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0') {
+    rawPath = std::string(home) + "/Pictures";
+  } else {
+    return std::filesystem::path("/tmp");
   }
-  return std::filesystem::path("/tmp");
+
+  return FileUtils::expandUserPath(FileUtils::expandEnvVars(rawPath));
 }
 
 std::filesystem::path ScreenshotService::outputDirectory(const OutputOptions& options) const {

--- a/src/capture/screenshot_service.h
+++ b/src/capture/screenshot_service.h
@@ -136,7 +136,6 @@ private:
       std::optional<std::filesystem::path> destPath, wl_output* output
   );
   [[nodiscard]] wl_output* preferredCaptureOutput() const;
-  [[nodiscard]] std::filesystem::path defaultPicturesDirectory() const;
   [[nodiscard]] std::filesystem::path outputDirectory(const OutputOptions& options) const;
   [[nodiscard]] std::filesystem::path
   makeScreenshotPath(const OutputOptions& options, const std::string& labelBase, int suffix = 0) const;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -508,7 +508,7 @@ struct WallpaperConfig {
   float transitionDurationMs = 1500.0F;
   float edgeSmoothness = 0.3F;
   bool transitionOnStartup = false;
-  std::string directory;      // empty = ~/Pictures/Wallpapers
+  std::string directory;      // empty = XDG_PICTURES_DIR
   std::string directoryLight; // empty = directory
   std::string directoryDark;  // empty = directory
   bool perMonitorDirectories = false;
@@ -1042,7 +1042,7 @@ struct ShellConfig {
     bool showCursor = false;
     bool pipeToCommand = false;
     std::string pipeCommand;
-    std::string directory;       // empty = ~/Pictures
+    std::string directory;       // empty = XDG Pictures directory
     std::string filenamePattern; // empty = screenshot_%Y%m%d_%H%M%S
 
     bool operator==(const ScreenshotConfig&) const = default;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -18,6 +18,7 @@
 #include "theme/builtin_palettes.h"
 #include "theme/builtin_templates.h"
 #include "ui/app_icon_colorization.h"
+#include "util/file_utils.h"
 #include "util/string_utils.h"
 
 #include <algorithm>
@@ -629,7 +630,7 @@ namespace settings {
         tr("settings.schema.wallpaper.directory.description"), {"wallpaper", "directory"},
         TextSetting{
             .value = cfg.wallpaper.directory,
-            .placeholder = std::string(wallpaper::kDefaultWallpaperDirectory),
+            .placeholder = FileUtils::defaultPicturesDirectory().string(),
             .browseMode = TextSettingBrowseMode::SelectFolder,
             .browseFileExtensions = {}
         },
@@ -698,7 +699,7 @@ namespace settings {
             monitorPath("directory"),
             TextSetting{
                 .value = ovr != nullptr && ovr->directory.has_value() ? *ovr->directory : "",
-                .placeholder = std::string(wallpaper::kDefaultWallpaperDirectory),
+                .placeholder = FileUtils::defaultPicturesDirectory().string(),
                 .browseMode = TextSettingBrowseMode::SelectFolder,
                 .browseFileExtensions = {}
             },

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -48,5 +48,5 @@ std::string wallpaper::resolveGlobalWallpaperDirectory(const WallpaperConfig& co
   if (!config.directory.empty()) {
     return config.directory;
   }
-  return FileUtils::expandUserPath(std::string(kDefaultWallpaperDirectory)).string();
+  return FileUtils::defaultPicturesDirectory().string();
 }

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <string>
-#include <string_view>
 
 struct WallpaperConfig;
 struct WallpaperMonitorOverride;
@@ -10,8 +9,6 @@ struct WaylandOutput;
 enum class ThemeMode : std::uint8_t;
 
 namespace wallpaper {
-
-  inline constexpr std::string_view kDefaultWallpaperDirectory = "~/Pictures/Wallpapers";
 
   // Maps theme.mode=auto to the currently resolved light/dark appearance.
   [[nodiscard]] ThemeMode effectiveThemeMode(ThemeMode mode, bool isLight) noexcept;

--- a/src/util/file_utils.h
+++ b/src/util/file_utils.h
@@ -109,6 +109,125 @@ namespace FileUtils {
     return out;
   }
 
+  // Resolves the user's standard Pictures directory. The environment override is
+  // useful for shells that export xdg-user-dirs values; the config-file lookup
+  // covers the normal xdg-user-dirs setup.
+  [[nodiscard]] inline std::filesystem::path defaultPicturesDirectory() {
+    const auto containsUndefinedVariable = [](std::string_view raw) {
+      const auto isNameStart = [](char c) { return (std::isalpha(static_cast<unsigned char>(c)) != 0) || c == '_'; };
+      const auto isNameChar = [](char c) { return (std::isalnum(static_cast<unsigned char>(c)) != 0) || c == '_'; };
+
+      for (std::size_t i = 0; i < raw.size();) {
+        if (raw[i] != '$') {
+          ++i;
+          continue;
+        }
+        if (i + 1 < raw.size() && raw[i + 1] == '{') {
+          const std::size_t close = raw.find('}', i + 2);
+          if (close == std::string_view::npos) {
+            ++i;
+            continue;
+          }
+          const std::string name(raw.substr(i + 2, close - (i + 2)));
+          const char* value = std::getenv(name.c_str());
+          if (value == nullptr || value[0] == '\0') {
+            return true;
+          }
+          i = close + 1;
+          continue;
+        }
+        if (i + 1 < raw.size() && isNameStart(raw[i + 1])) {
+          std::size_t end = i + 2;
+          while (end < raw.size() && isNameChar(raw[end])) {
+            ++end;
+          }
+          const std::string name(raw.substr(i + 1, end - (i + 1)));
+          const char* value = std::getenv(name.c_str());
+          if (value == nullptr || value[0] == '\0') {
+            return true;
+          }
+          i = end;
+          continue;
+        }
+        ++i;
+      }
+      return false;
+    };
+
+    const auto resolveExpanded = [&](std::string_view raw) {
+      if (raw.empty() || containsUndefinedVariable(raw)) {
+        return std::filesystem::path{};
+      }
+      const std::filesystem::path resolved = expandUserPath(expandEnvVars(raw));
+      return resolved.is_absolute() ? resolved : std::filesystem::path{};
+    };
+
+    if (const char* xdgPictures = std::getenv("XDG_PICTURES_DIR"); xdgPictures != nullptr && xdgPictures[0] != '\0') {
+      if (const std::filesystem::path resolved = resolveExpanded(xdgPictures); !resolved.empty()) {
+        return resolved;
+      }
+    }
+
+    const char* home = std::getenv("HOME");
+    if (home == nullptr || home[0] == '\0') {
+      return std::filesystem::path("/tmp");
+    }
+    const std::filesystem::path homePath(home);
+    if (!homePath.is_absolute()) {
+      return std::filesystem::path("/tmp");
+    }
+
+    std::filesystem::path configHome = homePath / ".config";
+    if (const char* xdgConfig = std::getenv("XDG_CONFIG_HOME"); xdgConfig != nullptr && xdgConfig[0] != '\0') {
+      const std::filesystem::path candidate(xdgConfig);
+      if (candidate.is_absolute()) {
+        configHome = candidate;
+      }
+    }
+
+    std::ifstream userDirs(configHome / "user-dirs.dirs");
+    std::string line;
+    constexpr std::string_view key = "XDG_PICTURES_DIR";
+    while (std::getline(userDirs, line)) {
+      const std::size_t keyStart = line.find_first_not_of(" \t");
+      if (keyStart == std::string::npos || line.compare(keyStart, key.size(), key) != 0) {
+        continue;
+      }
+      const std::size_t equals = keyStart + key.size();
+      if (equals >= line.size() || line[equals] != '=') {
+        continue;
+      }
+      const std::size_t valueStart = line.find_first_not_of(" \t", equals + 1);
+      if (valueStart == std::string::npos || line[valueStart] != '"') {
+        continue;
+      }
+
+      std::string value;
+      bool terminated = false;
+      for (std::size_t i = valueStart + 1; i < line.size(); ++i) {
+        if (line[i] == '"') {
+          terminated = true;
+          break;
+        }
+        if (line[i] == '\\' && i + 1 < line.size()) {
+          ++i;
+        }
+        value.push_back(line[i]);
+      }
+      if (!terminated) {
+        continue;
+      }
+      if (value.starts_with("$HOME/")) {
+        return homePath / value.substr(6);
+      }
+      if (!value.empty() && value[0] == '/') {
+        return std::filesystem::path(value);
+      }
+    }
+
+    return homePath / "Pictures";
+  }
+
   // Expand XDG base-directory tokens ($XDG_CONFIG_HOME, etc.) to absolute paths
   // using the same spec-aware resolution as the template engine.
   [[nodiscard]] inline std::string expandXdgBaseDir(const std::string& path) {


### PR DESCRIPTION
## Summary
This PR replaces the default screenshot directory. First, `XDG_PICTURES_DIR` environment variable is checked, then it falls back to `$HOME/Pictures`, then `/tmp`. 

## Motivation

Respects the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/) for [user directories](https://www.freedesktop.org/wiki/Software/xdg-user-dirs). Users who customize `XDG_PICTURES_DIR` will have screenshots saved to their preferred directory without needing to change it manually. 

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3415

## Testing
### Commands run
1. Ran `just format`, `just build` and `just run`
2. Ran the debug binary directly after killing noctalia process

### Verification
Tested with the following:
- XDG variable set as `/home/user/dir`
- XDG variable set as `$HOME/dir`
- XDG variable set as `~/dir`
- Empty XDG string
- XDG variable unset and HOME set: uses `$HOME/Pictures`
- Both unset: uses `/tmp`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- This should be enough for most users since people who use xdg-user-dirs will have `XDG_PICTURES_DIR` exported for use. 
- Also will work for users who manually set the environment variable.
- Support for `XDG_SCREENSHOTS_DIR` could also be added in the same manner but it is not used as frequently.