### PR TITLE
feat(idle): power-source dependent idle behavior and AC power profile

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1183,6 +1183,7 @@
         "resume-command-placeholder": "notify-send 'Back from idle'",
         "summary": "{name} · {seconds}s",
         "summary-disabled-timeout": "{name} · timeout disabled",
+        "suspend-behavior-label": "Suspend behavior",
         "timeout-label": "Timeout seconds",
         "unnamed": "Unnamed behavior"
       },
@@ -1194,6 +1195,7 @@
     },
     "navigation": {
       "groups": {
+        "ac": "AC Power",
         "accessibility": "Accessibility",
         "audio": "Audio",
         "authentication": "Authentication",
@@ -1382,6 +1384,11 @@
         "launcher": "Launcher",
         "none": "None",
         "window-switcher": "Window Switcher"
+      },
+      "idle-suspend-behavior": {
+        "hibernate": "Hibernate",
+        "suspend": "Suspend",
+        "suspend-then-hibernate": "Suspend then hibernate"
       },
       "layer": {
         "overlay": "Overlay",
@@ -2144,6 +2151,10 @@
         "behaviors": {
           "description": "Named idle actions with presets (lock, screen off, suspend) or custom commands, timeouts, resume pairing, and order",
           "label": "Behaviors"
+        },
+        "power-profile": {
+          "label": "Power Profile",
+          "description": "Power profile applied"
         },
         "pre-action-fade": {
           "description": "Seconds of fullscreen dim before the idle command (0 disables)",

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -286,6 +286,7 @@ private:
   std::optional<bool> m_prevWirelessEnabledForEvents;
   std::optional<bool> m_prevBluetoothPoweredForEvents;
   std::optional<std::string> m_prevPowerProfileActiveForEvents;
+  std::string m_appliedIdlePowerProfile;
   std::unique_ptr<BrightnessService> m_brightnessService;
   std::unique_ptr<KeyboardBacklightService> m_keyboardBacklightService;
   std::unique_ptr<TrayService> m_trayService;

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -209,6 +209,7 @@ private:
   void scheduleGreeterAutoSync();
   bool runShellCommandBlocking(const std::string& command);
   bool runIdleAction(const IdleActionRequest& action);
+  void reloadIdleBehaviors();
   void onIconThemeChanged();
   void onGraphicsReset(RenderGraphicsResetStatus status);
   void recoverGraphicsAfterReset();

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -287,6 +287,7 @@ private:
   std::optional<bool> m_prevBluetoothPoweredForEvents;
   std::optional<std::string> m_prevPowerProfileActiveForEvents;
   std::string m_appliedIdlePowerProfile;
+  std::optional<bool> m_lastIdlePowerSource;
   std::unique_ptr<BrightnessService> m_brightnessService;
   std::unique_ptr<KeyboardBacklightService> m_keyboardBacklightService;
   std::unique_ptr<TrayService> m_trayService;

--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -819,12 +819,12 @@ bool Application::runIdleAction(const IdleActionRequest& action) {
   case IdleActionKind::ScreenOn:
     return m_compositorPlatform.setOutputPower(true);
   case IdleActionKind::Suspend:
-    return m_sessionActionRunner.requestSuspendDetached();
+    return m_sessionActionRunner.requestSuspendDetached(action.suspendBehavior);
   case IdleActionKind::LockAndSuspend:
     if (!m_configService.isLockScreenEnabled()) {
-      return m_sessionActionRunner.requestSuspendDetached();
+      return m_sessionActionRunner.requestSuspendDetached(action.suspendBehavior);
     }
-    return m_sessionActionRunner.lockThenSuspendDetached();
+    return m_sessionActionRunner.lockThenSuspendDetached(action.suspendBehavior);
   }
   return false;
 }

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -1151,7 +1151,11 @@ void Application::initSystemBusServices() {
           return;
         }
         onUpowerStateChangedForHooks();
-        reloadIdleBehaviors();
+        const bool onBattery = m_upowerService->state().onBattery;
+        if (!m_lastIdlePowerSource.has_value() || *m_lastIdlePowerSource != onBattery) {
+          reloadIdleBehaviors();
+        }
+        m_lastIdlePowerSource = onBattery;
         m_batteryWarningMonitor.evaluate(m_configService.config().battery, *m_upowerService, m_notificationManager);
         if (m_bluetoothService != nullptr) {
           m_bluetoothService->refreshBatteryFromUPower();

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -1151,6 +1151,7 @@ void Application::initSystemBusServices() {
           return;
         }
         onUpowerStateChangedForHooks();
+        reloadIdleBehaviors();
         m_batteryWarningMonitor.evaluate(m_configService.config().battery, *m_upowerService, m_notificationManager);
         if (m_bluetoothService != nullptr) {
           m_bluetoothService->refreshBatteryFromUPower();

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -741,7 +741,7 @@ void Application::initNotificationAndOsd() {
   );
   m_configService.addReloadCallback([this]() { m_osdOverlay.onConfigReload(); });
   m_idleGraceOverlay.initialize(m_wayland, &m_renderContext);
-  m_wayland.setIdleCapabilitiesReadyCallback([this]() { m_idleManager.reload(m_configService.config().idle); });
+  m_wayland.setIdleCapabilitiesReadyCallback([this]() { reloadIdleBehaviors(); });
   m_idleManager.initialize(
       m_wayland,
       [this](
@@ -777,7 +777,7 @@ void Application::initNotificationAndOsd() {
   m_idleManager.setLiveIdleChangeCallback([this]() {
     DeferredCall::callLater([this]() { m_settingsWindow.onIdleLiveStatusChanged(); });
   });
-  m_idleManager.reload(m_configService.config().idle);
+  reloadIdleBehaviors();
   try {
     m_screenSaverService = std::make_unique<ScreenSaverService>(m_systemBus.get());
     if (m_screenSaverService->active()) {
@@ -795,7 +795,7 @@ void Application::initNotificationAndOsd() {
   m_configService.addReloadCallback(
       [this]() {
         if (m_configService.lastChange().idle) {
-          m_idleManager.reload(m_configService.config().idle);
+          reloadIdleBehaviors();
         }
       },
       "idle"
@@ -828,6 +828,24 @@ void Application::initNotificationAndOsd() {
       },
       "privacy-filters"
   );
+}
+
+void Application::reloadIdleBehaviors() {
+  const IdleConfig& idle = m_configService.config().idle;
+  // Unknown power source (upower unavailable) falls back to the battery behaviors so pre-existing
+  // systems without upower keep their current idle config.
+  const bool onBattery = m_upowerService == nullptr || m_upowerService->state().onBattery;
+  if (onBattery) {
+    m_idleManager.reload(idle);
+  } else {
+    IdleConfig ac = idle;
+    ac.behaviors = idle.ac.behaviors;
+    m_idleManager.reload(ac);
+  }
+  const std::string& profile = onBattery ? idle.powerProfile : idle.ac.powerProfile;
+  if (m_powerProfilesService != nullptr && !profile.empty() && profile != m_powerProfilesService->activeProfile()) {
+    (void)m_powerProfilesService->setActiveProfile(profile);
+  }
 }
 
 void Application::initBarDockAndLayout() {

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -843,8 +843,9 @@ void Application::reloadIdleBehaviors() {
     m_idleManager.reload(ac);
   }
   const std::string& profile = onBattery ? idle.powerProfile : idle.ac.powerProfile;
-  if (m_powerProfilesService != nullptr && !profile.empty() && profile != m_powerProfilesService->activeProfile()) {
-    (void)m_powerProfilesService->setActiveProfile(profile);
+  if (profile != m_appliedIdlePowerProfile && m_powerProfilesService != nullptr && !profile.empty()
+      && m_powerProfilesService->setActiveProfile(profile)) {
+    m_appliedIdlePowerProfile = profile;
   }
 }
 

--- a/src/config/config_types.cpp
+++ b/src/config/config_types.cpp
@@ -239,15 +239,19 @@ ResolvedIdleBehavior resolveIdleBehaviorActions(const IdleBehaviorConfig& behavi
     };
   }
   if (act == "suspend") {
+    IdleActionRequest request = idleAction(IdleActionKind::Suspend);
+    request.suspendBehavior = tmp.suspendBehavior;
     return {
-        .idleAction = idleAction(IdleActionKind::Suspend),
+        .idleAction = std::move(request),
         .resumeAction = {},
         .resumeCommand = tmp.resumeCommand,
     };
   }
   if (act == "lock_and_suspend") {
+    IdleActionRequest request = idleAction(IdleActionKind::LockAndSuspend);
+    request.suspendBehavior = tmp.suspendBehavior;
     return {
-        .idleAction = idleAction(IdleActionKind::LockAndSuspend),
+        .idleAction = std::move(request),
         .resumeAction = {},
         .resumeCommand = tmp.resumeCommand,
     };

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -274,8 +274,32 @@ struct IdleBehaviorConfig {
   bool lockBeforeSuspend = true;
   /// Shorter timeout (seconds) applied only while the session is locked; 0 = always use timeoutSeconds.
   double lockedTimeoutSeconds = 0.0;
+  /// When the action is a suspend action: `suspend` | `hibernate` | `suspend-then-hibernate`.
+  std::string suspendBehavior = "suspend";
 
   bool operator==(const IdleBehaviorConfig&) const = default;
+};
+
+/// Idle behavior applied while running on AC power. On battery the shell uses `IdleConfig::behaviors`
+/// unchanged; on AC power `AcIdleConfig::behaviors` take over instead.
+struct AcIdleConfig {
+  std::vector<IdleBehaviorConfig> behaviors = {
+      IdleBehaviorConfig{
+          .name = "lock", .enabled = false, .timeoutSeconds = 900, .action = "lock", .command = "", .resumeCommand = ""
+      },
+      IdleBehaviorConfig{
+          .name = "screen-off",
+          .enabled = false,
+          .timeoutSeconds = 3600,
+          .action = "screen_off",
+          .command = "",
+          .resumeCommand = ""
+      },
+  };
+  /// Power profile to switch to on AC power (e.g. `balanced`); empty = leave the active profile alone.
+  std::string powerProfile = "balanced";
+
+  bool operator==(const AcIdleConfig&) const = default;
 };
 
 struct NotificationFilterConfig {
@@ -298,11 +322,16 @@ struct NotificationFilterConfig {
 };
 
 struct IdleConfig {
+  /// Behaviors used while on battery (or when upower is unavailable and no AC idle config is set).
   std::vector<IdleBehaviorConfig> behaviors;
   /// When > 0, after the compositor reports idle the shell fades a fullscreen overlay (surface color)
   /// from transparent to opaque over this many seconds, then runs `command`. Compositor activity during
   /// the fade cancels. When 0, the idle command runs immediately with no overlay.
   float preActionFadeSeconds = 2.0F;
+  /// Power profile to switch to on battery (e.g. `balanced`); empty = leave the active profile alone.
+  std::string powerProfile = "balanced";
+  /// AC-power idle behavior. See `AcIdleConfig`.
+  AcIdleConfig ac;
 
   bool operator==(const IdleConfig&) const = default;
 };
@@ -325,6 +354,8 @@ struct IdleActionRequest {
   IdleActionKind kind = IdleActionKind::None;
   std::string command;
   bool lockBeforeSuspend = true;
+  /// `suspend` | `hibernate` | `suspend-then-hibernate` (meaningful for Suspend/LockAndSuspend).
+  std::string suspendBehavior = "suspend";
 
   bool operator==(const IdleActionRequest&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -931,77 +931,121 @@ namespace noctalia::config::schema {
                 }
               }
           ),
+          custom<IdleBehaviorConfig>(
+              "suspend_behavior",
+              [](const toml::table& tbl, IdleBehaviorConfig& out, std::string_view, Diagnostics&) {
+                if (auto v = tbl["suspend_behavior"].value<std::string>()) {
+                  out.suspendBehavior = StringUtils::trim(*v);
+                }
+              },
+              [](toml::table& tbl, const IdleBehaviorConfig& in) {
+                // Emitted only for a suspend action that deviates from the default.
+                if ((in.action == "suspend" || in.action == "lock_and_suspend") && in.suspendBehavior != "suspend") {
+                  tbl.insert_or_assign("suspend_behavior", in.suspendBehavior);
+                }
+              }
+          ),
           finalize<IdleBehaviorConfig>([](IdleBehaviorConfig& b, std::string_view, Diagnostics&) {
             normalizeIdleBehaviorAction(b);
           }),
       };
       return s;
     }
+
+    // Shared by idleSchema and acIdleSchema: reorder behaviors to match behavior_order,
+    // leaving any unlisted behaviors in their original relative order at the end.
+    void reorderIdleBehaviors(const toml::table& tbl, std::vector<IdleBehaviorConfig>& behaviors) {
+      const auto* orderArr = tbl["behavior_order"].as_array();
+      if (orderArr == nullptr || behaviors.empty()) {
+        return;
+      }
+      std::vector<std::string> orderedNames;
+      for (const auto& item : *orderArr) {
+        if (auto name = item.value<std::string>(); name && !name->empty()) {
+          orderedNames.push_back(*name);
+        }
+      }
+      if (orderedNames.empty()) {
+        return;
+      }
+      std::unordered_map<std::string, IdleBehaviorConfig> byName;
+      for (auto& b : behaviors) {
+        byName.insert_or_assign(b.name, std::move(b));
+      }
+      std::vector<IdleBehaviorConfig> ordered;
+      ordered.reserve(byName.size());
+      for (const auto& name : orderedNames) {
+        auto it = byName.find(name);
+        if (it == byName.end()) {
+          continue;
+        }
+        ordered.push_back(std::move(it->second));
+        byName.erase(it);
+      }
+      for (auto& [name, b] : byName) {
+        (void)name;
+        ordered.push_back(std::move(b));
+      }
+      behaviors = std::move(ordered);
+    }
+
+    // Shared by idleSchema and acIdleSchema: the name-keyed [behavior] map, its
+    // vector-order mirror behavior_order (emitted first so it reads before the
+    // map), and the keyless reorder finalizer that runs last on read.
+    template <typename Struct>
+    void appendIdleBehaviorFields(Schema<Struct>& schema, std::vector<IdleBehaviorConfig> Struct::* behaviors) {
+      schema.push_back(
+          custom<Struct>(
+              "behavior_order", [](const toml::table&, Struct&, std::string_view, Diagnostics&) {},
+              [behaviors](toml::table& tbl, const Struct& in) {
+                toml::array order;
+                for (const auto& b : in.*behaviors) {
+                  if (!b.name.empty()) {
+                    order.push_back(b.name);
+                  }
+                }
+                tbl.insert_or_assign("behavior_order", std::move(order));
+              }
+          )
+      );
+      schema.push_back(
+          namedMap<Struct, IdleBehaviorConfig>(
+              behaviors, "behavior", idleBehaviorSchema(),
+              [](IdleBehaviorConfig& b, std::string_view name) { b.name = std::string(name); },
+              [](const IdleBehaviorConfig& b) { return b.name; }
+          )
+      );
+      schema.push_back(
+          custom<Struct>(
+              "",
+              [behaviors](const toml::table& tbl, Struct& out, std::string_view, Diagnostics&) {
+                reorderIdleBehaviors(tbl, out.*behaviors);
+              },
+              [](toml::table&, const Struct&) {}
+          )
+      );
+    }
   } // namespace
 
   const Schema<IdleConfig>& idleSchema() {
-    static const Schema<IdleConfig> s = {
-        field(&IdleConfig::preActionFadeSeconds, "pre_action_fade_seconds", Range<float>{0.0F, 120.0F}),
-        // behavior_order is emitted here (vector order); the actual reorder runs
-        // last, after the behavior map has been read.
-        custom<IdleConfig>(
-            "behavior_order", [](const toml::table&, IdleConfig&, std::string_view, Diagnostics&) {},
-            [](toml::table& tbl, const IdleConfig& in) {
-              toml::array order;
-              for (const auto& b : in.behaviors) {
-                if (!b.name.empty()) {
-                  order.push_back(b.name);
-                }
-              }
-              tbl.insert_or_assign("behavior_order", std::move(order));
-            }
-        ),
-        namedMap<IdleConfig, IdleBehaviorConfig>(
-            &IdleConfig::behaviors, "behavior", idleBehaviorSchema(),
-            [](IdleBehaviorConfig& b, std::string_view name) { b.name = std::string(name); },
-            [](const IdleBehaviorConfig& b) { return b.name; }
-        ),
-        // Keyless finalizer: reorder behaviors to match behavior_order, leaving
-        // any unlisted behaviors in their original relative order at the end.
-        custom<IdleConfig>(
-            "",
-            [](const toml::table& tbl, IdleConfig& out, std::string_view, Diagnostics&) {
-              const auto* orderArr = tbl["behavior_order"].as_array();
-              if (orderArr == nullptr || out.behaviors.empty()) {
-                return;
-              }
-              std::vector<std::string> orderedNames;
-              for (const auto& item : *orderArr) {
-                if (auto name = item.value<std::string>(); name && !name->empty()) {
-                  orderedNames.push_back(*name);
-                }
-              }
-              if (orderedNames.empty()) {
-                return;
-              }
-              std::unordered_map<std::string, IdleBehaviorConfig> byName;
-              for (auto& b : out.behaviors) {
-                byName.insert_or_assign(b.name, std::move(b));
-              }
-              std::vector<IdleBehaviorConfig> ordered;
-              ordered.reserve(byName.size());
-              for (const auto& name : orderedNames) {
-                auto it = byName.find(name);
-                if (it == byName.end()) {
-                  continue;
-                }
-                ordered.push_back(std::move(it->second));
-                byName.erase(it);
-              }
-              for (auto& [name, b] : byName) {
-                (void)name;
-                ordered.push_back(std::move(b));
-              }
-              out.behaviors = std::move(ordered);
-            },
-            [](toml::table&, const IdleConfig&) {}
-        ),
-    };
+    static const Schema<IdleConfig> s = [] {
+      Schema<IdleConfig> schema;
+      schema.push_back(field(&IdleConfig::preActionFadeSeconds, "pre_action_fade_seconds", Range<float>{0.0F, 120.0F}));
+      schema.push_back(field(&IdleConfig::powerProfile, "power_profile"));
+      appendIdleBehaviorFields(schema, &IdleConfig::behaviors);
+      schema.push_back(subTable<IdleConfig, AcIdleConfig>(&IdleConfig::ac, "ac", acIdleSchema()));
+      return schema;
+    }();
+    return s;
+  }
+
+  const Schema<AcIdleConfig>& acIdleSchema() {
+    static const Schema<AcIdleConfig> s = [] {
+      Schema<AcIdleConfig> schema;
+      schema.push_back(field(&AcIdleConfig::powerProfile, "power_profile"));
+      appendIdleBehaviorFields(schema, &AcIdleConfig::behaviors);
+      return schema;
+    }();
     return s;
   }
 

--- a/src/config/schema/config_schema.h
+++ b/src/config/schema/config_schema.h
@@ -29,6 +29,7 @@ namespace noctalia::config::schema {
   const Schema<KeybindsConfig>& keybindsSchema();
   const Schema<HooksConfig>& hooksSchema();
   const Schema<IdleConfig>& idleSchema();
+  const Schema<AcIdleConfig>& acIdleSchema();
   const Schema<WallpaperConfig>& wallpaperSchema();
   const Schema<ThemeConfig>& themeSchema();
   // Parses a name-keyed [custom_colors] map (bare string or { color, color_dark,

--- a/src/dbus/power/power_profiles_service.cpp
+++ b/src/dbus/power/power_profiles_service.cpp
@@ -236,12 +236,21 @@ bool PowerProfilesService::setActiveProfile(std::string_view profile) {
     m_proxy->setPropertyAsync("ActiveProfile")
         .onInterface(kPowerProfilesInterface)
         .toValue(requested)
-        .uponReplyInvoke([lifetimeToken, requested](std::optional<sdbus::Error> err) {
-          if (lifetimeToken.expired() || !err.has_value()) {
+        .uponReplyInvoke([this, lifetimeToken, requested](std::optional<sdbus::Error> err) {
+          if (lifetimeToken.expired()) {
             return;
           }
-          // The optimistic update below already reconciles via refresh(); just surface the failure.
-          kLog.warn("power profile change failed profile={} err={}", requested, err->what());
+          if (err.has_value()) {
+            if (m_pendingLocalActiveProfile.has_value() && *m_pendingLocalActiveProfile == requested) {
+              m_pendingLocalActiveProfile.reset();
+            }
+            kLog.warn("power profile change failed profile={} err={}", requested, err->what());
+            return;
+          }
+          PowerProfilesState next = m_state;
+          next.activeProfile = requested;
+          emitChangedIfNeeded(std::move(next), false);
+          refresh();
         });
   } catch (const sdbus::Error& e) {
     if (m_pendingLocalActiveProfile.has_value() && *m_pendingLocalActiveProfile == requested) {
@@ -250,11 +259,6 @@ bool PowerProfilesService::setActiveProfile(std::string_view profile) {
     kLog.warn("power profile change dispatch failed profile={} err={}", requested, e.what());
     return false;
   }
-
-  PowerProfilesState next = m_state;
-  next.activeProfile = requested;
-  emitChangedIfNeeded(std::move(next), false);
-  refresh();
   return true;
 }
 

--- a/src/shell/session/session_action_runner.cpp
+++ b/src/shell/session/session_action_runner.cpp
@@ -68,8 +68,8 @@ namespace {
     }
   }
 
-  [[nodiscard]] const std::vector<std::vector<std::string>>& suspendCommandVariants() {
-    static const std::vector<std::vector<std::string>> variants = {
+  [[nodiscard]] const std::vector<std::vector<std::string>>& suspendCommandVariants(std::string_view behavior) {
+    static const std::vector<std::vector<std::string>> suspend = {
         {"systemctl", "suspend"},
         {"loginctl", "suspend"},
         {"pm-suspend"},
@@ -82,7 +82,28 @@ namespace {
         {"sudo", "-n", "zzz"},
         {"sudo", "-n", "sh", "-c", "echo mem > /sys/power/state"},
     };
-    return variants;
+    static const std::vector<std::vector<std::string>> hibernate = {
+        {"systemctl", "hibernate"},
+        {"loginctl", "hibernate"},
+        {"pm-hibernate"},
+        {"pkexec", "pm-hibernate"},
+        {"run0", "pm-hibernate"},
+        {"sudo", "-n", "pm-hibernate"},
+        {"pkexec", "sh", "-c", "echo disk > /sys/power/state"},
+        {"run0", "sh", "-c", "echo disk > /sys/power/state"},
+        {"sudo", "-n", "sh", "-c", "echo disk > /sys/power/state"},
+    };
+    static const std::vector<std::vector<std::string>> suspendThenHibernate = {
+        {"systemctl", "suspend-then-hibernate"},
+        {"loginctl", "suspend-then-hibernate"},
+    };
+    if (behavior == "hibernate") {
+      return hibernate;
+    }
+    if (behavior == "suspend-then-hibernate") {
+      return suspendThenHibernate;
+    }
+    return suspend;
   }
 
   [[nodiscard]] const std::vector<std::vector<std::string>>& rebootCommandVariants() {
@@ -232,6 +253,8 @@ void SessionActionRunner::setPowerConfig(const ShellSessionConfig::ShellSessionP
   m_rebootCommandOverride = power.reboot;
   m_shutdownCommandOverride = power.shutdown;
   m_cachedSuspendAutoStartIdx.reset();
+  m_cachedHibernateAutoStartIdx.reset();
+  m_cachedSuspendThenHibernateAutoStartIdx.reset();
   m_cachedRebootAutoStartIdx.reset();
   m_cachedShutdownAutoStartIdx.reset();
 }
@@ -292,15 +315,25 @@ std::function<bool()> SessionActionRunner::hookFor(std::string_view action) cons
 
 bool SessionActionRunner::lock() const { return requestLock(m_lockScreen); }
 
-bool SessionActionRunner::requestSuspendDetached() const {
+std::optional<std::size_t>& SessionActionRunner::suspendCacheFor(std::string_view behavior) const {
+  if (behavior == "hibernate") {
+    return m_cachedHibernateAutoStartIdx;
+  }
+  if (behavior == "suspend-then-hibernate") {
+    return m_cachedSuspendThenHibernateAutoStartIdx;
+  }
+  return m_cachedSuspendAutoStartIdx;
+}
+
+bool SessionActionRunner::requestSuspendDetached(std::string_view behavior) const {
   logActionContext("suspend");
   if (m_hooks.onBeforePlainSuspend) {
     m_hooks.onBeforePlainSuspend();
   }
   std::scoped_lock lock(m_powerMutex);
+  const std::optional<std::string> commandOverride = (behavior == "suspend") ? m_suspendCommandOverride : std::nullopt;
   const bool started = runPowerActionResolved(
-      "suspend", m_suspendCommandOverride, suspendCommandVariants(), m_cachedSuspendAutoStartIdx,
-      PowerLaunchMode::Detached
+      "suspend", commandOverride, suspendCommandVariants(behavior), suspendCacheFor(behavior), PowerLaunchMode::Detached
   );
   if (!started && m_hooks.onPlainSuspendAborted) {
     m_hooks.onPlainSuspendAborted();
@@ -325,20 +358,22 @@ bool SessionActionRunner::requestShutdownDetached() const {
   );
 }
 
-bool SessionActionRunner::lockThenSuspendDetached() const {
-  m_lockScreen.runAfterSessionLocked([this]() { (void)requestSuspendDetached(); });
+bool SessionActionRunner::lockThenSuspendDetached(std::string_view behavior) const {
+  m_lockScreen.runAfterSessionLocked([this, behavior = std::string(behavior)]() {
+    (void)requestSuspendDetached(behavior);
+  });
   return true;
 }
 
-bool SessionActionRunner::suspendBlocking() const {
+bool SessionActionRunner::suspendBlocking(std::string_view behavior) const {
   logActionContext("suspend");
   if (m_hooks.onBeforePlainSuspend) {
     m_hooks.onBeforePlainSuspend();
   }
   std::scoped_lock lock(m_powerMutex);
+  const std::optional<std::string> commandOverride = (behavior == "suspend") ? m_suspendCommandOverride : std::nullopt;
   const bool started = runPowerActionResolved(
-      "suspend", m_suspendCommandOverride, suspendCommandVariants(), m_cachedSuspendAutoStartIdx,
-      PowerLaunchMode::Blocking
+      "suspend", commandOverride, suspendCommandVariants(behavior), suspendCacheFor(behavior), PowerLaunchMode::Blocking
   );
   if (!started && m_hooks.onPlainSuspendAborted) {
     m_hooks.onPlainSuspendAborted();

--- a/src/shell/session/session_action_runner.h
+++ b/src/shell/session/session_action_runner.h
@@ -26,14 +26,18 @@ public:
   void setPowerConfig(const ShellSessionConfig::ShellSessionPowerConfig& power);
   void invoke(const SessionPanelActionConfig& cfg) const;
   [[nodiscard]] bool lock() const;
-  [[nodiscard]] bool requestSuspendDetached() const;
+  /// `behavior`: `suspend` | `hibernate` | `suspend-then-hibernate`.
+  [[nodiscard]] bool requestSuspendDetached(std::string_view behavior = "suspend") const;
   [[nodiscard]] bool requestRebootDetached() const;
   [[nodiscard]] bool requestShutdownDetached() const;
-  [[nodiscard]] bool lockThenSuspendDetached() const;
+  /// `behavior`: `suspend` | `hibernate` | `suspend-then-hibernate`.
+  [[nodiscard]] bool lockThenSuspendDetached(std::string_view behavior = "suspend") const;
 
 private:
   [[nodiscard]] std::function<bool()> hookFor(std::string_view action) const;
-  [[nodiscard]] bool suspendBlocking() const;
+  // Per-behavior auto-detection cache for the suspend command variant scan.
+  [[nodiscard]] std::optional<std::size_t>& suspendCacheFor(std::string_view behavior) const;
+  [[nodiscard]] bool suspendBlocking(std::string_view behavior = "suspend") const;
   [[nodiscard]] bool rebootBlocking() const;
   [[nodiscard]] bool shutdownBlocking() const;
 
@@ -50,6 +54,8 @@ private:
 
   // Auto-detection cache: where to start scanning fallback variants next time.
   mutable std::optional<std::size_t> m_cachedSuspendAutoStartIdx;
+  mutable std::optional<std::size_t> m_cachedHibernateAutoStartIdx;
+  mutable std::optional<std::size_t> m_cachedSuspendThenHibernateAutoStartIdx;
   mutable std::optional<std::size_t> m_cachedRebootAutoStartIdx;
   mutable std::optional<std::size_t> m_cachedShutdownAutoStartIdx;
 };

--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -929,7 +929,9 @@ namespace settings {
     };
 
     const auto makeIdleBehaviorsInlineBlock = [&](Flex& section, const SettingEntry& entry,
-                                                  const IdleBehaviorsSetting& idle) {
+                                                  const IdleBehaviorsSetting& idle,
+                                                  const std::function<void(std::size_t)>& openEntry,
+                                                  const std::function<void()>& openCreate) {
       const bool overridden = (ctx.configService != nullptr && ctx.configService->hasEffectiveOverride(entry.path));
 
       auto block = makeCollectionBlock(entry, overridden);
@@ -1008,7 +1010,7 @@ namespace settings {
             .minHeight = Style::controlHeightSm * scale,
             .padding = Style::spaceXs * scale,
             .radius = Style::scaledRadiusSm(scale),
-            .onClick = [openEntry = ctx.openIdleBehaviorEntryEditor, rowIndex = idx]() {
+            .onClick = [openEntry, rowIndex = idx]() {
               if (openEntry) {
                 openEntry(rowIndex);
               }
@@ -1043,7 +1045,7 @@ namespace settings {
           .paddingV = Style::spaceSm * scale,
           .paddingH = Style::spaceMd * scale,
           .radius = Style::scaledRadiusMd(scale),
-          .onClick = [openCreate = ctx.openIdleBehaviorCreateEditor]() {
+          .onClick = [openCreate]() {
             if (openCreate) {
               openCreate();
             }
@@ -1419,7 +1421,11 @@ namespace settings {
         } else if (const auto* sessionActs = std::get_if<SessionPanelActionsSetting>(&entry.control)) {
           makeSessionActionsInlineBlock(*activeGroupBody, entry, *sessionActs);
         } else if (const auto* idle = std::get_if<IdleBehaviorsSetting>(&entry.control)) {
-          makeIdleBehaviorsInlineBlock(*activeGroupBody, entry, *idle);
+          const bool isAc = entry.path.size() >= 2 && entry.path[0] == "idle" && entry.path[1] == "ac";
+          makeIdleBehaviorsInlineBlock(
+              *activeGroupBody, entry, *idle, isAc ? ctx.openAcIdleBehaviorEntryEditor : ctx.openIdleBehaviorEntryEditor,
+              isAc ? ctx.openAcIdleBehaviorCreateEditor : ctx.openIdleBehaviorCreateEditor
+          );
         } else if (const auto* filters = std::get_if<NotificationFiltersSetting>(&entry.control)) {
           makeNotificationFiltersInlineBlock(*activeGroupBody, entry, *filters);
         } else if (const auto* picker = std::get_if<SearchPickerSetting>(&entry.control)) {

--- a/src/shell/settings/settings_content.h
+++ b/src/shell/settings/settings_content.h
@@ -88,6 +88,8 @@ namespace settings {
     std::function<void(std::size_t)> openSessionActionEntryEditor;
     std::function<void(std::size_t)> openIdleBehaviorEntryEditor;
     std::function<void()> openIdleBehaviorCreateEditor;
+    std::function<void(std::size_t)> openAcIdleBehaviorEntryEditor;
+    std::function<void()> openAcIdleBehaviorCreateEditor;
     std::function<void(std::size_t)> openNotificationFilterEntryEditor;
     std::function<void()> openNotificationFilterCreateEditor;
     std::function<void(std::vector<std::string> laneListPath, std::string widgetName)> openWidgetInspectorEditor;

--- a/src/shell/settings/settings_content_idle_behavior.cpp
+++ b/src/shell/settings/settings_content_idle_behavior.cpp
@@ -38,6 +38,7 @@ namespace settings {
     normalizeIdleBehaviorAction(norm);
     const bool showCustomCommands = (norm.action == "command");
     const bool showLockedTimeout = (norm.action == "screen_off");
+    Flex* suspendBehaviorRaw = nullptr;
 
     auto body = ui::column({
         .align = FlexAlign::Stretch,
@@ -124,8 +125,8 @@ namespace settings {
         .controlHeight = Style::controlHeight * scale,
         .glyphSize = Style::fontSizeBody * scale,
         .onSelectionChanged =
-            [&row, persist, idleActionOptions, customCommandsRaw,
-             nameBlockRaw](std::size_t index, std::string_view /*label*/) {
+            [&row, persist, idleActionOptions, customCommandsRaw, nameBlockRaw,
+             suspendBehaviorRaw](std::size_t index, std::string_view /*label*/) {
               if (index < idleActionOptions.size()) {
                 row.action = idleActionOptions[index].value;
                 if (row.action != "command") {
@@ -139,6 +140,7 @@ namespace settings {
               normalizeIdleBehaviorAction(n);
               customCommandsRaw->setVisible(n.action == "command");
               nameBlockRaw->setVisible(n.action == "command");
+              suspendBehaviorRaw->setVisible(n.action == "suspend" || n.action == "lock_and_suspend");
               persist();
             },
         .configure = [](Select& select) { select.setFillWidth(true); },
@@ -244,6 +246,42 @@ namespace settings {
       lockedTimeoutBlock->addChild(std::move(lockedTimeoutIn));
       body->addChild(std::move(lockedTimeoutBlock));
     }
+
+    const bool showSuspendBehavior = (norm.action == "suspend" || norm.action == "lock_and_suspend");
+    auto suspendBehaviorGrp = ui::column(
+        {.out = &suspendBehaviorRaw,
+         .align = FlexAlign::Stretch,
+         .gap = Style::spaceXs * scale,
+         .visible = showSuspendBehavior},
+        makeLabel(
+            i18n::tr("settings.idle.behavior.suspend-behavior-label"), Style::fontSizeCaption * scale,
+            colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal
+        )
+    );
+    const std::vector<SelectOption> suspendBehaviorOptions = {
+        {"suspend", i18n::tr("settings.options.idle-suspend-behavior.suspend"), {}},
+        {"hibernate", i18n::tr("settings.options.idle-suspend-behavior.hibernate"), {}},
+        {"suspend-then-hibernate", i18n::tr("settings.options.idle-suspend-behavior.suspend-then-hibernate"), {}},
+    };
+    const auto suspendIndex = optionIndex(suspendBehaviorOptions, row.suspendBehavior);
+    auto suspendSelect = ui::select({
+        .options = optionLabels(suspendBehaviorOptions),
+        .selectedIndex = suspendIndex,
+        .clearSelection = !suspendIndex.has_value(),
+        .fontSize = Style::fontSizeBody * scale,
+        .controlHeight = Style::controlHeight * scale,
+        .glyphSize = Style::fontSizeBody * scale,
+        .onSelectionChanged =
+            [&row, persist, suspendBehaviorOptions](std::size_t index, std::string_view /*label*/) {
+              if (index < suspendBehaviorOptions.size()) {
+                row.suspendBehavior = suspendBehaviorOptions[index].value;
+              }
+              persist();
+            },
+        .configure = [](Select& select) { select.setFillWidth(true); },
+    });
+    suspendBehaviorGrp->addChild(std::move(suspendSelect));
+    body->addChild(std::move(suspendBehaviorGrp));
 
     body->addChild(std::move(customCommandsGrp));
     body->addChild(std::move(resumeCommandGrp));

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2756,10 +2756,40 @@ namespace settings {
         "idle fade dim seconds overlay"
     ));
     entries.push_back(makeEntry(
-        SettingsSection::Power, "idle", tr("settings.schema.idle.behaviors.label"),
+        SettingsSection::Power, "battery", tr("settings.schema.idle.behaviors.label"),
         tr("settings.schema.idle.behaviors.description"), {"idle", "behavior"},
         IdleBehaviorsSetting{.items = cfg.idle.behaviors},
         "idle behavior timeout command resume screen lock dpms suspend lock_and_suspend caffeine"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Power, "battery", tr("settings.schema.idle.power-profile.label"),
+        tr("settings.schema.idle.power-profile.description"), {"idle", "power_profile"},
+        plainSelect(
+            {{"power-saver", "power.profiles.power-saver"},
+             {"balanced", "power.profiles.balanced"},
+             {"performance", "power.profiles.performance"}},
+            cfg.idle.powerProfile
+        ),
+        "idle power profile balanced performance saver"
+    ));
+
+    // AC power idle behavior: used instead of the battery behaviors while on AC power.
+    entries.push_back(makeEntry(
+        SettingsSection::Power, "ac", tr("settings.schema.idle.behaviors.label"),
+        tr("settings.schema.idle.behaviors.description"), {"idle", "ac", "behavior"},
+        IdleBehaviorsSetting{.items = cfg.idle.ac.behaviors},
+        "idle ac behavior timeout command resume screen lock dpms suspend lock_and_suspend"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Power, "ac", tr("settings.schema.idle.power-profile.label"),
+        tr("settings.schema.idle.power-profile.description"), {"idle", "ac", "power_profile"},
+        plainSelect(
+            {{"power-saver", "power.profiles.power-saver"},
+             {"balanced", "power.profiles.balanced"},
+             {"performance", "power.profiles.performance"}},
+            cfg.idle.ac.powerProfile
+        ),
+        "idle ac power profile balanced performance saver"
     ));
 
     // Hooks

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -190,6 +190,8 @@ private:
   void syncSessionActionInlineSummary(std::size_t index, const SessionPanelActionConfig& row);
   void openIdleBehaviorEntryEditor(std::size_t index);
   void openIdleBehaviorCreateEditor();
+  void openAcIdleBehaviorEntryEditor(std::size_t index);
+  void openAcIdleBehaviorCreateEditor();
   void openNotificationFilterEntryEditor(std::size_t index);
   void openNotificationFilterCreateEditor();
   void openCalendarAccountEditor(std::optional<std::string> accountId);

--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -821,6 +821,190 @@ void SettingsWindow::openIdleBehaviorCreateEditor() {
   );
 }
 
+void SettingsWindow::openAcIdleBehaviorEntryEditor(std::size_t index) {
+  if (m_wayland == nullptr
+      || m_renderContext == nullptr
+      || m_surface == nullptr
+      || m_surface->xdgSurface() == nullptr
+      || m_config == nullptr) {
+    return;
+  }
+
+  if (m_editorSheetModal != nullptr && m_editorSheetModal->isOpen()) {
+    m_editorSheetModal->close();
+  }
+
+  const Config& cfg = m_config->config();
+  if (index >= cfg.idle.ac.behaviors.size()) {
+    return;
+  }
+
+  if (m_widgetAddPopup != nullptr && m_widgetAddPopup->isOpen()) {
+    m_widgetAddPopup->close();
+  }
+  if (m_searchPickerPopup != nullptr && m_searchPickerPopup->isOpen()) {
+    m_searchPickerPopup->close();
+  }
+
+  if (m_editorSheetModal == nullptr) {
+    m_editorSheetModal = std::make_unique<settings::SettingsSheetModal>();
+    m_editorSheetModal->initialize(m_modalHost, [this]() { dismissOpenSelectDropdown(); });
+  }
+  const float scale = uiScale();
+  const BarConfig* selectedBar = settings::findBar(cfg, m_selectedBarName);
+  const BarMonitorOverride* selectedMonitorOverride = nullptr;
+  if (selectedBar != nullptr && !m_selectedMonitorOverride.empty()) {
+    selectedMonitorOverride = settings::findMonitorOverride(*selectedBar, m_selectedMonitorOverride);
+  }
+
+  auto rowState = std::make_shared<IdleBehaviorConfig>(cfg.idle.ac.behaviors[index]);
+  auto rowKey = std::make_shared<std::string>(rowState->name);
+  normalizeIdleBehaviorAction(*rowState);
+
+  const auto persist = [this, rowState, rowKey, index]() {
+    if (m_config == nullptr) {
+      return;
+    }
+    normalizeIdleBehaviorAction(*rowState);
+    auto next = m_config->config().idle.ac.behaviors;
+    auto target = std::ranges::find(next, *rowKey, &IdleBehaviorConfig::name);
+    if (target == next.end() && index < next.size()) {
+      target = next.begin() + static_cast<std::ptrdiff_t>(index);
+    }
+    if (target == next.end()) {
+      return;
+    }
+    const auto targetIndex = static_cast<std::size_t>(std::distance(next.begin(), target));
+    next[targetIndex] = *rowState;
+    normalizeIdleBehaviorNames(next);
+    *rowState = next[targetIndex];
+    *rowKey = rowState->name;
+    setSettingOverride({"idle", "ac", "behavior"}, next);
+    requestContentRebuild();
+    if (m_editorSheetModal != nullptr && m_editorSheetModal->isOpen()) {
+      m_editorSheetModal->requestLayout();
+    }
+  };
+
+  const auto removeRow = [this, index]() {
+    if (m_config == nullptr) {
+      return;
+    }
+    auto next = m_config->config().idle.ac.behaviors;
+    if (index >= next.size()) {
+      return;
+    }
+    next.erase(next.begin() + static_cast<std::ptrdiff_t>(index));
+    normalizeIdleBehaviorNames(next);
+    setSettingOverride({"idle", "ac", "behavior"}, next);
+    if (m_editorSheetModal != nullptr) {
+      m_editorSheetModal->close();
+    }
+    requestContentRebuild();
+  };
+
+  auto ctx = makeContentContext(cfg, selectedBar, selectedMonitorOverride);
+  ctx.openSessionActionEntryEditor = {};
+  ctx.openAcIdleBehaviorEntryEditor = {};
+  ctx.closeHostedEditor = [this]() {
+    if (m_editorSheetModal != nullptr) {
+      m_editorSheetModal->close();
+    }
+  };
+
+  m_editorSheetModal->open(
+      settings::SettingsSheetRequest{
+          .sheetTitle = idleBehaviorTitle(*rowState),
+          .removeAction = removeRow,
+          .populateSheetBody =
+              [ctx, rowState, persist](Flex& body) mutable {
+                settings::buildIdleBehaviorEntryDetailContent(body, ctx, *rowState, persist);
+              },
+          .scale = scale,
+      }
+  );
+}
+
+void SettingsWindow::openAcIdleBehaviorCreateEditor() {
+  if (m_wayland == nullptr
+      || m_renderContext == nullptr
+      || m_surface == nullptr
+      || m_surface->xdgSurface() == nullptr
+      || m_config == nullptr) {
+    return;
+  }
+
+  if (m_editorSheetModal != nullptr && m_editorSheetModal->isOpen()) {
+    m_editorSheetModal->close();
+  }
+  if (m_widgetAddPopup != nullptr && m_widgetAddPopup->isOpen()) {
+    m_widgetAddPopup->close();
+  }
+  if (m_searchPickerPopup != nullptr && m_searchPickerPopup->isOpen()) {
+    m_searchPickerPopup->close();
+  }
+
+  if (m_editorSheetModal == nullptr) {
+    m_editorSheetModal = std::make_unique<settings::SettingsSheetModal>();
+    m_editorSheetModal->initialize(m_modalHost, [this]() { dismissOpenSelectDropdown(); });
+  }
+
+  const Config& cfg = m_config->config();
+  const float scale = uiScale();
+  const BarConfig* selectedBar = settings::findBar(cfg, m_selectedBarName);
+  const BarMonitorOverride* selectedMonitorOverride = nullptr;
+  if (selectedBar != nullptr && !m_selectedMonitorOverride.empty()) {
+    selectedMonitorOverride = settings::findMonitorOverride(*selectedBar, m_selectedMonitorOverride);
+  }
+
+  auto rowState = std::make_shared<IdleBehaviorConfig>(IdleBehaviorConfig{
+      .name = "idle-behavior",
+      .enabled = false,
+      .timeoutSeconds = 600,
+      .action = "command",
+      .command = "",
+      .resumeCommand = "",
+  });
+
+  const auto persistDraft = [this]() {
+    if (m_editorSheetModal != nullptr && m_editorSheetModal->isOpen()) {
+      m_editorSheetModal->requestLayout();
+    }
+  };
+
+  auto ctx = makeContentContext(cfg, selectedBar, selectedMonitorOverride);
+  ctx.openSessionActionEntryEditor = {};
+  ctx.openAcIdleBehaviorEntryEditor = {};
+  ctx.afterIdleBehaviorApply = [this, rowState]() {
+    if (m_config == nullptr) {
+      return;
+    }
+    normalizeIdleBehaviorAction(*rowState);
+    auto next = m_config->config().idle.ac.behaviors;
+    next.push_back(*rowState);
+    normalizeIdleBehaviorNames(next);
+    setSettingOverride({"idle", "ac", "behavior"}, next);
+    requestContentRebuild();
+  };
+  ctx.closeHostedEditor = [this]() {
+    if (m_editorSheetModal != nullptr) {
+      m_editorSheetModal->close();
+    }
+  };
+
+  m_editorSheetModal->open(
+      settings::SettingsSheetRequest{
+          .sheetTitle = idleBehaviorTitle(*rowState),
+          .removeAction = nullptr,
+          .populateSheetBody =
+              [ctx, rowState, persistDraft](Flex& body) mutable {
+                settings::buildIdleBehaviorEntryDetailContent(body, ctx, *rowState, persistDraft);
+              },
+          .scale = scale,
+      }
+  );
+}
+
 void SettingsWindow::openNotificationFilterEntryEditor(std::size_t index) {
   if (m_wayland == nullptr
       || m_renderContext == nullptr

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -941,6 +941,8 @@ settings::SettingsContentContext SettingsWindow::makeContentContext(
       .openSessionActionEntryEditor = [this](std::size_t entryIndex) { openSessionActionEntryEditor(entryIndex); },
       .openIdleBehaviorEntryEditor = [this](std::size_t entryIndex) { openIdleBehaviorEntryEditor(entryIndex); },
       .openIdleBehaviorCreateEditor = [this]() { openIdleBehaviorCreateEditor(); },
+      .openAcIdleBehaviorEntryEditor = [this](std::size_t entryIndex) { openAcIdleBehaviorEntryEditor(entryIndex); },
+      .openAcIdleBehaviorCreateEditor = [this]() { openAcIdleBehaviorCreateEditor(); },
       .openNotificationFilterEntryEditor =
           [this](std::size_t entryIndex) { openNotificationFilterEntryEditor(entryIndex); },
       .openNotificationFilterCreateEditor = [this]() { openNotificationFilterCreateEditor(); },


### PR DESCRIPTION
## Summary

Add an [idle.ac] block applied while on AC power: its own behavior list
, power profile (default balanced), and a per-suspend-action selector.
Battery behaviors are untouched.

## Motivation

Most power managers have a distinction between AC and battery.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [x] Breaking change - when you don't enable AC, but have battery enabled, it will not have any behaviors on AC
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

## Testing

- open settings
- set low and different idle for battery/AC (e.g. 10/15 s)
- observe

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Mango
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
