### PR TITLE
fix(plugin store): plugin store closes on installing

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1561,6 +1561,7 @@
         "held-back-hint": "Installs v{version} for plugin API {resolved}. The newest v{latest} needs plugin API {latestRequired}; this Noctalia supports up to {current}.",
         "incompatible": "Incompatible",
         "incompatible-hint": "Needs plugin API {required}; this Noctalia supports {oldest}–{current}.",
+        "installed": "Installed",
         "loading": "Loading catalog…",
         "no-readme": "No description available.",
         "open-page": "Open plugin page on noctalia.dev",

--- a/src/scripting/plugin_manager.cpp
+++ b/src/scripting/plugin_manager.cpp
@@ -593,6 +593,26 @@ namespace scripting {
 
   bool PluginManager::isEnabling(std::string_view pluginId) const { return m_enabling.contains(std::string(pluginId)); }
 
+  bool PluginManager::isMaterialized(std::string_view pluginId) const {
+    const auto subdir = pluginSubdirFromId(pluginId);
+    if (!subdir.has_value()) {
+      return false;
+    }
+    std::error_code ec;
+    const auto hasManifest = [&](const std::filesystem::path& root) {
+      return !root.empty() && std::filesystem::exists(root / *subdir / "plugin.toml", ec);
+    };
+    for (const auto& source : m_config.config().plugins.sources) {
+      if (!source.enabled) {
+        continue;
+      }
+      if (hasManifest(sourceRootFor(source))) {
+        return true;
+      }
+    }
+    return hasManifest(plugin_paths::localSourceRoot());
+  }
+
   void PluginManager::disable(std::string_view pluginId) {
     kLog.info("disabling plugin '{}'", pluginId);
     const bool wasEnabled = std::ranges::contains(m_config.config().plugins.enabled, pluginId);

--- a/src/scripting/plugin_manager.h
+++ b/src/scripting/plugin_manager.h
@@ -103,6 +103,11 @@ namespace scripting {
     // Whether a git-source plugin's background export is currently in flight.
     [[nodiscard]] bool isEnabling(std::string_view pluginId) const;
 
+    // Whether the plugin's files are present on disk under one of the enabled sources
+    // (a git source's export root or a path source's tree). Filesystem-only, no network,
+    // so UI can query it per frame; false while a git export is still in flight.
+    [[nodiscard]] bool isMaterialized(std::string_view pluginId) const;
+
     // Disable a plugin by id and persist. Code stays on disk; settings are retained.
     void disable(std::string_view pluginId);
 

--- a/src/shell/settings/plugin_store_content.cpp
+++ b/src/shell/settings/plugin_store_content.cpp
@@ -831,11 +831,16 @@ namespace settings {
               .text = i18n::tr("settings.plugins.store.add"),
               .fontSize = Style::fontSizeCaption * scale,
               .variant = ButtonVariant::Primary,
-              .onClick = [this, id = entry.id]() {
-                if (m_callbacks.setEnabled) {
-                  m_callbacks.setEnabled(id, true);
-                }
-              },
+              .onClick = [this, id = entry.id]() { installFromStore(id); },
+          })
+      );
+    } else {
+      info->addChild(
+          ui::button({
+              .glyph = "check",
+              .glyphSize = Style::fontSizeCaption * scale,
+              .enabled = false,
+              .variant = ButtonVariant::Default,
           })
       );
     }
