### PR TITLE
fix(pipewire): use in-follow passive mode on PipeWire >= 1.7

### DIFF
--- a/src/pipewire/pipewire_spectrum.cpp
+++ b/src/pipewire/pipewire_spectrum.cpp
@@ -12,7 +12,6 @@
 #include <pipewire/keys.h>
 #include <pipewire/properties.h>
 #include <pipewire/stream.h>
-#include <pipewire/version.h>
 #include <spa/param/audio/format.h>
 #include <spa/param/audio/raw-utils.h>
 #include <spa/param/audio/raw.h>
@@ -171,12 +170,7 @@ bool PipeWireSpectrum::Stream::start() {
   auto* props = pw_properties_new(
       PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Capture", PW_KEY_MEDIA_NAME, "Noctalia Spectrum",
       PW_KEY_APP_NAME, "Noctalia Spectrum", PW_KEY_STREAM_MONITOR, "true", PW_KEY_STREAM_CAPTURE_SINK, "true",
-      PW_KEY_MEDIA_ROLE, "Music", PW_KEY_TARGET_OBJECT, m_targetObject.c_str(),
-#if PW_CHECK_VERSION(1, 7, 0)
-      PW_KEY_NODE_PASSIVE, "in-follow",
-#else
-      PW_KEY_NODE_PASSIVE, "true",
-#endif
+      PW_KEY_MEDIA_ROLE, "Music", PW_KEY_TARGET_OBJECT, m_targetObject.c_str(), PW_KEY_NODE_PASSIVE, "in-follow",
       nullptr
   );
   if (props == nullptr) {

--- a/src/pipewire/pipewire_spectrum.cpp
+++ b/src/pipewire/pipewire_spectrum.cpp
@@ -12,6 +12,7 @@
 #include <pipewire/keys.h>
 #include <pipewire/properties.h>
 #include <pipewire/stream.h>
+#include <pipewire/version.h>
 #include <spa/param/audio/format.h>
 #include <spa/param/audio/raw-utils.h>
 #include <spa/param/audio/raw.h>
@@ -170,7 +171,13 @@ bool PipeWireSpectrum::Stream::start() {
   auto* props = pw_properties_new(
       PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Capture", PW_KEY_MEDIA_NAME, "Noctalia Spectrum",
       PW_KEY_APP_NAME, "Noctalia Spectrum", PW_KEY_STREAM_MONITOR, "true", PW_KEY_STREAM_CAPTURE_SINK, "true",
-      PW_KEY_MEDIA_ROLE, "Music", PW_KEY_TARGET_OBJECT, m_targetObject.c_str(), PW_KEY_NODE_PASSIVE, "true", nullptr
+      PW_KEY_MEDIA_ROLE, "Music", PW_KEY_TARGET_OBJECT, m_targetObject.c_str(),
+#if PW_CHECK_VERSION(1, 7, 0)
+      PW_KEY_NODE_PASSIVE, "in-follow",
+#else
+      PW_KEY_NODE_PASSIVE, "true",
+#endif
+      nullptr
   );
   if (props == nullptr) {
     kLog.warn("failed to create spectrum stream properties");


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adapted to the API updates made to pipewire in commit `22536600b`.
<!-- What changed and why? -->

## Motivation

In this PipeWire update, the configurable values for `PW_KEY_NODE_PASSIVE` have changed from the original "out"/"in"/"true" to "out"/"out-follow"/"out-follow-suspend"/"in"/"in-follow"/"in-follow-suspend"/"true"/"follow"/"follow-suspend".

In terms of behavior, this causes noctalia to be unable to display the audio spectrum.

Accordingly, on the noctalia side, it has been changed from `true` to `in-follow`, with `#if PW_CHECK_VERSION(1, 7, 0)` used to maintain compatibility with older versions of PipeWire.
<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

Observe the behavior on noctalia with PipeWire built from master.
<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

>I am not a native English speaker and used an LLM to assist with the translation.
<!-- Add follow-up notes, reviewer context, or known limitations. -->