### PR TITLE
feat(audio-visualizer): add wave rendering mode

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -556,6 +556,7 @@
         "show-unlock-hint": "Unlock Hint",
         "show-vpn-label": "Show VPN Label",
         "show-weather": "Weather",
+        "show-wave": "Show Wave",
         "show-week-numbers": "Show Week Numbers",
         "show-when-idle": "Show When Idle",
         "stat": "Stat",
@@ -3820,6 +3821,10 @@
         "show-when-idle": {
           "description": "Keep the visualizer visible even when no media is playing",
           "label": "Show When Idle"
+        },
+        "show-wave": {
+          "description": "Display as a filled-area wave instead of discrete bars",
+          "label": "Show Wave"
         },
         "show-window-title": {
           "description": "Show the window title next to its icon (only on horizontal bars)",

--- a/src/render/core/render_styles.h
+++ b/src/render/core/render_styles.h
@@ -175,6 +175,7 @@ struct AudioSpectrumStyle {
   bool mirrored = false;
   bool reversed = false;
   bool centered = false;
+  bool wave = false;
 };
 
 constexpr bool operator==(const AudioSpectrumStyle& lhs, const AudioSpectrumStyle& rhs) noexcept {
@@ -183,7 +184,8 @@ constexpr bool operator==(const AudioSpectrumStyle& lhs, const AudioSpectrumStyl
       && lhs.orientation == rhs.orientation
       && lhs.mirrored == rhs.mirrored
       && lhs.reversed == rhs.reversed
-      && lhs.centered == rhs.centered;
+      && lhs.centered == rhs.centered
+      && lhs.wave == rhs.wave;
 }
 
 enum class FancyAudioVisualizerMode : std::uint8_t {

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -190,8 +190,11 @@ void AudioSpectrumProgram::draw(
       const float p3 = get(i + 2);
       const float t2 = frac * frac;
       const float t3 = t2 * frac;
-      return 0.5F * ((2.0F * p1) + (-p0 + p2) * frac + (2.0F * p0 - 5.0F * p1 + 4.0F * p2 - p3) * t2
-                      + (-p0 + 3.0F * p1 - 3.0F * p2 + p3) * t3);
+      return 0.5F
+          * ((2.0F * p1)
+             + (-p0 + p2) * frac
+             + (2.0F * p0 - 5.0F * p1 + 4.0F * p2 - p3) * t2
+             + (-p0 + 3.0F * p1 - 3.0F * p2 + p3) * t3);
     };
 
     const int totalSlices = barCount * kTessellation;

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -160,47 +160,113 @@ void AudioSpectrumProgram::draw(
   m_vertices.clear();
   m_vertices.reserve(static_cast<std::size_t>(barCount) * 6U * 6U);
 
-  for (int i = 0; i < barCount; ++i) {
-    const int baseIndex = style.mirrored ? (i < valueCount ? valueCount - 1 - i : i - valueCount) : i;
-    const int valueIndex = style.reversed ? valueCount - 1 - baseIndex : baseIndex;
-    const float rawValue = valueIndex >= 0 && valueIndex < valueCount
-        ? std::clamp(values[static_cast<std::size_t>(valueIndex)], 0.0F, 1.0F)
-        : 0.0F;
-    float crossPixels = std::max(1.0F, std::floor(rawValue * crossAxisLen * crossPixelScale + 0.5F));
-    if (style.centered && crossPixels > 1.0F) {
-      crossPixels = std::max(2.0F, std::round(crossPixels * 0.5F) * 2.0F);
-    }
-    const float crossSize = crossPixels / crossPixelScale;
+  if (style.wave) {
+    constexpr int kTessellation = 4;
 
-    float mainStart = compactBars ? startOffset + static_cast<float>(i) * stride
-                                  : snapToPixel(startOffset + static_cast<float>(i) * stride, mainPixelScale);
-    float mainEnd = mainStart + barThickness;
-    if (mainStart < 0.0F) {
-      mainEnd -= mainStart;
-      mainStart = 0.0F;
+    std::vector<float> bandValues(static_cast<std::size_t>(barCount));
+    for (int i = 0; i < barCount; ++i) {
+      const int baseIndex = style.mirrored ? (i < valueCount ? valueCount - 1 - i : i - valueCount) : i;
+      const int valueIndex = style.reversed ? valueCount - 1 - baseIndex : baseIndex;
+      bandValues[static_cast<std::size_t>(i)] = valueIndex >= 0 && valueIndex < valueCount
+          ? std::clamp(values[static_cast<std::size_t>(valueIndex)], 0.0F, 1.0F)
+          : 0.0F;
     }
-    if (mainEnd > mainAxisLen) {
-      mainStart = std::max(0.0F, mainStart - (mainEnd - mainAxisLen));
-      mainEnd = mainAxisLen;
-    }
-    float crossStart =
-        snapToPixel(style.centered ? (crossAxisLen - crossSize) * 0.5F : crossAxisLen - crossSize, crossPixelScale);
-    float crossEnd = crossStart + crossSize;
-    if (crossStart < 0.0F) {
-      crossEnd -= crossStart;
-      crossStart = 0.0F;
-    }
-    if (crossEnd > crossAxisLen) {
-      crossStart = std::max(0.0F, crossStart - (crossEnd - crossAxisLen));
-      crossEnd = crossAxisLen;
-    }
-    const float t = barCount <= 1 ? 0.0F : static_cast<float>(i) / static_cast<float>(barCount - 1);
-    const Color color = colorAt(style.color1, style.color2, t);
 
-    if (horizontal) {
-      pushQuad(m_vertices, mainStart, crossStart, mainEnd, crossEnd, color);
-    } else {
-      pushQuad(m_vertices, crossStart, mainStart, crossEnd, mainEnd, color);
+    auto sampleValue = [&bandValues](float position) {
+      const auto count = static_cast<float>(bandValues.size());
+      const float clamped = std::clamp(position, 0.0F, count - 1.0F);
+      const float fi = std::floor(clamped);
+      const int i = static_cast<int>(fi);
+      const float frac = clamped - fi;
+      const auto get = [&bandValues](int idx) -> float {
+        return bandValues[static_cast<std::size_t>(std::clamp(idx, 0, static_cast<int>(bandValues.size()) - 1))];
+      };
+      if (frac == 0.0F) {
+        return get(i);
+      }
+      const float p0 = get(i - 1);
+      const float p1 = get(i);
+      const float p2 = get(i + 1);
+      const float p3 = get(i + 2);
+      const float t2 = frac * frac;
+      const float t3 = t2 * frac;
+      return 0.5F * ((2.0F * p1) + (-p0 + p2) * frac + (2.0F * p0 - 5.0F * p1 + 4.0F * p2 - p3) * t2
+                      + (-p0 + 3.0F * p1 - 3.0F * p2 + p3) * t3);
+    };
+
+    const int totalSlices = barCount * kTessellation;
+    const float sliceWidth = mainAxisLen / static_cast<float>(totalSlices);
+
+    auto waveCross = [&](float position) -> float {
+      const float value = sampleValue(position);
+      const float crossPixels = std::max(1.0F, std::floor(value * crossAxisLen * crossPixelScale + 0.5F));
+      return crossPixels / crossPixelScale;
+    };
+
+    for (int s = 0; s < totalSlices; ++s) {
+      const float pos0 = static_cast<float>(s) * static_cast<float>(barCount) / static_cast<float>(totalSlices);
+      const float pos1 = static_cast<float>(s + 1) * static_cast<float>(barCount) / static_cast<float>(totalSlices);
+      const float x0 = static_cast<float>(s) * sliceWidth;
+      const float x1 = static_cast<float>(s + 1) * sliceWidth;
+      const float topY0 = crossAxisLen - waveCross(pos0);
+      const float topY1 = crossAxisLen - waveCross(pos1);
+      const float bottomY = crossAxisLen;
+
+      const float t0 = barCount <= 1 ? 0.0F : std::clamp(pos0 / static_cast<float>(barCount - 1), 0.0F, 1.0F);
+      const float t1 = barCount <= 1 ? 0.0F : std::clamp(pos1 / static_cast<float>(barCount - 1), 0.0F, 1.0F);
+      const Color color0 = colorAt(style.color1, style.color2, t0);
+      const Color color1 = colorAt(style.color1, style.color2, t1);
+
+      pushVertex(m_vertices, x0, topY0, color0);
+      pushVertex(m_vertices, x0, bottomY, color0);
+      pushVertex(m_vertices, x1, topY1, color1);
+      pushVertex(m_vertices, x0, bottomY, color0);
+      pushVertex(m_vertices, x1, bottomY, color1);
+      pushVertex(m_vertices, x1, topY1, color1);
+    }
+  } else {
+    for (int i = 0; i < barCount; ++i) {
+      const int baseIndex = style.mirrored ? (i < valueCount ? valueCount - 1 - i : i - valueCount) : i;
+      const int valueIndex = style.reversed ? valueCount - 1 - baseIndex : baseIndex;
+      const float rawValue = valueIndex >= 0 && valueIndex < valueCount
+          ? std::clamp(values[static_cast<std::size_t>(valueIndex)], 0.0F, 1.0F)
+          : 0.0F;
+      float crossPixels = std::max(1.0F, std::floor(rawValue * crossAxisLen * crossPixelScale + 0.5F));
+      if (style.centered && crossPixels > 1.0F) {
+        crossPixels = std::max(2.0F, std::round(crossPixels * 0.5F) * 2.0F);
+      }
+      const float crossSize = crossPixels / crossPixelScale;
+
+      float mainStart = compactBars ? startOffset + static_cast<float>(i) * stride
+                                    : snapToPixel(startOffset + static_cast<float>(i) * stride, mainPixelScale);
+      float mainEnd = mainStart + barThickness;
+      if (mainStart < 0.0F) {
+        mainEnd -= mainStart;
+        mainStart = 0.0F;
+      }
+      if (mainEnd > mainAxisLen) {
+        mainStart = std::max(0.0F, mainStart - (mainEnd - mainAxisLen));
+        mainEnd = mainAxisLen;
+      }
+      float crossStart =
+          snapToPixel(style.centered ? (crossAxisLen - crossSize) * 0.5F : crossAxisLen - crossSize, crossPixelScale);
+      float crossEnd = crossStart + crossSize;
+      if (crossStart < 0.0F) {
+        crossEnd -= crossStart;
+        crossStart = 0.0F;
+      }
+      if (crossEnd > crossAxisLen) {
+        crossStart = std::max(0.0F, crossStart - (crossEnd - crossAxisLen));
+        crossEnd = crossAxisLen;
+      }
+      const float t = barCount <= 1 ? 0.0F : static_cast<float>(i) / static_cast<float>(barCount - 1);
+      const Color color = colorAt(style.color1, style.color2, t);
+
+      if (horizontal) {
+        pushQuad(m_vertices, mainStart, crossStart, mainEnd, crossEnd, color);
+      } else {
+        pushQuad(m_vertices, crossStart, mainStart, crossEnd, mainEnd, color);
+      }
     }
   }
 

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -175,8 +175,8 @@ void AudioSpectrumProgram::draw(
     // Wave renders from a fixed number of control points pooled from the band data, so
     // hill width follows the widget size and stays independent of the bands setting.
     // The baseline lifts valleys so the silhouette reads as one rolling wave, not teeth.
-    constexpr int kWaveControlPoints = 20;
-    constexpr float kWaveBaseline = 0.18F;
+    constexpr int kWaveControlPoints = 32;
+    constexpr float kWaveBaseline = 0.10F;
     const int pointCount = std::min(barCount, kWaveControlPoints);
     std::vector<float> wavePoints(static_cast<std::size_t>(pointCount));
     for (int i = 0; i < pointCount; ++i) {
@@ -193,15 +193,13 @@ void AudioSpectrumProgram::draw(
 
     // Blur across control points so raw FFT comb structure doesn't cut narrow teeth.
     std::vector<float> smoothed(bandValues.size());
-    for (int pass = 0; pass < 3; ++pass) {
-      for (int i = 0; i < pointCount; ++i) {
-        const auto get = [&bandValues, pointCount](int idx) -> float {
-          return bandValues[static_cast<std::size_t>(std::clamp(idx, 0, pointCount - 1))];
-        };
-        smoothed[static_cast<std::size_t>(i)] = 0.25F * get(i - 1) + 0.5F * get(i) + 0.25F * get(i + 1);
-      }
-      bandValues = smoothed;
+    for (int i = 0; i < pointCount; ++i) {
+      const auto get = [&bandValues, pointCount](int idx) -> float {
+        return bandValues[static_cast<std::size_t>(std::clamp(idx, 0, pointCount - 1))];
+      };
+      smoothed[static_cast<std::size_t>(i)] = 0.25F * get(i - 1) + 0.5F * get(i) + 0.25F * get(i + 1);
     }
+    bandValues = std::move(smoothed);
 
     auto sampleValue = [&bandValues](float position) {
       const auto count = static_cast<float>(bandValues.size());
@@ -231,61 +229,82 @@ void AudioSpectrumProgram::draw(
     // Keep the polyline dense enough that wide surfaces don't reveal straight segments.
     const auto minSlices = static_cast<int>(mainAxisLen * mainPixelScale / 3.0F);
     const int totalSlices = std::clamp(minSlices, pointCount * kTessellation, 1024);
+    m_vertices.reserve(static_cast<std::size_t>(totalSlices) * 24U * 6U);
     // Half-device-pixel skirt with a per-vertex alpha ramp acts as edge antialiasing;
     // the rasterizer would otherwise stair-step the curved top.
     const float aa = 0.5F / crossPixelScale;
     const float sliceWidth = mainAxisLen / static_cast<float>(totalSlices);
-
-    auto waveCross = [&](float position) -> float {
-      return std::max(1.0F / crossPixelScale, sampleValue(position) * crossAxisLen);
+    // Taper the wave into the baseline at both ends instead of ending in a vertical cliff.
+    constexpr float kWaveEdgeFade = 0.18F;
+    const auto edgeFade = [pointCount](float position) {
+      const auto smooth = [](float e0, float e1, float x) {
+        const float t = std::clamp((x - e0) / (e1 - e0), 0.0F, 1.0F);
+        return t * t * (3.0F - 2.0F * t);
+      };
+      const float u = pointCount <= 1 ? 0.0F : position / static_cast<float>(pointCount - 1);
+      return smooth(0.0F, kWaveEdgeFade, u) * smooth(1.0F, 1.0F - kWaveEdgeFade, u);
     };
 
-    for (int s = 0; s < totalSlices; ++s) {
-      const float pos0 = static_cast<float>(s) * static_cast<float>(pointCount) / static_cast<float>(totalSlices);
-      const float pos1 = static_cast<float>(s + 1) * static_cast<float>(pointCount) / static_cast<float>(totalSlices);
-      const float x0 = static_cast<float>(s) * sliceWidth;
-      const float x1 = static_cast<float>(s + 1) * sliceWidth;
-      const float topY0 = crossAxisLen - waveCross(pos0);
-      const float topY1 = crossAxisLen - waveCross(pos1);
-      const float bottomY = crossAxisLen;
+    auto waveCross = [&](float position, float offset, float scale) -> float {
+      const float raw = std::max(1.0F / crossPixelScale, sampleValue(position + offset) * scale * crossAxisLen);
+      return raw * edgeFade(position);
+    };
 
-      const float t0 = pointCount <= 1 ? 0.0F : std::clamp(pos0 / static_cast<float>(pointCount - 1), 0.0F, 1.0F);
-      const float t1 = pointCount <= 1 ? 0.0F : std::clamp(pos1 / static_cast<float>(pointCount - 1), 0.0F, 1.0F);
-      const Color color0 = colorAt(style.color1, style.color2, t0);
-      const Color color1 = colorAt(style.color1, style.color2, t1);
-      Color fade0 = color0;
-      fade0.a = 0.0F;
-      Color fade1 = color1;
-      fade1.a = 0.0F;
+    const auto emitWaveLayer = [&](float offset, float scale, bool solidColor2) {
+      for (int s = 0; s < totalSlices; ++s) {
+        const float pos0 = static_cast<float>(s) * static_cast<float>(pointCount) / static_cast<float>(totalSlices);
+        const float pos1 = static_cast<float>(s + 1) * static_cast<float>(pointCount) / static_cast<float>(totalSlices);
+        const float x0 = static_cast<float>(s) * sliceWidth;
+        const float x1 = static_cast<float>(s + 1) * sliceWidth;
+        const float topY0 = crossAxisLen - waveCross(pos0, offset, scale);
+        const float topY1 = crossAxisLen - waveCross(pos1, offset, scale);
+        const float bottomY = crossAxisLen;
 
-      if (horizontal) {
-        pushVertex(m_vertices, x0, topY0 - aa, fade0);
-        pushVertex(m_vertices, x1, topY1 - aa, fade1);
-        pushVertex(m_vertices, x0, topY0 + aa, color0);
-        pushVertex(m_vertices, x0, topY0 + aa, color0);
-        pushVertex(m_vertices, x1, topY1 - aa, fade1);
-        pushVertex(m_vertices, x1, topY1 + aa, color1);
-        pushVertex(m_vertices, x0, topY0 + aa, color0);
-        pushVertex(m_vertices, x0, bottomY, color0);
-        pushVertex(m_vertices, x1, topY1 + aa, color1);
-        pushVertex(m_vertices, x0, bottomY, color0);
-        pushVertex(m_vertices, x1, bottomY, color1);
-        pushVertex(m_vertices, x1, topY1 + aa, color1);
-      } else {
-        pushVertex(m_vertices, topY0 - aa, x0, fade0);
-        pushVertex(m_vertices, topY1 - aa, x1, fade1);
-        pushVertex(m_vertices, topY0 + aa, x0, color0);
-        pushVertex(m_vertices, topY0 + aa, x0, color0);
-        pushVertex(m_vertices, topY1 - aa, x1, fade1);
-        pushVertex(m_vertices, topY1 + aa, x1, color1);
-        pushVertex(m_vertices, topY0 + aa, x0, color0);
-        pushVertex(m_vertices, bottomY, x0, color0);
-        pushVertex(m_vertices, topY1 + aa, x1, color1);
-        pushVertex(m_vertices, bottomY, x0, color0);
-        pushVertex(m_vertices, bottomY, x1, color1);
-        pushVertex(m_vertices, topY1 + aa, x1, color1);
+        const float t0 = pointCount <= 1 ? 0.0F : std::clamp(pos0 / static_cast<float>(pointCount - 1), 0.0F, 1.0F);
+        const float t1 = pointCount <= 1 ? 0.0F : std::clamp(pos1 / static_cast<float>(pointCount - 1), 0.0F, 1.0F);
+        Color color0 = solidColor2 ? style.color2 : colorAt(style.color1, style.color2, t0);
+        Color color1 = solidColor2 ? style.color2 : colorAt(style.color1, style.color2, t1);
+        Color fade0 = color0;
+        fade0.a = 0.0F;
+        Color fade1 = color1;
+        fade1.a = 0.0F;
+
+        if (horizontal) {
+          pushVertex(m_vertices, x0, topY0 - aa, fade0);
+          pushVertex(m_vertices, x1, topY1 - aa, fade1);
+          pushVertex(m_vertices, x0, topY0 + aa, color0);
+          pushVertex(m_vertices, x0, topY0 + aa, color0);
+          pushVertex(m_vertices, x1, topY1 - aa, fade1);
+          pushVertex(m_vertices, x1, topY1 + aa, color1);
+          pushVertex(m_vertices, x0, topY0 + aa, color0);
+          pushVertex(m_vertices, x0, bottomY, color0);
+          pushVertex(m_vertices, x1, topY1 + aa, color1);
+          pushVertex(m_vertices, x0, bottomY, color0);
+          pushVertex(m_vertices, x1, bottomY, color1);
+          pushVertex(m_vertices, x1, topY1 + aa, color1);
+        } else {
+          pushVertex(m_vertices, topY0 - aa, x0, fade0);
+          pushVertex(m_vertices, topY1 - aa, x1, fade1);
+          pushVertex(m_vertices, topY0 + aa, x0, color0);
+          pushVertex(m_vertices, topY0 + aa, x0, color0);
+          pushVertex(m_vertices, topY1 - aa, x1, fade1);
+          pushVertex(m_vertices, topY1 + aa, x1, color1);
+          pushVertex(m_vertices, topY0 + aa, x0, color0);
+          pushVertex(m_vertices, bottomY, x0, color0);
+          pushVertex(m_vertices, topY1 + aa, x1, color1);
+          pushVertex(m_vertices, bottomY, x0, color0);
+          pushVertex(m_vertices, bottomY, x1, color1);
+          pushVertex(m_vertices, topY1 + aa, x1, color1);
+        }
       }
-    }
+    };
+
+    // Secondary echo wave drawn in front of the main curve in the secondary color,
+    // phase-shifted and scaled down so its peaks layer over the main wave.
+    constexpr float kWaveSecondaryOffset = 0.3F;
+    constexpr float kWaveSecondaryScale = 0.55F;
+    emitWaveLayer(0.0F, 1.0F, false);
+    emitWaveLayer(static_cast<float>(pointCount) * kWaveSecondaryOffset, kWaveSecondaryScale, true);
   } else {
     for (int i = 0; i < barCount; ++i) {
       const int baseIndex = style.mirrored ? (i < valueCount ? valueCount - 1 - i : i - valueCount) : i;

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -172,6 +172,37 @@ void AudioSpectrumProgram::draw(
           : 0.0F;
     }
 
+    // Wave renders from a fixed number of control points pooled from the band data, so
+    // hill width follows the widget size and stays independent of the bands setting.
+    // The baseline lifts valleys so the silhouette reads as one rolling wave, not teeth.
+    constexpr int kWaveControlPoints = 20;
+    constexpr float kWaveBaseline = 0.18F;
+    const int pointCount = std::min(barCount, kWaveControlPoints);
+    std::vector<float> wavePoints(static_cast<std::size_t>(pointCount));
+    for (int i = 0; i < pointCount; ++i) {
+      const int s0 = i * barCount / pointCount;
+      const int s1 = std::max(s0 + 1, (i + 1) * barCount / pointCount);
+      float sum = 0.0F;
+      for (int j = s0; j < s1; ++j) {
+        sum += bandValues[static_cast<std::size_t>(j)];
+      }
+      wavePoints[static_cast<std::size_t>(i)] =
+          kWaveBaseline + (1.0F - kWaveBaseline) * std::pow(sum / static_cast<float>(s1 - s0), 0.4F);
+    }
+    bandValues = std::move(wavePoints);
+
+    // Blur across control points so raw FFT comb structure doesn't cut narrow teeth.
+    std::vector<float> smoothed(bandValues.size());
+    for (int pass = 0; pass < 3; ++pass) {
+      for (int i = 0; i < pointCount; ++i) {
+        const auto get = [&bandValues, pointCount](int idx) -> float {
+          return bandValues[static_cast<std::size_t>(std::clamp(idx, 0, pointCount - 1))];
+        };
+        smoothed[static_cast<std::size_t>(i)] = 0.25F * get(i - 1) + 0.5F * get(i) + 0.25F * get(i + 1);
+      }
+      bandValues = smoothed;
+    }
+
     auto sampleValue = [&bandValues](float position) {
       const auto count = static_cast<float>(bandValues.size());
       const float clamped = std::clamp(position, 0.0F, count - 1.0F);
@@ -190,50 +221,69 @@ void AudioSpectrumProgram::draw(
       const float p3 = get(i + 2);
       const float t2 = frac * frac;
       const float t3 = t2 * frac;
-      return 0.5F
-          * ((2.0F * p1)
-             + (-p0 + p2) * frac
-             + (2.0F * p0 - 5.0F * p1 + 4.0F * p2 - p3) * t2
-             + (-p0 + 3.0F * p1 - 3.0F * p2 + p3) * t3);
+      return (1.0F / 6.0F)
+          * ((-t3 + 3.0F * t2 - 3.0F * frac + 1.0F) * p0
+             + (3.0F * t3 - 6.0F * t2 + 4.0F) * p1
+             + (-3.0F * t3 + 3.0F * t2 + 3.0F * frac + 1.0F) * p2
+             + t3 * p3);
     };
 
-    const int totalSlices = barCount * kTessellation;
+    // Keep the polyline dense enough that wide surfaces don't reveal straight segments.
+    const auto minSlices = static_cast<int>(mainAxisLen * mainPixelScale / 3.0F);
+    const int totalSlices = std::clamp(minSlices, pointCount * kTessellation, 1024);
+    // Half-device-pixel skirt with a per-vertex alpha ramp acts as edge antialiasing;
+    // the rasterizer would otherwise stair-step the curved top.
+    const float aa = 0.5F / crossPixelScale;
     const float sliceWidth = mainAxisLen / static_cast<float>(totalSlices);
 
     auto waveCross = [&](float position) -> float {
-      const float value = sampleValue(position);
-      const float crossPixels = std::max(1.0F, std::floor(value * crossAxisLen * crossPixelScale + 0.5F));
-      return crossPixels / crossPixelScale;
+      return std::max(1.0F / crossPixelScale, sampleValue(position) * crossAxisLen);
     };
 
     for (int s = 0; s < totalSlices; ++s) {
-      const float pos0 = static_cast<float>(s) * static_cast<float>(barCount) / static_cast<float>(totalSlices);
-      const float pos1 = static_cast<float>(s + 1) * static_cast<float>(barCount) / static_cast<float>(totalSlices);
+      const float pos0 = static_cast<float>(s) * static_cast<float>(pointCount) / static_cast<float>(totalSlices);
+      const float pos1 = static_cast<float>(s + 1) * static_cast<float>(pointCount) / static_cast<float>(totalSlices);
       const float x0 = static_cast<float>(s) * sliceWidth;
       const float x1 = static_cast<float>(s + 1) * sliceWidth;
       const float topY0 = crossAxisLen - waveCross(pos0);
       const float topY1 = crossAxisLen - waveCross(pos1);
       const float bottomY = crossAxisLen;
 
-      const float t0 = barCount <= 1 ? 0.0F : std::clamp(pos0 / static_cast<float>(barCount - 1), 0.0F, 1.0F);
-      const float t1 = barCount <= 1 ? 0.0F : std::clamp(pos1 / static_cast<float>(barCount - 1), 0.0F, 1.0F);
+      const float t0 = pointCount <= 1 ? 0.0F : std::clamp(pos0 / static_cast<float>(pointCount - 1), 0.0F, 1.0F);
+      const float t1 = pointCount <= 1 ? 0.0F : std::clamp(pos1 / static_cast<float>(pointCount - 1), 0.0F, 1.0F);
       const Color color0 = colorAt(style.color1, style.color2, t0);
       const Color color1 = colorAt(style.color1, style.color2, t1);
+      Color fade0 = color0;
+      fade0.a = 0.0F;
+      Color fade1 = color1;
+      fade1.a = 0.0F;
 
       if (horizontal) {
-        pushVertex(m_vertices, x0, topY0, color0);
+        pushVertex(m_vertices, x0, topY0 - aa, fade0);
+        pushVertex(m_vertices, x1, topY1 - aa, fade1);
+        pushVertex(m_vertices, x0, topY0 + aa, color0);
+        pushVertex(m_vertices, x0, topY0 + aa, color0);
+        pushVertex(m_vertices, x1, topY1 - aa, fade1);
+        pushVertex(m_vertices, x1, topY1 + aa, color1);
+        pushVertex(m_vertices, x0, topY0 + aa, color0);
         pushVertex(m_vertices, x0, bottomY, color0);
-        pushVertex(m_vertices, x1, topY1, color1);
+        pushVertex(m_vertices, x1, topY1 + aa, color1);
         pushVertex(m_vertices, x0, bottomY, color0);
         pushVertex(m_vertices, x1, bottomY, color1);
-        pushVertex(m_vertices, x1, topY1, color1);
+        pushVertex(m_vertices, x1, topY1 + aa, color1);
       } else {
-        pushVertex(m_vertices, topY0, x0, color0);
+        pushVertex(m_vertices, topY0 - aa, x0, fade0);
+        pushVertex(m_vertices, topY1 - aa, x1, fade1);
+        pushVertex(m_vertices, topY0 + aa, x0, color0);
+        pushVertex(m_vertices, topY0 + aa, x0, color0);
+        pushVertex(m_vertices, topY1 - aa, x1, fade1);
+        pushVertex(m_vertices, topY1 + aa, x1, color1);
+        pushVertex(m_vertices, topY0 + aa, x0, color0);
         pushVertex(m_vertices, bottomY, x0, color0);
-        pushVertex(m_vertices, topY1, x1, color1);
+        pushVertex(m_vertices, topY1 + aa, x1, color1);
         pushVertex(m_vertices, bottomY, x0, color0);
         pushVertex(m_vertices, bottomY, x1, color1);
-        pushVertex(m_vertices, topY1, x1, color1);
+        pushVertex(m_vertices, topY1 + aa, x1, color1);
       }
     }
   } else {

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -220,12 +220,21 @@ void AudioSpectrumProgram::draw(
       const Color color0 = colorAt(style.color1, style.color2, t0);
       const Color color1 = colorAt(style.color1, style.color2, t1);
 
-      pushVertex(m_vertices, x0, topY0, color0);
-      pushVertex(m_vertices, x0, bottomY, color0);
-      pushVertex(m_vertices, x1, topY1, color1);
-      pushVertex(m_vertices, x0, bottomY, color0);
-      pushVertex(m_vertices, x1, bottomY, color1);
-      pushVertex(m_vertices, x1, topY1, color1);
+      if (horizontal) {
+        pushVertex(m_vertices, x0, topY0, color0);
+        pushVertex(m_vertices, x0, bottomY, color0);
+        pushVertex(m_vertices, x1, topY1, color1);
+        pushVertex(m_vertices, x0, bottomY, color0);
+        pushVertex(m_vertices, x1, bottomY, color1);
+        pushVertex(m_vertices, x1, topY1, color1);
+      } else {
+        pushVertex(m_vertices, topY0, x0, color0);
+        pushVertex(m_vertices, bottomY, x0, color0);
+        pushVertex(m_vertices, topY1, x1, color1);
+        pushVertex(m_vertices, bottomY, x0, color0);
+        pushVertex(m_vertices, bottomY, x1, color1);
+        pushVertex(m_vertices, topY1, x1, color1);
+      }
     }
   } else {
     for (int i = 0; i < barCount; ++i) {

--- a/src/shell/bar/widgets/audio_visualizer_widget.cpp
+++ b/src/shell/bar/widgets/audio_visualizer_widget.cpp
@@ -13,7 +13,7 @@
 
 AudioVisualizerWidget::AudioVisualizerWidget(PipeWireSpectrum* spectrum, Options options)
     : m_spectrum(spectrum), m_width(static_cast<float>(options.width)), m_bands(options.bands),
-      m_mirrored(options.mirrored), m_reversed(options.reversed), m_centered(options.centered),
+      m_mirrored(options.mirrored), m_reversed(options.reversed), m_centered(options.centered), m_wave(options.wave),
       m_showWhenIdle(options.showWhenIdle), m_color1(options.color1), m_color2(options.color2) {}
 
 AudioVisualizerWidget::~AudioVisualizerWidget() {
@@ -33,6 +33,7 @@ void AudioVisualizerWidget::create() {
   visualizer->setCentered(m_centered);
   visualizer->setMirrored(m_mirrored);
   visualizer->setReversed(m_reversed);
+  visualizer->setWave(m_wave);
   visualizer->setGradient(m_color1, m_color2);
   m_visualizer = visualizer.get();
   root->addChild(std::move(visualizer));

--- a/src/shell/bar/widgets/audio_visualizer_widget.h
+++ b/src/shell/bar/widgets/audio_visualizer_widget.h
@@ -16,6 +16,7 @@ public:
     bool mirrored = true;
     bool reversed = false;
     bool centered = true;
+    bool wave = false;
     bool showWhenIdle = false;
     ColorSpec color1 = colorSpecFromRole(ColorRole::Primary);
     ColorSpec color2 = colorSpecFromRole(ColorRole::Primary);
@@ -44,6 +45,7 @@ private:
   bool m_mirrored = false;
   bool m_reversed = false;
   bool m_centered = true;
+  bool m_wave = false;
   bool m_showWhenIdle = false;
   ColorSpec m_color1 = colorSpecFromRole(ColorRole::Primary);
   ColorSpec m_color2 = colorSpecFromRole(ColorRole::Primary);

--- a/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
+++ b/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
@@ -25,9 +25,13 @@ const noctalia::bar::WidgetDefinition<AudioVisualizerWidget::Options>& audioVisu
           field<&Options::reversed>({
               .key = "reversed",
           }),
-          field<&Options::centered>({
-              .key = "centered",
-          }),
+          field<&Options::centered>(
+              {.key = "centered",
+               .presentation =
+                   settings::WidgetSettingPresentation{
+                       .visibleWhen = settings::WidgetSettingVisibility{"show_wave", {"false"}},
+                   }}
+          ),
           field<&Options::wave>({
               .key = "show_wave",
           }),

--- a/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
+++ b/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
@@ -28,6 +28,9 @@ const noctalia::bar::WidgetDefinition<AudioVisualizerWidget::Options>& audioVisu
           field<&Options::centered>({
               .key = "centered",
           }),
+          field<&Options::wave>({
+              .key = "show_wave",
+          }),
           field<&Options::showWhenIdle>({
               .key = "show_when_idle",
           }),

--- a/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
+++ b/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
@@ -13,12 +13,16 @@ const noctalia::bar::WidgetDefinition<AudioVisualizerWidget::Options>& audioVisu
               .maxValue = 2048.0,
               .step = 1.0,
           }),
-          field<&Options::bands>({
-              .key = "bands",
-              .minValue = 2.0,
-              .maxValue = 128.0,
-              .step = 1.0,
-          }),
+          field<&Options::bands>(
+              {.key = "bands",
+               .minValue = 2.0,
+               .maxValue = 128.0,
+               .step = 1.0,
+               .presentation =
+                   settings::WidgetSettingPresentation{
+                       .visibleWhen = settings::WidgetSettingVisibility{"show_wave", {"false"}},
+                   }}
+          ),
           field<&Options::mirrored>({
               .key = "mirrored",
           }),

--- a/src/shell/desktop/desktop_widget_factory.cpp
+++ b/src/shell/desktop/desktop_widget_factory.cpp
@@ -233,6 +233,7 @@ std::unique_ptr<DesktopWidget> DesktopWidgetFactory::create(
             .mirrored = getBoolSetting(settings, "mirrored", true),
             .reversed = getBoolSetting(settings, "reversed", false),
             .centered = getBoolSetting(settings, "centered", true),
+            .wave = getBoolSetting(settings, "show_wave", false),
             .showWhenIdle = getBoolSetting(settings, "show_when_idle", true),
             .color1 = getColorSpecSetting(settings, "color_1", colorSpecFromRole(ColorRole::Primary)),
             .color2 = getColorSpecSetting(settings, "color_2", colorSpecFromRole(ColorRole::Primary)),

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -275,7 +275,9 @@ namespace desktop_settings {
       circle.visibleWhen = analogOnly;
       add(std::move(circle));
     } else if (type == "audio_visualizer") {
-      add(intSpec("bands", 32, 4.0, 128.0, 4.0));
+      auto bands = intSpec("bands", 32, 4.0, 128.0, 4.0);
+      bands.visibleWhen = WidgetSettingVisibility{"show_wave", {"false"}};
+      add(std::move(bands));
       add(boolSpec("mirrored", true));
       add(boolSpec("reversed", false));
       auto centered = boolSpec("centered", true);

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -278,7 +278,10 @@ namespace desktop_settings {
       add(intSpec("bands", 32, 4.0, 128.0, 4.0));
       add(boolSpec("mirrored", true));
       add(boolSpec("reversed", false));
-      add(boolSpec("centered", true));
+      auto centered = boolSpec("centered", true);
+      centered.visibleWhen = WidgetSettingVisibility{"show_wave", {"false"}};
+      add(std::move(centered));
+      add(boolSpec("show_wave", false));
       add(boolSpec("show_when_idle", true));
       add(colorSpec("color_1", "primary"));
       add(colorSpec("color_2", "primary"));

--- a/src/shell/desktop/widgets/desktop_audio_visualizer_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_audio_visualizer_widget.cpp
@@ -23,8 +23,8 @@ namespace {
 
 DesktopAudioVisualizerWidget::DesktopAudioVisualizerWidget(PipeWireSpectrum* spectrum, Options options)
     : m_spectrum(spectrum), m_bands(std::max(1, options.bands)), m_mirrored(options.mirrored),
-      m_reversed(options.reversed), m_centered(options.centered), m_showWhenIdle(options.showWhenIdle),
-      m_color1(options.color1), m_color2(options.color2) {}
+      m_reversed(options.reversed), m_centered(options.centered), m_wave(options.wave),
+      m_showWhenIdle(options.showWhenIdle), m_color1(options.color1), m_color2(options.color2) {}
 
 DesktopAudioVisualizerWidget::~DesktopAudioVisualizerWidget() {
   cancelVisibilityAnimation();
@@ -42,6 +42,7 @@ void DesktopAudioVisualizerWidget::create() {
   visualizer->setCentered(m_centered);
   visualizer->setMirrored(m_mirrored);
   visualizer->setReversed(m_reversed);
+  visualizer->setWave(m_wave);
   visualizer->setGradient(m_color1, m_color2);
   m_visualizer = visualizer.get();
   rootNode->addChild(std::move(visualizer));
@@ -95,6 +96,14 @@ bool DesktopAudioVisualizerWidget::applySetting(
     if (const auto* v = std::get_if<bool>(&value)) {
       m_centered = *v;
       m_visualizer->setCentered(m_centered);
+      return true;
+    }
+    return false;
+  }
+  if (key == "show_wave") {
+    if (const auto* v = std::get_if<bool>(&value)) {
+      m_wave = *v;
+      m_visualizer->setWave(m_wave);
       return true;
     }
     return false;

--- a/src/shell/desktop/widgets/desktop_audio_visualizer_widget.h
+++ b/src/shell/desktop/widgets/desktop_audio_visualizer_widget.h
@@ -16,6 +16,7 @@ public:
     bool mirrored = true;
     bool reversed = false;
     bool centered = true;
+    bool wave = false;
     bool showWhenIdle = true;
     ColorSpec color1 = colorSpecFromRole(ColorRole::Primary);
     ColorSpec color2 = colorSpecFromRole(ColorRole::Primary);
@@ -51,6 +52,7 @@ private:
   bool m_mirrored = true;
   bool m_reversed = false;
   bool m_centered = true;
+  bool m_wave = false;
   bool m_showWhenIdle = false;
   bool m_editorPreview = false;
   ColorSpec m_color1 = colorSpecFromRole(ColorRole::Primary);

--- a/src/ui/visuals/audio_visualizer.cpp
+++ b/src/ui/visuals/audio_visualizer.cpp
@@ -94,6 +94,12 @@ void AudioVisualizer::setCentered(bool centered) {
   setStyle(next);
 }
 
+void AudioVisualizer::setWave(bool wave) {
+  auto next = style();
+  next.wave = wave;
+  setStyle(next);
+}
+
 void AudioVisualizer::syncPalette() {
   auto next = style();
   next.color1 = resolveColorSpec(m_color1);

--- a/src/ui/visuals/audio_visualizer.h
+++ b/src/ui/visuals/audio_visualizer.h
@@ -17,6 +17,7 @@ public:
   void setMirrored(bool mirrored);
   void setReversed(bool reversed);
   void setCentered(bool centered);
+  void setWave(bool wave);
   void setSmoothingTimeMs(float tauMs) noexcept { m_smoothingTauMs = std::max(0.0F, tauMs); }
 
   void tick(float deltaMs);


### PR DESCRIPTION
EDIT: For most recent changes read latest comment as images in here are not final but more of the starting implementation.

## Summary

Add a wave rendering mode to `AudioSpectrumProgram` and expose it as a `show_wave` toggle in the Audio Visualizer widget. When enabled, spectrum data is displayed as a smooth filled-area wave using catmull-rom interpolation instead of discrete bars.

The wave geometry uses a tessellated strip (4 slices per band) with catmull-rom spline interpolation between band values, producing a continuous smooth curve. The rendering integrates into the existing `AudioSpectrumStyle` via a `wave` flag that defaults to `false`, preserving all existing bar behavior for current users. Adjusting the bands also adjust just like it does normally with bars.

## Motivation

The audio visualizer widget currently only supports discrete bar rendering. A smooth wave mode provides an alternative visual presentation that better represents continuous audio spectrum data.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

## Testing

- `just build` — clean
- `just lint` — no warnings or errors
- `just test` — 92/92 pass
- `python3 tools/i18n-check.py` — all keys present
- `just format` — no changes

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="379" height="34" alt="image" src="https://github.com/user-attachments/assets/5526e1f0-7728-49b5-ab45-488c193993c2" />
<img width="397" height="36" alt="image" src="https://github.com/user-attachments/assets/05180813-b9b1-46ac-9870-45d9f19358ef" />

<img width="42" height="1400" alt="image" src="https://github.com/user-attachments/assets/037ddad6-826e-4a0d-8ae9-5e2fad8c162f" />



## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- `wave` flag defaults to `false` in `AudioSpectrumStyle`, so all existing users are unaffected.
- The wave mode ignores `centered` so centering a continuous curve doesn't apply.
- Catmull-rom interpolation clamps at endpoints, producing flat edges at band 0 and band N-1.
- `kTessellation = 4` is a constexpr hardcoded value. Can be exposed as a config option later if users want to tune smoothness.
- Doesn't effect audio visualizers anywhere else, just the widget
