### PR TITLE
fix(pipewire): enter/leave loop before iterate

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -755,6 +755,10 @@ PipeWireService::PipeWireService() {
   spa_zero(*m_registryListener);
   pw_registry_add_listener(m_registry, m_registryListener, &kRegistryEvents, this);
 
+  // pw_loop_iterate() requires entering the loop first; PipeWire >= 1.7
+  // enforces this and returns -EPERM otherwise.
+  pw_loop_enter(m_loop);
+
   // Do initial roundtrip to discover existing objects
   auto* loop = m_loop;
   pw_core_sync(m_core, PW_ID_CORE, 0);
@@ -828,6 +832,7 @@ PipeWireService::~PipeWireService() {
     pw_context_destroy(m_context);
   }
   if (m_loop != nullptr) {
+    pw_loop_leave(m_loop);
     pw_loop_destroy(m_loop);
   }
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Fixed the issue of not following PipeWire conventions; detailed analysis can be found in #4081.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4081 
<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Adjust the volume and observe the log output and volume changes.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
