### PR TITLE
fix(mango): template support optional source

### DIFF
--- a/assets/templates/mango/apply.sh
+++ b/assets/templates/mango/apply.sh
@@ -19,7 +19,7 @@ if [ ! -f "$config_file" ]; then
     exit 0
 fi
 
-if ! grep -q '^[[:space:]]*source[[:space:]]*=[[:space:]]*.*noctalia\.conf' "$config_file"; then
+if ! grep -Eq '^[[:space:]]*source(-optional)?[[:space:]]*=[[:space:]]*.*noctalia\.conf' "$config_file"; then
     printf '\n%s\n' "$include_line" >>"$config_file"
 fi
 


### PR DESCRIPTION
## Summary

The template today looks for a mango config with the source for the generated noctalia file with the colors. If that source include is not present, it tries to add it as part of applying the template.

However, in the case that the file is read-only (like home-manager config file) and that the original file already has a source-optional (which will not match the script condition) it will fail as there's no permission to overwrite the home-manager file.

This PR fixes it by applying an optional (-optional) in the regular expression check in case the user prefers to use source-optional. The written line in case there's no source include present stays the same.

## Motivation

Users might prefer to use source-optional in configs that don't fail on the first time noctalia is run on that system so there's no noctalia colors file.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

In a system with home-manager config isntalled and source-optional present, tried to run the script:
```
sh -x /nix/store/zax2sikx392kw047w8mmdsllaw3wcy99-noctalia-5.0.0/share/noctalia/assets/templates/mango/apply.sh
+ set -euo pipefail
+ config_dir=/home/rogervn/.config
+ config_file=/home/rogervn/.config/mango/config.conf
+ [[ /home/rogervn/.config == /home/rogervn/* ]]
+ include_dir='~/.config'
+ include_line='source=~/.config/mango/noctalia.conf'
++ dirname /home/rogervn/.config/mango/config.conf
+ mkdir -p /home/rogervn/.config/mango
+ '[' '!' -f /home/rogervn/.config/mango/config.conf ']'
+ grep -q 'source=.*noctalia\.conf' /home/rogervn/.config/mango/config.conf
+ printf '\n%s\n' 'source=~/.config/mango/noctalia.conf'
/nix/store/zax2sikx392kw047w8mmdsllaw3wcy99-noctalia-5.0.0/share/noctalia/assets/templates/mango/apply.sh: line 23: /home/rogervn/.config/mango/config.conf: Permission denied
```

And ran the modified script:
```
sh ~/git/noctalia/assets/templates/mango/apply.sh
{"success":true}
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [X] Tested on another compositor: (mango)
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [-] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [-] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [-] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [-] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [-] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
