### PR TITLE
fix(nix): wrap gsettings-desktop-schemas

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -41,6 +41,7 @@
   jemalloc,
   makeWrapper,
   git,
+  gsettings-desktop-schemas,
   autoAddDriverRunpath,
   # DEPRECATED: no longer affects the build; kept for `.override` compat.
   cudaSupport ? config.cudaSupport,
@@ -68,7 +69,8 @@ lib.warnIf cudaSupport
 
   postFixup = ''
     wrapProgram $out/bin/noctalia \
-      --prefix PATH : ${lib.makeBinPath [ git ]}
+      --prefix PATH : ${lib.makeBinPath [ git ]} \
+      --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
 
     $out/bin/noctalia completions bash | install -D /dev/stdin $out/share/bash-completion/completions/noctalia
     $out/bin/noctalia completions zsh  | install -D /dev/stdin $out/share/zsh/site-functions/_noctalia

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -70,7 +70,7 @@ lib.warnIf cudaSupport
   postFixup = ''
     wrapProgram $out/bin/noctalia \
       --prefix PATH : ${lib.makeBinPath [ git ]} \
-      --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
+      --prefix XDG_DATA_DIRS : "${glib.getSchemaDataDirPath gsettings-desktop-schemas}"
 
     $out/bin/noctalia completions bash | install -D /dev/stdin $out/share/bash-completion/completions/noctalia
     $out/bin/noctalia completions zsh  | install -D /dev/stdin $out/share/zsh/site-functions/_noctalia


### PR DESCRIPTION
## Summary

Prefix `gsettings-desktop-schemas` onto `XDG_DATA_DIRS` in the existing
`wrapProgram` (same pattern as `git` on `PATH`).

## Motivation

Tray `IconName` lookup uses GSettings (`org.gnome.desktop.interface`).
glib does not ship that schema. On NixOS without GNOME it is also not
on the session profile, so IconResolver only searches hicolor.

Apps that advertise a themed name and no pixmap (e.g. Solaar
`battery-090`) then miss and the tray falls back to the `menu-2` glyph.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

None open that I could find. Closest prior report is #2859 (hamburger
after a restart); that was SNI re-registration, not schema lookup.

## Testing

- `nix build .#default`
- Wrapper prefixes
  `…/gsettings-desktop-schemas-*/share/gsettings-schemas/…`
- `gsettings get org.gnome.desktop.interface icon-theme` is
  `No schemas installed` without the prefix, `'Papirus-Dark'` with it
- Replaced the running user unit with the built binary on niri: Solaar
  still published `IconName=battery-090`, tray showed the Papirus
  battery glyph instead of `menu-2`

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

Happy to attach a before/after of the tray (hamburger → battery).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

nixpkgs GNOME packaging (`doc/languages-frameworks/gnome.section.md`)
would normally use `wrapGAppsNoGuiHook` so the glib setup hook can put
`GSETTINGS_SCHEMAS_PATH` on `XDG_DATA_DIRS`.

This package already `wrapProgram`s for `git`. Using that hook here
means `dontWrapGApps` plus splicing `gappsWrapperArgs` into the existing
wrapper, and it also injects `$out/share`, default `/usr/share`, and
`dconf.lib` on `GIO_EXTRA_MODULES`. One explicit `--prefix XDG_DATA_DIRS`
is the single path we need, same style as the git wrap.
