### PR TITLE
fix(brightness): honor explicit backlight mapping fallback

### DIFF
--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -803,7 +803,7 @@ struct BrightnessService::Impl {
       const WaylandOutput* output = findOutputByConnector(wayland, connectorName);
 
       // Honor an explicit output-to-backlight mapping when automatic DRM/sysfs connector discovery fails.
-      if (connectorName.empty() || output == nullptr) {
+      if (!resolution.exactDrmMatch || connectorName.empty() || output == nullptr) {
         for (const auto& candidateOutput : wayland.outputs()) {
           if (!candidateOutput.done || candidateOutput.connectorName.empty()) {
             continue;

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -798,9 +798,36 @@ struct BrightnessService::Impl {
         continue;
       }
 
-      const BacklightConnectorResolution resolution = resolveBacklightConnector(path, wayland);
-      const std::string& connectorName = resolution.connectorName;
+      BacklightConnectorResolution resolution = resolveBacklightConnector(path, wayland);
+      std::string connectorName = resolution.connectorName;
       const WaylandOutput* output = findOutputByConnector(wayland, connectorName);
+
+      // Honor an explicit output-to-backlight mapping when automatic DRM/sysfs connector discovery fails.
+      if (connectorName.empty() || output == nullptr) {
+        for (const auto& candidateOutput : wayland.outputs()) {
+          if (!candidateOutput.done || candidateOutput.connectorName.empty()) {
+            continue;
+          }
+
+          const auto explicitDevice = backlightDeviceForOutput(activeConfig, &candidateOutput);
+          if (!explicitDevice.has_value() || extractBacklightDeviceName(*explicitDevice) != name) {
+            continue;
+          }
+
+          const BrightnessBackendPreference explicitPreference =
+              backendPreferenceForOutput(activeConfig, &candidateOutput);
+          if (explicitPreference == BrightnessBackendPreference::None
+              || explicitPreference == BrightnessBackendPreference::Ddcutil) {
+            continue;
+          }
+
+          connectorName = candidateOutput.connectorName;
+          output = &candidateOutput;
+          resolution.exactDrmMatch = false;
+          kLog.info("using explicitly configured backlight '{}' for connector {}", name, connectorName);
+          break;
+        }
+      }
 
       if (connectorName.empty() || output == nullptr) {
         kLog.debug("skipping backlight '{}' because it could not be matched to an active output", name);


### PR DESCRIPTION
## Summary

- Fall back to the configured per-output `backlight_device` when automatic DRM/sysfs connector discovery cannot match a backlight to an active output.
- Keep automatic connector resolution unchanged when it succeeds.
- Continue honoring `none` and `ddcutil` backend preferences during fallback selection.

## Motivation

Platform backlights do not necessarily have a DRM connector in their sysfs ancestry. On a ClockworkPi uConsole, the internal display uses this topology:

```text
Wayland output: DSI-2
Backlight: /sys/class/backlight/backlight@0
Resolved device: /sys/devices/platform/backlight@0/backlight/backlight@0
Driver: ocp8178-backlight
```

The output is explicitly configured:

```toml
[brightness.monitor.DSI-2]
backend = "backlight"
backlight_device = "/sys/class/backlight/backlight@0"
```

However, backlight enumeration currently skips the device when automatic connector resolution fails, before consulting `backlight_device`. This means the explicit mapping cannot recover from the missing DRM ancestry.

This change consults active outputs for a matching explicit device only after automatic discovery fails. The selected candidate remains marked as a fallback rather than an exact DRM match.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Related context: #1898, #1899, and #3160.

## Testing

Commands run on current `main`:

```sh
just format
just configure
just build
just test
git diff --check
```

Results:

- Formatted with clang-format 22.1.8.
- Full test suite passed: 91/91 tests.
- The identical source change was applied to the v5.0.0-beta.9 release, built as an aarch64 release package, and installed on Arch Linux ARM.
- Verified on a ClockworkPi uConsole under Niri 26.04. Brightness adjustment works after restart.
- Startup logs confirm the fallback path:

```text
[brightness] using explicitly configured backlight 'backlight@0' for connector DSI-2
[brightness] found backlight candidate 'backlight@0' type='raw' current=11% connector=DSI-2 match=fallback
[brightness] selected backlight 'backlight@0' type='raw' connector=DSI-2 match=fallback
```

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Not applicable; this change has no visual UI component.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No new configuration key or user-facing string is introduced. This fixes fallback handling for the existing per-monitor `backlight_device` option.