### PR TITLE
fix(nix): disable home-manager noctalia module, add improvements from hm module

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -22,17 +22,24 @@ let
   generateJson = generateConfig jsonFormat;
 in
 {
+  # Disable the home-manager module to avoid conflicts
+  disabledModules = [ "programs/noctalia.nix" ];
+
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "noctalia" "validateConfig" ]
+      [ "programs" "noctalia" "checkConfig" ]
+    )
+  ];
+
   options.programs.noctalia = {
-    enable = lib.mkEnableOption "Whether to enable noctalia, a lightweight Wayland shell and bar.";
+    enable = lib.mkEnableOption "noctalia, a lightweight Wayland shell and bar";
 
-    systemd.enable = lib.mkEnableOption "Enables a systemd user service for noctalia.";
+    systemd.enable = lib.mkEnableOption "a systemd user service for noctalia";
 
-    package = lib.mkOption {
-      type = lib.types.nullOr lib.types.package;
-      description = "The noctalia package to use.";
-    };
+    package = lib.mkPackageOption pkgs "noctalia" { nullable = true; };
 
-    validateConfig = lib.mkOption {
+    checkConfig = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Validate the configuration file at build time.";
@@ -74,11 +81,11 @@ in
     customPalettes = lib.mkOption {
       type =
         with lib.types;
-        oneOf [
+        attrsOf (oneOf [
           jsonFormat.type
           str
           path
-        ];
+        ]);
       default = { };
       description = ''
         Custom color pallete options.
@@ -119,8 +126,8 @@ in
             let
               rawConfig = generateToml "config.toml" cfg.settings;
             in
-            if cfg.validateConfig && cfg.package != null then
-              pkgs.runCommand "noctalia-config" { } ''
+            if cfg.checkConfig && cfg.package != null then
+              pkgs.runCommand "noctalia-config.toml" { } ''
                 ${lib.getExe cfg.package} config validate ${rawConfig}
                 cp ${rawConfig} $out
               ''


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

disable the home-manager module for folks using the flake module, and converge the option names. using the old option name causes a deprecation warning at eval time.

also some improvements were made to the module when it was added to home-manager, so i'm adding them here too:
- use `mkPackageOption`
- add `attrsOf` to the `customPalettes` type
- `mkEnableOption` description fixes
- `noctalia-config` -> `noctalia-config.toml` derivation rename

## Motivation

disabling the hm module means users of the flake module don't get conflicts from the options existing in both.

with option names converged, once the downstream module is in hm stable we can remove the one from this flake and users will require no changes.

adding the improvements because they're general qol improvements and are not breaking changes.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

Closes: #4083

## Testing

tested via eval:

| configuration | status |
| --- | --- |
| home-manager master + this module | disables hm module, no error |
| home-manager stable + this module | no hm module, no error |
| this module using `validateConfig` | deprecation warning, no error |
| `homeModules.default` with `package` unset | uses flake package instead of nixpkgs | 

## Manual Coverage

<!-- Mark what applies to this PR. -->

n/a, no runtime changes

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

didn't touch the hjem module, that could probably also do with a review pass but there's nothing being upstreamed rn so didn't worry about it for now.