@@ -977,8 +982,16 @@ namespace settings {
     if (!m_callbacks.setEnabled) {
       return false;
     }
-    m_callbacks.setEnabled(entry.id, true);
+    installFromStore(entry.id);
     return true;
+  }
+
+  void PluginStoreContent::installFromStore(const std::string& id) {
+    // Installed immediately, a failed export self-heals on store reopen.
+    m_onDiskIds.insert(id);
+    if (m_callbacks.setEnabled) {
+      m_callbacks.setEnabled(id, true);
+    }
   }
 
   bool PluginStoreContent::handleKeyEvent(

--- a/src/shell/settings/plugin_store_content.cpp
+++ b/src/shell/settings/plugin_store_content.cpp
@@ -77,7 +77,6 @@ namespace settings {
       void setContent(PluginStoreContent* content) { m_content = content; }
       void setFilteredIndices(const std::vector<std::size_t>* indices) { m_indices = indices; }
       void setCatalog(const std::vector<StoreCatalogEntry>* catalog) { m_catalog = catalog; }
-      void setOnDiskIds(const std::unordered_set<std::string>* ids) { m_onDiskIds = ids; }
       void setCallbacks(const PluginStoreCallbacks* callbacks) { m_callbacks = callbacks; }
       void setThumbnailPaths(const std::unordered_map<std::string, std::string>* paths) { m_thumbnailPaths = paths; }
       void setRenderer(Renderer* r) { m_renderer = r; }
@@ -93,7 +92,8 @@ namespace settings {
         }
         auto* t = static_cast<PluginStoreTile*>(&tile);
         const auto& storeEntry = (*m_catalog)[(*m_indices)[index]];
-        const bool onDisk = m_onDiskIds != nullptr && m_onDiskIds->contains(storeEntry.entry.id);
+        const bool onDisk =
+            m_callbacks != nullptr && m_callbacks->isInstalled && m_callbacks->isInstalled(storeEntry.entry.id);
         std::string thumbPath;
         if (m_thumbnailPaths != nullptr) {
           auto it = m_thumbnailPaths->find(storeEntry.entry.id);
@@ -115,7 +115,6 @@ namespace settings {
       PluginStoreContent* m_content = nullptr;
       const std::vector<std::size_t>* m_indices = nullptr;
       const std::vector<StoreCatalogEntry>* m_catalog = nullptr;
-      const std::unordered_set<std::string>* m_onDiskIds = nullptr;
       const PluginStoreCallbacks* m_callbacks = nullptr;
       const std::unordered_map<std::string, std::string>* m_thumbnailPaths = nullptr;
       Renderer* m_renderer = nullptr;
@@ -125,11 +124,11 @@ namespace settings {
   } // namespace
 
   PluginStoreContent::PluginStoreContent(
-      std::vector<StoreCatalogEntry> catalog, ConfigService* config, std::unordered_set<std::string> onDiskIds,
-      PluginStoreCallbacks callbacks, scripting::PluginFileCache* fileCache, ScrollViewState* scrollState
+      std::vector<StoreCatalogEntry> catalog, ConfigService* config, PluginStoreCallbacks callbacks,
+      scripting::PluginFileCache* fileCache, ScrollViewState* scrollState
   )
-      : m_catalog(std::move(catalog)), m_config(config), m_onDiskIds(std::move(onDiskIds)),
-        m_callbacks(std::move(callbacks)), m_fileCache(fileCache), m_scrollState(scrollState) {
+      : m_catalog(std::move(catalog)), m_config(config), m_callbacks(std::move(callbacks)), m_fileCache(fileCache),
+        m_scrollState(scrollState) {
     if (m_config != nullptr) {
       if (const std::optional<std::string> sort = m_config->stateString("plugin_store", "sort")) {
         m_sortMode = sortModeFromState(*sort);
@@ -411,6 +410,7 @@ namespace settings {
 
     body.addChild(
         ui::input({
+            .value = m_searchQuery,
             .placeholder = i18n::tr("settings.plugins.store.search-placeholder"),
             .fontSize = Style::fontSizeBody * scale,
             .onChange = [this](const std::string& text) {
@@ -566,7 +566,6 @@ namespace settings {
     adapterPtr->setContent(this);
     adapterPtr->setFilteredIndices(&m_filteredIndices);
     adapterPtr->setCatalog(&m_catalog);
-    adapterPtr->setOnDiskIds(&m_onDiskIds);
     adapterPtr->setCallbacks(&m_callbacks);
     adapterPtr->setThumbnailPaths(&m_thumbnailPaths);
     adapterPtr->setRenderer(&renderer);
@@ -618,7 +617,7 @@ namespace settings {
     const auto& storeEntry = m_catalog[m_filteredIndices[*m_detailIndex]];
     const auto& entry = storeEntry.entry;
     const float scale = m_callbacks.scale;
-    const bool onDisk = m_onDiskIds.contains(entry.id);
+    const bool onDisk = m_callbacks.isInstalled && m_callbacks.isInstalled(entry.id);
     const bool enabling = m_callbacks.isEnabling && m_callbacks.isEnabling(entry.id);
 
     // The sheet hosts the store without an outer ScrollView, so the detail view scrolls its own
@@ -831,17 +830,28 @@ namespace settings {
               .text = i18n::tr("settings.plugins.store.add"),
               .fontSize = Style::fontSizeCaption * scale,
               .variant = ButtonVariant::Primary,
-              .onClick = [this, id = entry.id]() { installFromStore(id); },
+              .onClick = [this, id = entry.id]() {
+                if (m_callbacks.setEnabled) {
+                  m_callbacks.setEnabled(id, true);
+                }
+              },
           })
       );
     } else {
       info->addChild(
-          ui::button({
-              .glyph = "check",
-              .glyphSize = Style::fontSizeCaption * scale,
-              .enabled = false,
-              .variant = ButtonVariant::Default,
-          })
+          ui::row(
+              {.align = FlexAlign::Center, .gap = Style::spaceXs * scale},
+              ui::glyph({
+                  .glyph = "check",
+                  .glyphSize = Style::fontSizeCaption * scale,
+                  .color = colorSpecFromRole(ColorRole::Primary),
+              }),
+              ui::label({
+                  .text = i18n::tr("settings.plugins.store.installed"),
+                  .fontSize = Style::fontSizeCaption * scale,
+                  .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+              })
+          )
       );
     }
     header->addChild(std::move(info));
@@ -973,7 +983,7 @@ namespace settings {
     }
     const auto& storeEntry = m_catalog[m_filteredIndices[*m_detailIndex]];
     const auto& entry = storeEntry.entry;
-    if (!entry.compatible || m_onDiskIds.contains(entry.id)) {
+    if (!entry.compatible || (m_callbacks.isInstalled && m_callbacks.isInstalled(entry.id))) {
       return false;
     }
     if (m_callbacks.isEnabling && m_callbacks.isEnabling(entry.id)) {
@@ -982,16 +992,8 @@ namespace settings {
     if (!m_callbacks.setEnabled) {
       return false;
     }
-    installFromStore(entry.id);
+    m_callbacks.setEnabled(entry.id, true);
     return true;
-  }
-
-  void PluginStoreContent::installFromStore(const std::string& id) {
-    // Installed immediately, a failed export self-heals on store reopen.
-    m_onDiskIds.insert(id);
-    if (m_callbacks.setEnabled) {
-      m_callbacks.setEnabled(id, true);
-    }
   }
 
   bool PluginStoreContent::handleKeyEvent(
@@ -1050,13 +1052,6 @@ namespace settings {
       return activateSelection();
     }
     return false;
-  }
-
-  void PluginStoreContent::updateOnDiskIds(std::unordered_set<std::string> ids) {
-    m_onDiskIds = std::move(ids);
-    if (m_grid != nullptr && !isDetailView()) {
-      m_grid->notifyDataChanged();
-    }
   }
 
   void

--- a/src/shell/settings/plugin_store_content.h
+++ b/src/shell/settings/plugin_store_content.h
@@ -106,6 +106,8 @@ namespace settings {
     void moveSelection(int delta);
     [[nodiscard]] bool activateSelection();
     [[nodiscard]] bool installDetailIfAvailable();
+    // Marks plugin installed then enables it.
+    void installFromStore(const std::string& id);
 
     std::vector<StoreCatalogEntry> m_catalog;
     ConfigService* m_config = nullptr;

--- a/src/shell/settings/plugin_store_content.h
+++ b/src/shell/settings/plugin_store_content.h
@@ -9,7 +9,6 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 class ConfigService;
@@ -47,14 +46,17 @@ namespace settings {
   struct PluginStoreCallbacks {
     std::function<void(std::string id, bool enable)> setEnabled;
     std::function<bool(const std::string& id)> isEnabling;
+    // Whether the plugin's files are on disk right now. Queried per build so a failed
+    // install keeps offering the add action instead of claiming the plugin is there.
+    std::function<bool(const std::string& id)> isInstalled;
     float scale = 1.0F;
   };
 
   class PluginStoreContent {
   public:
     PluginStoreContent(
-        std::vector<StoreCatalogEntry> catalog, ConfigService* config, std::unordered_set<std::string> onDiskIds,
-        PluginStoreCallbacks callbacks, scripting::PluginFileCache* fileCache, ScrollViewState* scrollState
+        std::vector<StoreCatalogEntry> catalog, ConfigService* config, PluginStoreCallbacks callbacks,
+        scripting::PluginFileCache* fileCache, ScrollViewState* scrollState
     );
     ~PluginStoreContent();
 
@@ -63,7 +65,6 @@ namespace settings {
 
     void populateBody(Flex& body, Renderer& renderer, AsyncTextureCache* textureCache);
 
-    void updateOnDiskIds(std::unordered_set<std::string> ids);
     void onFileReady(const std::string& pluginId, const std::string& filename, const std::string& path);
 
     void setOnRebuildNeeded(std::function<void()> cb);
@@ -106,13 +107,10 @@ namespace settings {
     void moveSelection(int delta);
     [[nodiscard]] bool activateSelection();
     [[nodiscard]] bool installDetailIfAvailable();
-    // Marks plugin installed then enables it.
-    void installFromStore(const std::string& id);
 
     std::vector<StoreCatalogEntry> m_catalog;
     ConfigService* m_config = nullptr;
     std::vector<std::size_t> m_filteredIndices;
-    std::unordered_set<std::string> m_onDiskIds;
     std::vector<std::string> m_sources;
     bool m_tagFiltersCollapsed = true;
     std::vector<std::string> m_allTags;

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -1207,7 +1207,11 @@ void SettingsWindow::onExternalOptionsChanged() { requestSceneRebuild(); }
 void SettingsWindow::onPluginsChanged() {
   markPluginListDirty();
   if (isOpen() && m_selectedSection == "plugins") {
-    requestContentRebuild(/*refreshRegistry=*/false, /*refreshFilterRow=*/false, /*rebuildEditorSheet=*/true);
+    // The plugin store's body shows install progress, so it needs the rebuild; any other
+    // editor sheet would just lose its focus for an unrelated plugin event.
+    requestContentRebuild(
+        /*refreshRegistry=*/false, /*refreshFilterRow=*/false, /*rebuildEditorSheet=*/m_pluginStoreSheetOpen
+    );
   }
 }
 

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -1207,7 +1207,7 @@ void SettingsWindow::onExternalOptionsChanged() { requestSceneRebuild(); }
 void SettingsWindow::onPluginsChanged() {
   markPluginListDirty();
   if (isOpen() && m_selectedSection == "plugins") {
-    requestContentRebuild();
+    requestContentRebuild(/*refreshRegistry=*/false, /*refreshFilterRow=*/false, /*rebuildEditorSheet=*/true);
   }
 }
 

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -237,6 +237,9 @@ private:
   bool m_pluginListDirty = true;
   bool m_pluginListRefreshInFlight = false;
   std::uint64_t m_pluginListRefreshGeneration = 0;
+  // The plugin store sheet is the sheet currently on screen, so plugin events may rebuild
+  // the sheet body; any other editor sheet must be left alone.
+  bool m_pluginStoreSheetOpen = false;
   // Plugin catalog scroll state outlives both the store sheet and its async file callbacks.
   ScrollViewState m_pluginStoreScrollState;
   scripting::PluginFileCache m_pluginFileCache;

--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -2018,20 +2018,13 @@ void SettingsWindow::openPluginStore() {
 
       const float scale = uiScale();
 
-      std::unordered_set<std::string> onDiskIds;
-      for (const auto& p : m_pluginList) {
-        if (p.materialized) {
-          onDiskIds.insert(p.id);
-        }
-      }
-
       auto catalogLookup = std::make_shared<std::unordered_map<std::string, scripting::CatalogEntry>>();
       for (const auto& entry : catalog) {
         catalogLookup->emplace(entry.entry.id, entry.entry);
       }
 
       auto storeContent = std::make_shared<settings::PluginStoreContent>(
-          std::move(catalog), m_config, std::move(onDiskIds),
+          std::move(catalog), m_config,
           settings::PluginStoreCallbacks{
               .setEnabled =
                   [this, catalogLookup](std::string id, bool enable) {
@@ -2067,6 +2060,9 @@ void SettingsWindow::openPluginStore() {
               .isEnabling = [this](
                                 const std::string& id
                             ) { return m_pluginManager != nullptr && m_pluginManager->isEnabling(id); },
+              .isInstalled = [this](
+                                 const std::string& id
+                             ) { return m_pluginManager != nullptr && m_pluginManager->isMaterialized(id); },
               .scale = scale,
           },
           &m_pluginFileCache, &m_pluginStoreScrollState
@@ -2180,9 +2176,15 @@ void SettingsWindow::openPluginStore() {
                         event.sym, event.modifiers, event.pressed, event.preedit, focused
                     );
                   },
-              .onClosed = [storeContent]() { storeContent->detachGrid(); },
+              .onClosed =
+                  [storeContent, this]() {
+                    storeContent->detachGrid();
+                    m_pluginFileCache.setOnReady(nullptr);
+                    m_pluginStoreSheetOpen = false;
+                  },
           }
       );
+      m_pluginStoreSheetOpen = m_editorSheetModal->isOpen();
     });
   }).detach();
 }

--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -2040,9 +2040,6 @@ void SettingsWindow::openPluginStore() {
                     }
                     if (enable) {
                       (void)m_pluginManager->enable(id);
-                      if (m_editorSheetModal != nullptr) {
-                        m_editorSheetModal->close();
-                      }
                       ++m_pluginListRefreshGeneration;
                       m_pluginListDirty = false;
                       auto existing = std::ranges::find_if(m_pluginList, [&](const auto& p) { return p.id == id; });
@@ -2062,7 +2059,10 @@ void SettingsWindow::openPluginStore() {
                       m_pluginManager->disable(id);
                       m_pluginListDirty = true;
                     }
-                    requestContentRebuild();
+                    // Keep the store open, rebuild the sheet body so Add swaps to the install spinner.
+                    requestContentRebuild(
+                        /*refreshRegistry=*/false, /*refreshFilterRow=*/false, /*rebuildEditorSheet=*/true
+                    );
                   },
               .isEnabling = [this](
                                 const std::string& id

--- a/tests/plugin_lifecycle_test.cpp
+++ b/tests/plugin_lifecycle_test.cpp
@@ -762,6 +762,11 @@ int main() {
     );
     scripting::PluginManager manager(config);
     manager.refresh();
+    // The plugin store reads install state straight off disk, so a plugin whose files
+    // never landed must not report as materialized.
+    ok = expect(manager.isMaterialized("test/plugin"), "path-source plugin on disk should report materialized") && ok;
+    ok = expect(!manager.isMaterialized("test/absent"), "missing plugin should not report materialized") && ok;
+    ok = expect(!manager.isMaterialized("not-an-id"), "invalid plugin id should not report materialized") && ok;
     config.addReloadCallback([&]() { manager.refresh(); });
     scripting::PluginServiceHost host(api, nullptr, nullptr, nullptr);
     host.start(config.config().plugins.pluginSettings);


### PR DESCRIPTION
## Summary

This PR fix the issue where installing plugin closes the store rather than keep it open. Swaps Add button to spinner on installing.

## Motivation

Closing the store on every install forces users to reopen it and scroll back for plugin again, keeping it open makes multiple installs painless.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4055

## Testing

- Ran `just format`, `just build`, `just test` everything went smoothly
- Killed noctalia and starts build-debug
- Tested with installing plugin and store stay open.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/1a2d92da-3850-439c-ae3a-dd45d880cc33




## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
