### PR TITLE
fix(privacy): detect screen captures from xdg-desktop-portal-wlr

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -555,6 +555,7 @@ namespace {
   });
 
   constexpr auto kScreenShareNamePrefixes = std::to_array<std::string_view>({
+      "xdpw-stream",
       "xdph-streaming",
       "gsr-default",
       "game capture",


### PR DESCRIPTION
## Problem

The privacy widget and OSD never show the **screen-capture** icon while sharing the screen through `xdg-desktop-portal-wlr`.

Screen-share detection in `src/pipewire/pipewire_service.cpp` relies on node-name heuristics (`kScreenShareNamePrefixes` etc.). `xdg-desktop-portal-wlr` names its stream nodes `xdpw-stream-<random>` (verified: `media.name = xdpw-stream-heAokj`), which matches none of the existing prefixes/fragments:

- `xdph-streaming` (Hyprland portal) is checked, but not `xdpw-stream` (wlr portal)
- the node has no `media.role`, so classification falls through to the name heuristics and fails

## Repro

1. niri (or any wlroots compositor) with `xdg-desktop-portal-wlr`
2. Share the screen from Chromium (e.g. Jitsi)
3. PipeWire graph shows a `Video/Source` node `xdpw-stream-*` linked to `Stream/Input/Video` — privacy widget/OSD show nothing

## Fix

Add `xdpw-stream` to `kScreenShareNamePrefixes`. Mic and camera detection are unaffected.