### PR TITLE
feat(calendar): Fade passed events in calendar view

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1132,6 +1132,7 @@ if build_tests
     'caldav_client',
     'calendar_credential_store',
     'calendar_discovery_state',
+    'calendar_view_passed_event',
     'capsule_group_lane_override',
     'capsule_group_reconcile',
     'clipboard_service',

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -20,6 +20,7 @@
 #include "ui/controls/scroll_view.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <memory>
 #include <string_view>
@@ -307,9 +308,16 @@ void CalendarTab::doUpdate(Renderer& renderer) {
 
 void CalendarTab::setActive(bool active) {
   if (!active) {
+    m_eventFadeTimer.stop();
     return;
   }
   focusToday();
+  if (!m_eventFadeTimer.active()) {
+    m_eventFadeTimer.startRepeating(std::chrono::minutes{1}, [this]() {
+      m_eventsDirty = true;
+      PanelManager::instance().refresh();
+    });
+  }
 }
 
 void CalendarTab::focusToday() {
@@ -325,6 +333,7 @@ void CalendarTab::focusToday() {
 }
 
 void CalendarTab::onClose() {
+  m_eventFadeTimer.stop();
   cancelMonthSlide();
   m_rootLayout = nullptr;
   m_calendarArea = nullptr;

--- a/src/shell/control_center/tabs/calendar_tab.h
+++ b/src/shell/control_center/tabs/calendar_tab.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/timer_manager.h"
 #include "render/animation/animation_manager.h"
 #include "shell/control_center/tab.h"
 #include "ui/controls/calendar_view.h"
@@ -74,4 +75,5 @@ private:
   AnimationManager::Id m_monthSlideAnimId = 0;
   bool m_showEventsCard = true;
   bool m_showWeekNumbers = false;
+  Timer m_eventFadeTimer;
 };

--- a/src/ui/controls/calendar_view.cpp
+++ b/src/ui/controls/calendar_view.cpp
@@ -54,9 +54,30 @@ namespace {
 
   constexpr float kPassedEventAlpha = 0.55F;
 
+  std::chrono::system_clock::time_point nextLocalMidnight(std::chrono::system_clock::time_point time) {
+    const std::time_t raw = std::chrono::system_clock::to_time_t(time);
+    std::tm local{};
+    if (localtime_r(&raw, &local) == nullptr) {
+      return time + std::chrono::hours{24};
+    }
+    local.tm_hour = 0;
+    local.tm_min = 0;
+    local.tm_sec = 0;
+    ++local.tm_mday;
+    local.tm_isdst = -1;
+    const std::time_t next = std::mktime(&local);
+    return next == static_cast<std::time_t>(-1) ? time + std::chrono::hours{24}
+                                                : std::chrono::system_clock::from_time_t(next);
+  }
+
   std::chrono::system_clock::time_point eventEndInstant(const CalendarEvent& event) {
-    const auto minEnd = event.allDay ? event.start + std::chrono::hours{24} : event.start;
-    return std::max(event.end, minEnd);
+    if (!event.allDay) {
+      return std::max(event.end, event.start);
+    }
+    if (event.end > event.start) {
+      return event.end;
+    }
+    return nextLocalMidnight(event.start);
   }
 
   int localDateKey(std::chrono::system_clock::time_point time) {

--- a/src/ui/controls/calendar_view.cpp
+++ b/src/ui/controls/calendar_view.cpp
@@ -52,6 +52,13 @@ namespace {
 #endif
   }
 
+  constexpr float kPassedEventAlpha = 0.55F;
+
+  std::chrono::system_clock::time_point eventEndInstant(const CalendarEvent& event) {
+    const auto minEnd = event.allDay ? event.start + std::chrono::hours{24} : event.start;
+    return std::max(event.end, minEnd);
+  }
+
   int localDateKey(std::chrono::system_clock::time_point time) {
     const std::time_t raw = std::chrono::system_clock::to_time_t(time);
     std::tm value{};
@@ -68,15 +75,15 @@ namespace {
     return {start, std::max(start, localDateKey(endTime))};
   }
 
-  ColorSpec eventColor(const CalendarEvent& event) {
-    Color color;
-    if (!event.colorHex.empty() && tryParseHexColor(event.colorHex, color)) {
-      return fixedColorSpec(color);
+  ColorSpec eventColor(const CalendarEvent& event, float alpha = 1.0F) {
+    ColorSpec spec = colorSpecFromRole(ColorRole::Primary);
+    if (Color color; !event.colorHex.empty() && tryParseHexColor(event.colorHex, color)) {
+      spec = fixedColorSpec(color);
+    } else if (const auto role = colorRoleFromToken(event.colorHex); role.has_value()) {
+      spec = colorSpecFromRole(*role);
     }
-    if (const auto role = colorRoleFromToken(event.colorHex); role.has_value()) {
-      return colorSpecFromRole(*role);
-    }
-    return colorSpecFromRole(ColorRole::Primary);
+    spec.alpha = alpha;
+    return spec;
   }
 
   std::unique_ptr<Flex> spacer(float width, float height) {
@@ -109,6 +116,10 @@ namespace calendar_view {
   }
 
   int dateKey(Date date) noexcept { return date.year * 10000 + (date.month + 1) * 100 + date.day; }
+
+  bool eventPassed(const CalendarEvent& event, std::chrono::system_clock::time_point now) {
+    return eventEndInstant(event) < now;
+  }
 
   void rebuildMonth(const MonthBuildOptions& options) {
     uiAssertNotRendering("calendar_view::rebuildMonth");
@@ -180,12 +191,14 @@ namespace calendar_view {
     if (options.snapshot != nullptr) {
       const int firstKey = dateKey({.year = year, .month = month, .day = 1});
       const int lastKey = dateKey({.year = year, .month = month, .day = monthDays});
+      const auto now = std::chrono::system_clock::now();
       for (const CalendarEvent& event : options.snapshot->events) {
         const auto [eventStart, eventEnd] = eventDayRange(event);
         if (eventEnd < firstKey || eventStart > lastKey) {
           continue;
         }
-        const ColorSpec color = eventColor(event);
+        const float eventAlpha = eventPassed(event, now) ? kPassedEventAlpha : 1.0F;
+        const ColorSpec color = eventColor(event, eventAlpha);
         for (int day = 1; day <= monthDays; ++day) {
           const int key = dateKey({.year = year, .month = month, .day = day});
           auto& dots = eventDots[static_cast<std::size_t>(day)];
@@ -399,6 +412,7 @@ namespace calendar_view {
     const float linkGlyphSize = Style::fontSizeCaption * options.scale;
     const float linkGlyphGap = Style::spaceXs * options.scale;
     const int selectedKey = dateKey(options.selected);
+    const auto now = std::chrono::system_clock::now();
     bool hasEvents = false;
     if (options.snapshot != nullptr) {
       for (const CalendarEvent& event : options.snapshot->events) {
@@ -410,6 +424,7 @@ namespace calendar_view {
         const bool hasLink = options.state != nullptr && !event.url.empty();
         const float timeMaxWidth =
             hasLink ? std::max(40.0F, textMaxWidth - linkGlyphSize - linkGlyphGap) : textMaxWidth;
+        const float eventAlpha = eventPassed(event, now) ? kPassedEventAlpha : 1.0F;
 
         std::string timeText;
         if (event.allDay) {
@@ -423,7 +438,7 @@ namespace calendar_view {
             .text = timeText,
             .fontSize = Style::fontSizeCaption * options.scale,
             .fontFamily = options.fontFamily,
-            .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+            .color = colorSpecFromRole(ColorRole::OnSurfaceVariant, eventAlpha),
             .maxWidth = timeMaxWidth,
             .maxLines = 1,
         });
@@ -434,7 +449,7 @@ namespace calendar_view {
               ui::glyph({
                   .glyph = "external-link",
                   .glyphSize = linkGlyphSize,
-                  .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                  .color = colorSpecFromRole(ColorRole::OnSurfaceVariant, eventAlpha),
                   .flexGrow = 0.0F,
               })
           );
@@ -446,7 +461,7 @@ namespace calendar_view {
                 .text = event.title.empty() ? i18n::tr("control-center.calendar.events") : event.title,
                 .fontSize = Style::fontSizeBody * options.scale,
                 .fontFamily = options.fontFamily,
-                .color = colorSpecFromRole(ColorRole::OnSurface),
+                .color = colorSpecFromRole(ColorRole::OnSurface, eventAlpha),
                 .maxWidth = textMaxWidth,
                 .maxLines = 3,
             }),
@@ -457,7 +472,7 @@ namespace calendar_view {
         auto eventRowNode = ui::row(
             {.out = &eventRow, .align = FlexAlign::Stretch, .gap = rowGap},
             ui::box({
-                .fill = eventColor(event),
+                .fill = eventColor(event, eventAlpha),
                 .radius = dotWidth * 0.5F,
                 .width = dotWidth,
                 .flexGrow = 0.0F,

--- a/src/ui/controls/calendar_view.h
+++ b/src/ui/controls/calendar_view.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <string>
 #include <string_view>
@@ -9,6 +10,7 @@ class Flex;
 class InputArea;
 class Label;
 class ScrollView;
+struct CalendarEvent;
 struct CalendarSnapshot;
 
 namespace calendar_view {
@@ -82,6 +84,9 @@ namespace calendar_view {
 
   [[nodiscard]] State stateForOffset(int monthOffset);
   [[nodiscard]] int dateKey(Date date) noexcept;
+
+  [[nodiscard]] bool eventPassed(const CalendarEvent& event, std::chrono::system_clock::time_point now);
+
   void rebuildMonth(const MonthBuildOptions& options);
   void rebuildEventList(const EventListBuildOptions& options);
   void layoutEventLinkOverlays(const EventListState& state);

--- a/tests/calendar_view_passed_event_test.cpp
+++ b/tests/calendar_view_passed_event_test.cpp
@@ -2,6 +2,7 @@
 #include "ui/controls/calendar_view.h"
 
 #include <chrono>
+#include <ctime>
 #include <print>
 
 namespace {
@@ -20,6 +21,15 @@ namespace {
     return sys_days{year{y} / month{static_cast<unsigned>(m)} / day{static_cast<unsigned>(d)}} + hours(h);
   }
 
+  system_clock::time_point localMidnight(int y, int m, int d) {
+    std::tm value{};
+    value.tm_year = y - 1900;
+    value.tm_mon = m - 1;
+    value.tm_mday = d;
+    value.tm_isdst = -1;
+    return system_clock::from_time_t(std::mktime(&value));
+  }
+
   CalendarEvent timedEvent(system_clock::time_point start, system_clock::time_point end) {
     return CalendarEvent{.start = start, .end = end, .allDay = false};
   }
@@ -33,7 +43,7 @@ namespace {
 int main() {
   bool ok = true;
 
-  const auto now = utc(2026, 8, 22, 12);
+  const auto now = localMidnight(2026, 8, 22) + hours{12};
 
   {
     ok = expect(eventPassed(timedEvent(now - hours{2}, now - hours{1}), now), "finished event was not passed") && ok;
@@ -51,23 +61,33 @@ int main() {
 
   {
     ok = expect(
-             !eventPassed(allDayEvent(utc(2026, 8, 22), utc(2026, 8, 23)), now),
+             !eventPassed(allDayEvent(localMidnight(2026, 8, 22), localMidnight(2026, 8, 23)), now),
              "today's all-day event was passed at noon"
          )
         && ok;
     ok = expect(
-             eventPassed(allDayEvent(utc(2026, 8, 21), utc(2026, 8, 22)), now),
+             eventPassed(allDayEvent(localMidnight(2026, 8, 21), localMidnight(2026, 8, 22)), now),
              "yesterday's all-day event was not passed"
+         )
+        && ok;
+  }
+
+  {
+    const auto start = utc(2026, 3, 8);
+    const auto end = start + hours{23};
+    ok = expect(
+             eventPassed(allDayEvent(start, end), end + hours{1}),
+             "all-day event with a shorter civil-day end was not passed"
          )
         && ok;
   }
 
   // Feeds that omit DTEND leave end == start. An all-day event must still own its whole day.
   {
-    const auto midnight = utc(2026, 8, 22);
+    const auto midnight = localMidnight(2026, 8, 22);
     ok = expect(!eventPassed(allDayEvent(midnight, midnight), now), "all-day event without DTEND was passed") && ok;
     ok = expect(
-             eventPassed(allDayEvent(utc(2026, 8, 20), utc(2026, 8, 20)), now),
+             eventPassed(allDayEvent(localMidnight(2026, 8, 20), localMidnight(2026, 8, 20)), now),
              "past all-day event without DTEND was not passed"
          )
         && ok;

--- a/tests/calendar_view_passed_event_test.cpp
+++ b/tests/calendar_view_passed_event_test.cpp
@@ -1,0 +1,85 @@
+#include "calendar/calendar_types.h"
+#include "ui/controls/calendar_view.h"
+
+#include <chrono>
+#include <print>
+
+namespace {
+
+  using namespace std::chrono;
+  using calendar_view::eventPassed;
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::println(stderr, "calendar_view_passed_event_test: {}", message);
+    }
+    return condition;
+  }
+
+  system_clock::time_point utc(int y, int m, int d, int h = 0) {
+    return sys_days{year{y} / month{static_cast<unsigned>(m)} / day{static_cast<unsigned>(d)}} + hours(h);
+  }
+
+  CalendarEvent timedEvent(system_clock::time_point start, system_clock::time_point end) {
+    return CalendarEvent{.start = start, .end = end, .allDay = false};
+  }
+
+  CalendarEvent allDayEvent(system_clock::time_point start, system_clock::time_point end) {
+    return CalendarEvent{.start = start, .end = end, .allDay = true};
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  const auto now = utc(2026, 8, 22, 12);
+
+  {
+    ok = expect(eventPassed(timedEvent(now - hours{2}, now - hours{1}), now), "finished event was not passed") && ok;
+    ok = expect(!eventPassed(timedEvent(now + hours{1}, now + hours{2}), now), "upcoming event was passed") && ok;
+  }
+
+  {
+    ok = expect(!eventPassed(timedEvent(now - hours{1}, now), now), "event ending exactly now was passed") && ok;
+  }
+
+  {
+    const CalendarEvent event = timedEvent(utc(2026, 8, 20) + hours{9}, now + hours{3});
+    ok = expect(!eventPassed(event, now), "running multi-day event was passed") && ok;
+  }
+
+  {
+    ok = expect(
+             !eventPassed(allDayEvent(utc(2026, 8, 22), utc(2026, 8, 23)), now),
+             "today's all-day event was passed at noon"
+         )
+        && ok;
+    ok = expect(
+             eventPassed(allDayEvent(utc(2026, 8, 21), utc(2026, 8, 22)), now),
+             "yesterday's all-day event was not passed"
+         )
+        && ok;
+  }
+
+  // Feeds that omit DTEND leave end == start. An all-day event must still own its whole day.
+  {
+    const auto midnight = utc(2026, 8, 22);
+    ok = expect(!eventPassed(allDayEvent(midnight, midnight), now), "all-day event without DTEND was passed") && ok;
+    ok = expect(
+             eventPassed(allDayEvent(utc(2026, 8, 20), utc(2026, 8, 20)), now),
+             "past all-day event without DTEND was not passed"
+         )
+        && ok;
+  }
+
+  {
+    ok = expect(eventPassed(timedEvent(now - hours{1}, now - hours{1}), now), "zero-length event was not passed") && ok;
+  }
+
+  {
+    ok = expect(!eventPassed(timedEvent(now + hours{2}, now - hours{2}), now), "inverted range was passed") && ok;
+  }
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Draw already passed events in calendar view with reduced alpha to differentiate which has passed and which has not. 

## Motivation

Fading the passed events makes it easy on a glance to see what is upcoming and what has already passed.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Added tests/calendar_view_passed_event_test.cpp to cover some edge cases.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="587" height="529" alt="image" src="https://github.com/user-attachments/assets/af98987a-c116-4f3b-8b87-128304a8618d" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I added this as default behavior without any configuration option but if controlling this via config would be better then I can add that as well.