### PR TITLE
fix(time): improve timezone handling

### DIFF
--- a/src/time/time_format.cpp
+++ b/src/time/time_format.cpp
@@ -209,8 +209,8 @@ std::string formatLocalTime(const char* fmt) {
     return *compat;
   }
 
+  const auto local = local_seconds{seconds{raw + localTm.tm_gmtoff}};
   try {
-    const auto local = current_zone()->to_local(now);
     return std::vformat(std::locale(""), normalizedFmt, std::make_format_args(local));
   } catch (...) {
     return normalizedFmt;
@@ -306,8 +306,8 @@ std::string formatLocalUnixTime(std::int64_t unixSeconds, std::string_view fmt) 
     return *compat;
   }
 
+  const auto local = local_seconds{seconds{raw + localTm.tm_gmtoff}};
   try {
-    const auto local = current_zone()->to_local(tp);
     return std::vformat(std::locale(""), normalizedFmt, std::make_format_args(local));
   } catch (...) {
     return normalizedFmt;

--- a/src/time/time_format.cpp
+++ b/src/time/time_format.cpp
@@ -83,13 +83,42 @@ namespace {
     return fmt.contains("%-") || (fmt.contains('%') && (!fmt.contains('{') || fmt.contains("{:")));
   }
 
+  // musl's strftime resolves %Z from its own timezone state and ignores tm_zone, so the
+  // abbreviation is interpolated into the spec before strftime ever sees it.
+  std::string substituteTzAbbrev(std::string_view fmt, const char* abbrev) {
+    if (!fmt.contains("%Z") || abbrev == nullptr) {
+      return std::string{fmt};
+    }
+    std::string out;
+    out.reserve(fmt.size());
+    for (std::size_t i = 0; i < fmt.size();) {
+      if (fmt[i] != '%' || i + 1 >= fmt.size()) {
+        out.push_back(fmt[i++]);
+      } else if (fmt[i + 1] == '%') {
+        out.append("%%");
+        i += 2;
+      } else if (fmt[i + 1] == 'Z') {
+        // The abbreviation becomes part of a strftime spec, so its own '%' must stay literal.
+        for (const char* c = abbrev; *c != '\0'; ++c) {
+          if (*c == '%') {
+            out.push_back('%');
+          }
+          out.push_back(*c);
+        }
+        i += 2;
+      } else {
+        out.push_back(fmt[i++]);
+      }
+    }
+    return out;
+  }
+
   std::string formatStrftimeRaw(std::string_view fmt, const std::tm& tm) {
-    std::string spec(fmt);
+    const std::string spec = substituteTzAbbrev(fmt, tm.tm_zone);
     std::size_t size = std::max<std::size_t>(64, spec.size() * 4 + 16);
     for (int attempt = 0; attempt < 6; ++attempt) {
       std::string buffer(size, '\0');
-      std::tm copy = tm;
-      const std::size_t written = std::strftime(buffer.data(), buffer.size(), spec.c_str(), &copy);
+      const std::size_t written = std::strftime(buffer.data(), buffer.size(), spec.c_str(), &tm);
       if (written > 0 || spec.empty()) {
         buffer.resize(written);
         return buffer;
@@ -266,10 +295,8 @@ std::string formatTimezoneUnixTime(std::int64_t unixSeconds, std::string_view fm
   tm.tm_wday = weekday(localDays).c_encoding();
   tm.tm_yday = static_cast<int>((localDays - local_days{ymd.year() / January / 1}).count());
   tm.tm_isdst = zoneInfo.save != minutes::zero();
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
   tm.tm_gmtoff = static_cast<long>(zoneInfo.offset.count());
   tm.tm_zone = zoneInfo.abbrev.c_str();
-#endif
 
   if (auto compat = formatStrftimeCompat(normalizedFmt, tm, unixSeconds)) {
     return *compat;

--- a/tests/time_format_test.cpp
+++ b/tests/time_format_test.cpp
@@ -2,6 +2,7 @@
 #include "time/time_format.h"
 
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <format>
@@ -66,6 +67,11 @@ int main() {
            "formats configured timezone offset and abbreviation"
        )
       && ok;
+  ok = expectEqual(
+           formatTimezoneTime("{:%Z}", kiritimati->name()), formatTimezoneTime("%Z", kiritimati->name()),
+           "renders the zone abbreviation the same in a chrono field as in a bare spec"
+       )
+      && ok;
   const std::string formattedUtcDay = formatTimezoneTime("%j", "UTC");
   const auto afterTimezoneFormat = floor<seconds>(system_clock::now());
   const bool utcDayMatches =
@@ -75,5 +81,20 @@ int main() {
   ok = expectEqual(formatDuration(1min), "1 minute", "formats singular minute") && ok;
   ok = expectEqual(formatDuration(2h + 1min), "2 hours 1 minute", "formats hours and minutes") && ok;
   ok = expectEqual(formatDuration(24h + 1h + 1min), "1 day 1 hour 1 minute", "formats days hours and minutes") && ok;
+
+  // Both rendering paths must report the same local time: a %-spec goes through strftime, a bare
+  // {} through std::format. Deriving the offset from one clock keeps them on the configured zone.
+  ::setenv("TZ", "Asia/Kathmandu", 1);
+  ::tzset();
+  constexpr std::int64_t kFixedStamp = 1700000000; // 2023-11-14T22:13:20Z, +05:45 in Kathmandu.
+  ok = expectEqual(
+           formatLocalUnixTime(kFixedStamp, "%Y-%m-%d %H:%M:%S"), "2023-11-15 03:58:20",
+           "strftime path honors the configured timezone"
+       )
+      && ok;
+  ok = expectEqual(
+           formatLocalUnixTime(kFixedStamp, "{}"), "2023-11-15 03:58:20", "chrono path honors the configured timezone"
+       )
+      && ok;
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

On some systems having a certain time format string causes a crash.

This is because when using libc++ you can run into an issue where
current_zone() in libc++ throws an uncaught runtime exception for certain valid
timezone configurations. For example, musl users may have a POSIX string for
their $TZ and no /etc/localtime, which is fine for POSIX functions but not for
libc++. libstdc++ sidesteps this because it has a hard fallback to UTC.

My fix is to not use current_zone(), and instead use the timezone that was
already retrieved from the localtime_r() call.

I also improved time format handling on musl systems by handling %Z
substitution manually for configured timezones instead of just using
strftime(). This fixes a bug on musl systems, and allows the existing tests to
start passing.

## Motivation

<!-- What problem does this solve? -->

Improves stability for more systems.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

Fixes #4028 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

I manually tested to make sure the crash no longer occurs for the once-problematic format specifiers. I also manually tested %Z works with a set timezone whereas it didn't before.
`meson test time_format` was failing on my musl system before these changes, now it passes.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
