### PR TITLE
fix(mango,niri) remove shadow from niri and mango templates

### DIFF
--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -7,7 +7,6 @@ local secondary = "rgb({{colors.secondary.default.hex_stripped}})"
 local on_secondary = "rgb({{colors.on_secondary.default.hex_stripped}})"
 local error = "rgb({{colors.error.default.hex_stripped}})"
 local on_error = "rgb({{colors.on_error.default.hex_stripped}})"
-local shadow = "rgb({{colors.shadow.default.hex_stripped}})"
 
 local function apply_theme()
     hl.config({
@@ -51,7 +50,6 @@ return {
         on_secondary = on_secondary,
         error = error,
         on_error = on_error,
-        shadow = shadow,
     },
     apply_theme = apply_theme
 }

--- a/assets/templates/mango/mango.conf
+++ b/assets/templates/mango/mango.conf
@@ -1,7 +1,6 @@
 # Noctalia Theme for Mango
 # Generated automatically by Noctalia
 
-shadowscolor = 0x{{colors.shadow.default.hex_stripped}}ff
 rootcolor = 0x{{colors.surface.default.hex_stripped}}ff
 bordercolor = 0x{{colors.outline.default.hex_stripped}}ff
 dropcolor = 0x{{colors.primary.default.hex_stripped}}80

--- a/assets/templates/niri/niri.kdl
+++ b/assets/templates/niri/niri.kdl
@@ -12,9 +12,6 @@ layout {
         urgent-color   "{{colors.error.default.hex}}"
     }
 
-    shadow {
-        color "{{colors.shadow.default.hex}}70"
-    }
 
     tab-indicator {
         active-color   "{{colors.primary.default.hex}}"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Removes shadow from Niri and Mango templates, as well as the now unneeded variables in https://github.com/noctalia-dev/noctalia/commit/7fd9f7bfa9604022b9de311b30a3da0c2c4415de 

## Motivation

Per https://github.com/noctalia-dev/noctalia/commit/7fd9f7bfa9604022b9de311b30a3da0c2c4415de, The shadow in the light mode themes does the same in Mango, and Niri, as it did in Hyprland. This removes those so it can be more consistent.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging


## Testing

Pretty much just removing these lines in Niri, Mango and Hyprland's configs.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [X] Tested on another compositor: Mango
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
