### PR TITLE
fix(launcher): activate pinned applications on mouse click

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1205,6 +1205,7 @@ if build_tests
     'ui_tree_reconciler',
     'upower_charge_limit',
     'upower_device_catalog',
+    'virtual_grid_view_gesture',
     'wayland_output_scale',
     'wayland_toplevels_identity',
     'widget_action',

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -757,28 +757,16 @@ public:
     m_dragSourceIndex = index;
     m_dropIndex.reset();
     m_dragging = false;
-    m_dragStartPos.reset();
     return true;
   }
 
   bool onPointerDrag(
-      std::optional<std::size_t> index, float localX, float localY, float /*cellWidth*/, float /*cellHeight*/
+      std::optional<std::size_t> index, float /*localX*/, float /*localY*/, float /*cellWidth*/, float /*cellHeight*/
   ) override {
     if (!m_dragSourceIndex.has_value()) {
       return false;
     }
-    if (!m_dragStartPos.has_value()) {
-      m_dragStartPos = std::pair<float, float>{localX, localY};
-    }
-    const float dx = localX - m_dragStartPos->first;
-    const float dy = localY - m_dragStartPos->second;
-    const float threshold = Style::dragStartThreshold * m_style.scale;
-    if (!m_dragging) {
-      if (std::hypot(dx, dy) < threshold) {
-        return false;
-      }
-      m_dragging = true;
-    }
+    m_dragging = true;
 
     const std::optional<std::size_t> nextTarget =
         index.has_value() && *index != *m_dragSourceIndex && isReorderable(*index) ? index : std::nullopt;
@@ -789,16 +777,14 @@ public:
     return true;
   }
 
