### PR TITLE
fix(control-center): tick home tab clock while the panel is open

### DIFF
--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -1233,6 +1233,7 @@ void HomeTab::setActive(bool active) {
   m_active = active;
   if (!active) {
     m_progressTimer.stop();
+    m_clockTimer.stop();
     m_nextRealtimeUpdateAt = {};
     m_lastRealtimeMprisPollAt = {};
     m_mediaPositionBusName.clear();
@@ -1251,11 +1252,33 @@ void HomeTab::setActive(bool active) {
       PanelManager::instance().requestLayout();
       PanelManager::instance().requestUpdateOnly();
     });
+
+    // Tick the clock once per second so the time/date labels keep moving while the panel is
+    // open and idle. Without this, the clock only refreshes when an unrelated service happens
+    // to force a redraw (see issue #4046). setText() is a no-op when the text is unchanged, so
+    // formats without seconds cost nothing beyond the cheap format + comparison each second.
+    m_clockTimer.startRepeating(std::chrono::milliseconds(1000), [this]() {
+      if (!m_active) {
+        return;
+      }
+      bool changed = false;
+      if (m_timeLabel != nullptr) {
+        changed = m_timeLabel->setText(formatShellTime(m_config)) || changed;
+      }
+      if (m_dateLabel != nullptr) {
+        changed = m_dateLabel->setText(formatShellDate(m_config)) || changed;
+      }
+      if (changed) {
+        PanelManager::instance().requestLayout();
+        PanelManager::instance().requestRedraw();
+      }
+    });
   }
 }
 
 void HomeTab::onClose() {
   m_progressTimer.stop();
+  m_clockTimer.stop();
   m_rootLayout = nullptr;
   m_bottomRow = nullptr;
   m_dateTimeCard = nullptr;

--- a/src/shell/control_center/tabs/home_tab.h
+++ b/src/shell/control_center/tabs/home_tab.h
@@ -158,6 +158,9 @@ private:
   std::chrono::steady_clock::time_point m_nextRealtimeUpdateAt;
   std::chrono::steady_clock::time_point m_lastRealtimeMprisPollAt;
   Timer m_progressTimer;
+  // Keeps the home tab clock ticking while the panel is open and idle; the clock
+  // otherwise only refreshes when an unrelated service forces a redraw.
+  Timer m_clockTimer;
 
   GridView* m_shortcutsGrid = nullptr;
   std::vector<ShortcutPad> m_shortcutPads;


### PR DESCRIPTION


<!-- If this PR is not ready for review yet, please mark it as Draft. -->



## Summary



Added a repeating timer that fires every second to the clock on the Control Center home tab, reformatting the time/date text each second and triggering `requestLayout` + `requestRedraw` only when the text actually changes. It is stopped synchronously in `setActive(false)` and `onClose()`.


<!-- What changed and why? -->



## Motivation



The clock text was originally only updated in `HomeTab::sync()`, and `sync()` only runs when the panel's `update` path is triggered. When the panel is open and idle, nothing schedules a redraw for the clock, causing it to freeze. `onFrameTick()` was originally an empty implementation, exactly missing a `tick` to drive the clock. With this timer added, the clock refreshes precisely every second or every minute.


<!-- What problem does this solve? -->



## Type of Change



<!-- Mark all that apply. -->



- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging



## Related Issue



Closes #4046


<!-- Example: Closes #123 -->



## Testing

Observe the clock status and find that it updates normally once per second.
<!-- List commands run and any manual testing. If not run, say why. -->



## Manual Coverage



<!-- Mark what applies to this PR. -->



- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors



## Screenshots / Videos



<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->



## Checklist



- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.



## Additional Notes

>I am not a native English speaker and used LLM-assisted translation

<!-- Add follow-up notes, reviewer context, or known limitations. -->