### PR TITLE
fix(capture): pipe screenshot on copy/save confirm in region overlay

### DIFF
--- a/src/capture/screenshot_service.cpp
+++ b/src/capture/screenshot_service.cpp
@@ -846,11 +846,9 @@ void ScreenshotService::ensureRegionOverlay() {
         if (action == capture::ConfirmAction::ForceClipboard) {
           options.copyToClipboard = true;
           options.saveToFile = false;
-          options.pipeToCommand = false;
         } else if (action == capture::ConfirmAction::ForceSave) {
           options.copyToClipboard = false;
           options.saveToFile = true;
-          options.pipeToCommand = false;
         }
 
         if (options.freezeScreen && m_regionOverlay != nullptr) {


### PR DESCRIPTION

## Summary

Previously, confirming a region capture with Copy (Ctrl+C) or Save (Ctrl+S) in the screenshot overlay forcibly disabled `pipe_to_command`, so the configured pipe command (e.g. `swash`) never ran. This PR makes Copy/Save preserve the pipe option, so those keybinds deliver to the clipboard/file *and* then pipe the PNG to the command. Plain **Enter** continues to follow the config alone (pipe, no forced copy/save).

## Motivation

With a pipe command configured, the region-overlay Copy/Save keybinds silently bypassed the pipe. This makes the overlay's explicit confirm actions compose with the configured pipe instead of overriding it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- Manual: with `pipe_to_command = true` and `pipe_command = "swash"`, selecting a region then pressing Ctrl+C copies to clipboard and pipes to `swash`; Ctrl+S saves the file and pipes; Enter pipes only. Pipe failure/output verified through the command's exit status logging.
- `just format`

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: *Umbriel*
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A — no UI/visual/layout change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers. *(no new keys/identifiers introduced; no config surface change)*

## Additional Notes
None