-  bool onPointerRelease(std::optional<std::size_t> releaseIndex) override {
+  bool onPointerRelease(std::optional<std::size_t> /*index*/) override {
     const auto sourceIndex = m_dragSourceIndex;
     const auto targetIndex = m_dropIndex;
     const bool reordered = m_dragging && sourceIndex.has_value() && targetIndex.has_value() && m_onReorder;
-    const bool activated = !reordered && sourceIndex.has_value() && m_onActivate
-        && (!m_dragging || (!targetIndex.has_value() && releaseIndex == sourceIndex));
+    const bool activated = !m_dragging && sourceIndex.has_value() && m_onActivate;
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
-    m_dragStartPos.reset();
     if (reordered) {
       m_onReorder(*sourceIndex, *targetIndex);
     } else if (activated) {
@@ -811,7 +797,6 @@ public:
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
-    m_dragStartPos.reset();
   }
 
   void onActivate(std::size_t index) override {
@@ -842,7 +827,6 @@ private:
   std::optional<std::size_t> m_dragSourceIndex;
   std::optional<std::size_t> m_dropIndex;
   bool m_dragging = false;
-  std::optional<std::pair<float, float>> m_dragStartPos;
 };
 
 class LauncherAppGridAdapter final : public VirtualGridAdapter {
@@ -921,29 +905,16 @@ public:
     m_dragSourceIndex = index;
     m_dropIndex.reset();
     m_dragging = false;
-    m_dragStartPos.reset();
     return true;
   }
 
   bool onPointerDrag(
-      std::optional<std::size_t> index, float localX, float localY, float /*cellWidth*/, float /*cellHeight*/
+      std::optional<std::size_t> index, float /*localX*/, float /*localY*/, float /*cellWidth*/, float /*cellHeight*/
   ) override {
     if (!m_dragSourceIndex.has_value()) {
       return false;
     }
-    if (!m_dragStartPos.has_value()) {
-      m_dragStartPos = std::pair<float, float>{localX, localY};
-    }
-    const float dx = localX - m_dragStartPos->first;
-    const float dy = localY - m_dragStartPos->second;
-    const float threshold = Style::dragStartThreshold * m_style.scale;
-    if (!m_dragging) {
-      if (std::hypot(dx, dy) < threshold) {
-        return false;
-      }
-      m_dragging = true;
-    }
-
+    m_dragging = true;
     const std::optional<std::size_t> nextTarget =
         index.has_value() && *index != *m_dragSourceIndex && isReorderable(*index) ? index : std::nullopt;
     if (nextTarget == m_dropIndex) {
@@ -953,16 +924,14 @@ public:
     return true;
   }
 
-  bool onPointerRelease(std::optional<std::size_t> releaseIndex) override {
+  bool onPointerRelease(std::optional<std::size_t> /*index*/) override {
     const auto sourceIndex = m_dragSourceIndex;
     const auto targetIndex = m_dropIndex;
     const bool reordered = m_dragging && sourceIndex.has_value() && targetIndex.has_value() && m_onReorder;
-    const bool activated = !reordered && sourceIndex.has_value() && m_onActivate
-        && (!m_dragging || (!targetIndex.has_value() && releaseIndex == sourceIndex));
+    const bool activated = !m_dragging && sourceIndex.has_value() && m_onActivate;
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
-    m_dragStartPos.reset();
     if (reordered) {
       m_onReorder(*sourceIndex, *targetIndex);
     } else if (activated) {
@@ -975,7 +944,6 @@ public:
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
-    m_dragStartPos.reset();
   }
 
   void onActivate(std::size_t index) override {
@@ -1006,7 +974,6 @@ private:
   std::optional<std::size_t> m_dragSourceIndex;
   std::optional<std::size_t> m_dropIndex;
   bool m_dragging = false;
-  std::optional<std::pair<float, float>> m_dragStartPos;
 };
 
 LauncherPanel::LauncherPanel(ConfigService* config, AsyncTextureCache* asyncTextures)
@@ -1278,6 +1245,7 @@ void LauncherPanel::syncLauncherViewLayout(Renderer* renderer) {
   const bool useGrid = shouldUseAppGrid();
   const float scale = contentScale();
   const LauncherListStyle style = launcherListStyleFrom(m_config, scale, panelCardOpacity());
+  m_grid->setScale(scale);
   m_listAdapter->setListStyle(style);
   m_gridAdapter->setListStyle(style);
   const bool reorderEnabled = m_query.empty() && m_scopedProviderId.empty() && m_activeCategoryType == All;

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -757,16 +757,26 @@ public:
     m_dragSourceIndex = index;
     m_dropIndex.reset();
     m_dragging = false;
+    m_dragStartPos.reset();
     return true;
   }
 
   bool onPointerDrag(
-      std::optional<std::size_t> index, float /*localX*/, float /*localY*/, float /*cellWidth*/, float /*cellHeight*/
+      std::optional<std::size_t> index, float localX, float localY, float /*cellWidth*/, float /*cellHeight*/
   ) override {
     if (!m_dragSourceIndex.has_value()) {
       return false;
     }
+    if (!m_dragStartPos.has_value()) {
+      m_dragStartPos = std::pair<float, float>{localX, localY};
+    }
+    const float dx = localX - m_dragStartPos->first;
+    const float dy = localY - m_dragStartPos->second;
+    const float threshold = Style::dragStartThreshold * m_style.scale;
     if (!m_dragging) {
+      if (std::hypot(dx, dy) < threshold) {
+        return false;
+      }
       m_dragging = true;
     }
 
@@ -779,14 +789,16 @@ public:
     return true;
   }
 
-  bool onPointerRelease(std::optional<std::size_t> /*index*/) override {
+  bool onPointerRelease(std::optional<std::size_t> releaseIndex) override {
     const auto sourceIndex = m_dragSourceIndex;
     const auto targetIndex = m_dropIndex;
     const bool reordered = m_dragging && sourceIndex.has_value() && targetIndex.has_value() && m_onReorder;
-    const bool activated = !m_dragging && sourceIndex.has_value() && m_onActivate;
+    const bool activated = !reordered && sourceIndex.has_value() && m_onActivate
+        && (!m_dragging || (!targetIndex.has_value() && releaseIndex == sourceIndex));
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
+    m_dragStartPos.reset();
     if (reordered) {
       m_onReorder(*sourceIndex, *targetIndex);
     } else if (activated) {
@@ -799,6 +811,7 @@ public:
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
+    m_dragStartPos.reset();
   }
 
   void onActivate(std::size_t index) override {
@@ -829,6 +842,7 @@ private:
   std::optional<std::size_t> m_dragSourceIndex;
   std::optional<std::size_t> m_dropIndex;
   bool m_dragging = false;
+  std::optional<std::pair<float, float>> m_dragStartPos;
 };
 
 class LauncherAppGridAdapter final : public VirtualGridAdapter {
@@ -907,16 +921,29 @@ public:
     m_dragSourceIndex = index;
     m_dropIndex.reset();
     m_dragging = false;
+    m_dragStartPos.reset();
     return true;
   }
 
   bool onPointerDrag(
-      std::optional<std::size_t> index, float /*localX*/, float /*localY*/, float /*cellWidth*/, float /*cellHeight*/
+      std::optional<std::size_t> index, float localX, float localY, float /*cellWidth*/, float /*cellHeight*/
   ) override {
     if (!m_dragSourceIndex.has_value()) {
       return false;
     }
-    m_dragging = true;
+    if (!m_dragStartPos.has_value()) {
+      m_dragStartPos = std::pair<float, float>{localX, localY};
+    }
+    const float dx = localX - m_dragStartPos->first;
+    const float dy = localY - m_dragStartPos->second;
+    const float threshold = Style::dragStartThreshold * m_style.scale;
+    if (!m_dragging) {
+      if (std::hypot(dx, dy) < threshold) {
+        return false;
+      }
+      m_dragging = true;
+    }
+
     const std::optional<std::size_t> nextTarget =
         index.has_value() && *index != *m_dragSourceIndex && isReorderable(*index) ? index : std::nullopt;
     if (nextTarget == m_dropIndex) {
@@ -926,14 +953,16 @@ public:
     return true;
   }
 
-  bool onPointerRelease(std::optional<std::size_t> /*index*/) override {
+  bool onPointerRelease(std::optional<std::size_t> releaseIndex) override {
     const auto sourceIndex = m_dragSourceIndex;
     const auto targetIndex = m_dropIndex;
     const bool reordered = m_dragging && sourceIndex.has_value() && targetIndex.has_value() && m_onReorder;
-    const bool activated = !m_dragging && sourceIndex.has_value() && m_onActivate;
+    const bool activated = !reordered && sourceIndex.has_value() && m_onActivate
+        && (!m_dragging || (!targetIndex.has_value() && releaseIndex == sourceIndex));
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
+    m_dragStartPos.reset();
     if (reordered) {
       m_onReorder(*sourceIndex, *targetIndex);
     } else if (activated) {
@@ -946,6 +975,7 @@ public:
     m_dragSourceIndex.reset();
     m_dropIndex.reset();
     m_dragging = false;
+    m_dragStartPos.reset();
   }
 
   void onActivate(std::size_t index) override {
@@ -976,6 +1006,7 @@ private:
   std::optional<std::size_t> m_dragSourceIndex;
   std::optional<std::size_t> m_dropIndex;
   bool m_dragging = false;
+  std::optional<std::pair<float, float>> m_dragStartPos;
 };
 
 LauncherPanel::LauncherPanel(ConfigService* config, AsyncTextureCache* asyncTextures)

--- a/src/ui/controls/virtual_grid_view.cpp
+++ b/src/ui/controls/virtual_grid_view.cpp
@@ -491,6 +491,17 @@ void VirtualGridView::onPointerMotion(float localX, float localY) {
   const auto idx = indexAt(localX, localY);
 
   if (m_adapterPointerCapture && m_adapter != nullptr) {
+    // A held press only becomes a drag once the pointer has travelled the same
+    // distance the rest of the shell requires. Pointers emit motion between
+    // press and release (and enter is replayed as motion after a scene-root
+    // swap), so without this every click would reach the adapter as a
+    // zero-distance drag and never as a click.
+    if (!m_dragThresholdPassed) {
+      if (std::hypot(localX - m_pressLocalX, localY - m_pressLocalY) < Style::dragStartThreshold * m_scale) {
+        return;
+      }
+      m_dragThresholdPassed = true;
+    }
     if (m_adapter->onPointerDrag(idx, localX, localY, m_cellWidth, m_cellHeightResolved)) {
       notifyDataChanged();
     }
@@ -569,6 +580,9 @@ void VirtualGridView::onPointerPress(float localX, float localY) {
   cellLocalAt(localX, localY, *idx, cellLocalX, cellLocalY);
   if (m_adapter->onPointerPress(*idx, cellLocalX, cellLocalY, m_cellWidth, m_cellHeightResolved)) {
     m_adapterPointerCapture = true;
+    m_pressLocalX = localX;
+    m_pressLocalY = localY;
+    m_dragThresholdPassed = false;
     return;
   }
   m_adapter->onActivate(*idx);

--- a/src/ui/controls/virtual_grid_view.h
+++ b/src/ui/controls/virtual_grid_view.h
@@ -109,6 +109,9 @@ public:
   void setColumnGap(float gap);
   void setRowGap(float gap);
   void setOverscanRows(std::size_t rows);
+  // Content scale, used for the pointer travel threshold that separates a click
+  // from a drag on an adapter-consumed press.
+  void setScale(float scale) { m_scale = scale; }
 
   void scrollToIndex(std::size_t index);
   void setSelectedIndex(std::optional<std::size_t> index);
@@ -168,6 +171,7 @@ private:
   float m_columnGap = 4.0F;
   float m_rowGap = 4.0F;
   std::size_t m_overscanRows = 2;
+  float m_scale = 1.0F;
 
   std::optional<std::size_t> m_selectedIndex;
   std::optional<std::size_t> m_hoveredIndex;
@@ -186,4 +190,10 @@ private:
   bool m_pendingScrollToIndex = false;
   std::size_t m_pendingScrollIndex = 0;
   bool m_adapterPointerCapture = false;
+  // Press point of the captured press, and whether the pointer has travelled
+  // far enough since for the gesture to count as a drag. Only meaningful while
+  // m_adapterPointerCapture holds, and both are set when capture begins.
+  float m_pressLocalX = 0.0F;
+  float m_pressLocalY = 0.0F;
+  bool m_dragThresholdPassed = false;
 };

--- a/tests/virtual_grid_view_gesture_test.cpp
+++ b/tests/virtual_grid_view_gesture_test.cpp
@@ -1,0 +1,215 @@
+// Covers the click-vs-drag split for adapter-consumed presses. Pointers emit
+// motion between press and release (and a scene-root swap replays enter as
+// motion), so a grid that forwards every motion as a drag turns each click on a
+// reorderable item into a zero-distance drag the adapter can never tell apart
+// from a real one.
+
+#include "render/core/renderer.h"
+#include "render/scene/input_area.h"
+#include "render/scene/node.h"
+#include "ui/controls/virtual_grid_view.h"
+#include "ui/style.h"
+
+#include <cstddef>
+#include <linux/input-event-codes.h>
+#include <memory>
+#include <optional>
+#include <print>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+  int gFailures = 0;
+
+  void expect(bool condition, std::string_view message) {
+    if (!condition) {
+      std::println(stderr, "virtual_grid_view_gesture_test: {}", message);
+      ++gFailures;
+    }
+  }
+
+  class StubRenderer final : public Renderer {
+  public:
+    TextMetrics measureText(
+        std::string_view, float fontSize, FontWeight, float, int, TextAlign, std::string_view, TextEllipsize, bool
+    ) override {
+      return TextMetrics{.bottom = fontSize};
+    }
+
+    TextMetrics measureFont(float fontSize, FontWeight) override { return TextMetrics{.bottom = fontSize}; }
+
+    void measureTextCursorStops(
+        std::string_view, float, const std::vector<std::size_t>&, std::vector<float>&, FontWeight
+    ) override {}
+
+    void measureTextCursorStopsWrapped(
+        std::string_view, float, const std::vector<std::size_t>&, float, std::vector<TextCursorStop>&, FontWeight
+    ) override {}
+
+    TextMetrics measureGlyph(char32_t, float) override { return TextMetrics{}; }
+
+    TextureManager& textureManager() override { std::abort(); }
+    [[nodiscard]] float renderScale() const noexcept override { return 1.0F; }
+  };
+
+  // Stands in for the launcher's pinned-entry adapters: consumes the press so it
+  // can tell a reorder drag from an activation on release.
+  class RecordingAdapter final : public VirtualGridAdapter {
+  public:
+    [[nodiscard]] std::size_t itemCount() const override { return 4; }
+    [[nodiscard]] std::unique_ptr<Node> createTile() override { return std::make_unique<Node>(); }
+    void bindTile(Node&, std::size_t, bool, bool) override {}
+
+    bool onPointerPress(std::size_t index, float, float, float, float) override {
+      presses.push_back(index);
+      return true;
+    }
+
+    bool onPointerDrag(std::optional<std::size_t> index, float, float, float, float) override {
+      drags.push_back(index);
+      return false;
+    }
+
+    bool onPointerRelease(std::optional<std::size_t> index) override {
+      releases.push_back(index);
+      return false;
+    }
+
+    void reset() {
+      presses.clear();
+      drags.clear();
+      releases.clear();
+    }
+
+    std::vector<std::size_t> presses;
+    std::vector<std::optional<std::size_t>> drags;
+    std::vector<std::optional<std::size_t>> releases;
+  };
+
+  constexpr float kCellHeight = 40.0F;
+
+} // namespace
+
+int main() {
+  StubRenderer renderer;
+  RecordingAdapter adapter;
+
+  VirtualGridView grid;
+  grid.setAdapter(&adapter);
+  grid.setColumns(1);
+  grid.setSquareCells(false);
+  grid.setCellHeight(kCellHeight);
+  grid.setRowGap(0.0F);
+  grid.setSize(100.0F, 200.0F);
+  grid.layout(renderer);
+
+  InputArea* area = grid.focusArea();
+  if (area == nullptr) {
+    std::println(stderr, "virtual_grid_view_gesture_test: grid has no input area");
+    return 1;
+  }
+
+  const float threshold = Style::dragStartThreshold;
+
+  {
+    // A click that jitters below the threshold is a click, not a drag.
+    adapter.reset();
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F + threshold - 0.5F, 10.0F);
+    area->dispatchPress(10.0F + threshold - 0.5F, 10.0F, BTN_LEFT, false);
+    expect(adapter.presses == std::vector<std::size_t>{0}, "press did not reach the adapter");
+    expect(adapter.drags.empty(), "sub-threshold motion was forwarded as a drag");
+    expect(
+        adapter.releases == std::vector<std::optional<std::size_t>>{std::optional<std::size_t>{0}},
+        "release did not report the item under the pointer"
+    );
+  }
+
+  {
+    // The motion replayed after a scene-root swap carries the press position.
+    adapter.reset();
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F, 10.0F);
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, false);
+    expect(adapter.drags.empty(), "zero-distance motion was forwarded as a drag");
+    expect(adapter.releases.size() == 1, "release was not delivered");
+  }
+
+  {
+    // Past the threshold the adapter gets the drag, with the item under the
+    // pointer, and no drag event for the travel that was still below it.
+    adapter.reset();
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F, 10.0F + threshold - 0.5F);
+    area->dispatchMotion(10.0F, 10.0F + threshold + 1.0F);
+    area->dispatchMotion(10.0F, kCellHeight + 10.0F);
+    area->dispatchPress(10.0F, kCellHeight + 10.0F, BTN_LEFT, false);
+    expect(
+        adapter.drags
+            == std::vector<std::optional<std::size_t>>{
+                std::optional<std::size_t>{0},
+                std::optional<std::size_t>{1},
+            },
+        "drag delivery did not start exactly at the threshold crossing"
+    );
+    expect(
+        adapter.releases == std::vector<std::optional<std::size_t>>{std::optional<std::size_t>{1}},
+        "release did not report the item the drag ended on"
+    );
+  }
+
+  {
+    // Once armed, the gesture stays a drag even if the pointer returns inside
+    // the threshold radius.
+    adapter.reset();
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F, 10.0F + threshold + 1.0F);
+    area->dispatchMotion(10.0F, 10.0F);
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, false);
+    expect(
+        adapter.drags
+            == std::vector<std::optional<std::size_t>>{
+                std::optional<std::size_t>{0},
+                std::optional<std::size_t>{0},
+            },
+        "return inside the threshold radius disarmed the drag"
+    );
+  }
+
+  {
+    // The threshold is a logical distance: it scales with the surface.
+    adapter.reset();
+    grid.setScale(2.0F);
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F + threshold + 1.0F, 10.0F);
+    expect(adapter.drags.empty(), "threshold ignored the content scale");
+    area->dispatchMotion(10.0F + 2.0F * threshold + 1.0F, 10.0F);
+    expect(adapter.drags.size() == 1, "scaled threshold never armed the drag");
+    area->dispatchPress(10.0F + 2.0F * threshold + 1.0F, 10.0F, BTN_LEFT, false);
+    grid.setScale(1.0F);
+  }
+
+  {
+    // A fresh press re-arms: the anchor is the press point, not wherever the
+    // previous gesture ended.
+    adapter.reset();
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F, 10.0F + threshold + 1.0F);
+    area->dispatchPress(10.0F, 10.0F + threshold + 1.0F, BTN_LEFT, false);
+    expect(adapter.drags.size() == 1, "first gesture did not arm");
+
+    adapter.reset();
+    area->dispatchPress(10.0F, 10.0F, BTN_LEFT, true);
+    area->dispatchMotion(10.0F, 10.0F + threshold - 0.5F);
+    area->dispatchPress(10.0F, 10.0F + threshold - 0.5F, BTN_LEFT, false);
+    expect(adapter.drags.empty(), "second press reused the previous drag state");
+    expect(adapter.releases.size() == 1, "second release was not delivered");
+  }
+
+  if (gFailures != 0) {
+    std::println(stderr, "virtual_grid_view_gesture_test: {} failure(s)", gFailures);
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary

Fixes pinned applications in the launcher ignoring left clicks. Pinned items now launch normally on click while keeping drag reordering intact when dragged past the threshold.

## Motivation

After pinned app reordering landed, clicking pinned entries stopped working. Both `LauncherResultAdapter` and `LauncherAppGridAdapter` intercept presses on reorderable items, but `onPointerDrag` was setting `m_dragging = true` on the very first motion event without checking if the pointer actually moved past a drag threshold.

On Wayland, practically every mouse click emits slight motion between press and release. With `m_dragging` set immediately, `onPointerRelease` assumed a drag was in progress and dropped `m_onActivate`. Since no drop target was hit, it didn't reorder either, leaving users unable to launch pinned apps with LMB.

This fix:
1. Keeps `m_dragging` false until pointer movement exceeds `Style::dragStartThreshold * scale`.
2. Triggers `m_onActivate` on release if no reorder occurred and the release happened on the source item.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4098

## Testing

- Built with meson and ninja on Arch Linux.
- Tested on Hyprland with both `app_grid = true` and list view.
- Single clicks now reliably launch pinned apps.
- Dragging items past the threshold still reorders them cleanly.
- Dragging out into empty space cancels without accidental launches.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

None.
