### PR TITLE
feat(config): warn when settings.toml shadows hand-authored widget placement keys

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1131,6 +1131,7 @@ if build_tests
     'calendar_cache_permissions',
     'cli_help',
     'cli_parse',
+    'config_shadowed_override',
     'cli_schema',
     'caldav_client',
     'calendar_credential_store',

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -7,7 +7,9 @@
 #include <algorithm>
 #include <format>
 #include <set>
+#include <sstream>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 
 namespace noctalia::config {
@@ -144,6 +146,72 @@ namespace noctalia::config {
       return expandFile(path, parsed, visited, out);
     }
 
+    // Canonical textual form of a scalar/array leaf, used only for equality
+    // comparison between the two merge layers (formatting quirks do not matter
+    // as long as both sides go through the same serializer).
+    void appendLeafValue(const toml::node& node, std::string& out) {
+      node.visit([&out](const auto& value) {
+        using Value = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<Value, toml::table>) {
+          out += "<table>";
+        } else if constexpr (std::is_same_v<Value, toml::array>) {
+          out += '[';
+          bool first = true;
+          for (const auto& element : value) {
+            if (!first) {
+              out += ',';
+            }
+            first = false;
+            appendLeafValue(element, out);
+          }
+          out += ']';
+        } else {
+          std::ostringstream stream;
+          stream << value;
+          out += stream.str();
+        }
+      });
+    }
+
+    [[nodiscard]] bool leafValuesDiffer(const toml::node& base, const toml::node& overlay) {
+      std::string baseValue;
+      std::string overlayValue;
+      appendLeafValue(base, baseValue);
+      appendLeafValue(overlay, overlayValue);
+      return baseValue != overlayValue;
+    }
+
+    // Dotted paths of every key that exists in both tables (recursively) where
+    // the overlay entry replaces the base entry with a different value. A
+    // table-vs-scalar kind change replaces the whole subtree, so it counts as
+    // one shadowed key at that path. Keys present only in `overlay` are
+    // intentional overrides and are skipped.
+    void collectShadowedKeys(
+        const toml::table& base, const toml::table& overlay, std::string& path, std::vector<std::string>& out
+    ) {
+      for (const auto& [key, overlayNode] : overlay) {
+        const toml::node* baseNode = base.get(key);
+        if (baseNode == nullptr) {
+          continue;
+        }
+        const std::size_t pathLength = path.size();
+        if (!path.empty()) {
+          path += '.';
+        }
+        path += key.str();
+        if (const auto* overlayTable = overlayNode.as_table(); overlayTable != nullptr) {
+          if (const auto* baseTable = baseNode->as_table(); baseTable != nullptr) {
+            collectShadowedKeys(*baseTable, *overlayTable, path, out);
+          } else {
+            out.push_back(path);
+          }
+        } else if (baseNode->is_table() || leafValuesDiffer(*baseNode, overlayNode)) {
+          out.push_back(path);
+        }
+        path.resize(pathLength);
+      }
+    }
+
   } // namespace
 
   MergeResult mergeConfigWithIncludes(std::string_view configDir) {
@@ -189,6 +257,41 @@ namespace noctalia::config {
     }
 
     return out;
+  }
+
+  void
+  collectShadowedPlacementOverrides(const toml::table& base, const toml::table& overlay, schema::Diagnostics& diag) {
+    constexpr std::size_t kMaxWarnings = 24;
+    constexpr std::string_view kMessage =
+        "overridden by state-dir settings.toml (where the widget editor and placement remaps save state); "
+        "the value in the config directory is ignored";
+
+    std::vector<std::string> shadowed;
+    for (std::string_view section : {"desktop_widgets", "lockscreen_widgets"}) {
+      const auto* overlaySection = overlay.get(section);
+      const auto* baseSection = base.get(section);
+      if (overlaySection == nullptr || baseSection == nullptr) {
+        continue;
+      }
+      const auto* overlaySectionTable = overlaySection->as_table();
+      const auto* baseSectionTable = baseSection->as_table();
+      if (overlaySectionTable == nullptr || baseSectionTable == nullptr) {
+        continue;
+      }
+      std::string path{section};
+      collectShadowedKeys(*baseSectionTable, *overlaySectionTable, path, shadowed);
+    }
+    const std::size_t reported = std::min(shadowed.size(), kMaxWarnings);
+    for (std::size_t i = 0; i < reported; ++i) {
+      diag.warn(std::move(shadowed[i]), std::string{kMessage}, "config.shadowed-override");
+    }
+    if (shadowed.size() > kMaxWarnings) {
+      diag.warn(
+          "desktop_widgets",
+          std::format("+{} more keys overridden by state-dir settings.toml", shadowed.size() - kMaxWarnings),
+          "config.shadowed-override"
+      );
+    }
   }
 
 } // namespace noctalia::config

--- a/src/config/config_merge.h
+++ b/src/config/config_merge.h
@@ -41,4 +41,15 @@ namespace noctalia::config {
   // responsible for overlaying settings.toml afterwards (it is never include-expanded).
   [[nodiscard]] MergeResult mergeConfigWithIncludes(std::string_view configDir);
 
+  // Appends warnings for keys under the widget placement sections ([desktop_widgets] /
+  // [lockscreen_widgets]) that are defined in both the config-directory table `base` and
+  // the state-dir settings.toml `overlay` with different values. Those sections are
+  // captured wholesale into settings.toml by widget-editor saves and by automatic
+  // placement remaps, which silently turns the same keys in the config directory into
+  // dead config; the warnings name the hand-authored values that are being ignored.
+  // Call before deepMerge applies `overlay` so `base` still carries the hand-authored
+  // values. Keys defined only in `overlay` are intentional overrides and stay silent.
+  void
+  collectShadowedPlacementOverrides(const toml::table& base, const toml::table& overlay, schema::Diagnostics& diag);
+
 } // namespace noctalia::config

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1456,6 +1456,9 @@ void ConfigService::loadAll() {
 
   // Apply the app-writable overrides overlay last; sidecar wins. Compatibility
   // normalization must see the final effective values to preserve overlay intent.
+  // Placement keys that the sidecar shadows are warned about before it wins.
+  schema::Diagnostics shadowedOverrideDiag;
+  noctalia::config::collectShadowedPlacementOverrides(merged, effectiveOverrides, shadowedOverrideDiag);
   deepMerge(merged, effectiveOverrides);
   merged.erase(noctalia::config::kConfigVersionKey);
   noctalia::config::LegacyConfigIssues legacyIssues;
@@ -1490,6 +1493,9 @@ void ConfigService::loadAll() {
   if (semanticError.empty()) {
     try {
       diagnostics = noctalia::config::validateMergedConfig(merged, origins);
+      diagnostics.entries.insert(
+          diagnostics.entries.end(), shadowedOverrideDiag.entries.begin(), shadowedOverrideDiag.entries.end()
+      );
       std::size_t errorCount = 0;
       for (const auto& entry : diagnostics.entries) {
         if (entry.severity == schema::Diagnostics::Severity::Error) {

--- a/src/config/config_validate.cpp
+++ b/src/config/config_validate.cpp
@@ -65,6 +65,9 @@ namespace noctalia::config {
             const int appliedVersion = applyPendingConfigMigrations(sidecar, *version, diag);
             sidecar.insert_or_assign(kConfigVersionKey, static_cast<std::int64_t>(appliedVersion));
           }
+          // Warn before the overlay wins so hand-authored placement values
+          // that settings.toml shadows are visible in `noctalia config validate`.
+          collectShadowedPlacementOverrides(merged, sidecar, diag);
           ConfigService::deepMerge(merged, sidecar);
         } catch (const toml::parse_error& e) {
           diag.fatalAt(parseErrorOrigin(e, settingsFile), "syntax", std::string(e.description()), "config.syntax");

--- a/tests/config_shadowed_override_test.cpp
+++ b/tests/config_shadowed_override_test.cpp
@@ -1,0 +1,173 @@
+#include "config/config_merge.h"
+#include "core/toml.h"
+
+#include <algorithm>
+#include <print>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+  int g_failures = 0;
+
+  void expect(bool condition, std::string_view message) {
+    if (!condition) {
+      std::println(stderr, "config_shadowed_override_test: FAIL: {}", message);
+      ++g_failures;
+    }
+  }
+
+  [[nodiscard]] bool hasWarning(const noctalia::config::schema::Diagnostics& diag, std::string_view path) {
+    return std::ranges::any_of(diag.entries, [path](const auto& entry) {
+      return entry.severity == noctalia::config::schema::Diagnostics::Severity::Warning && entry.path == path;
+    });
+  }
+
+  [[nodiscard]] std::size_t warningCount(const noctalia::config::schema::Diagnostics& diag) {
+    return static_cast<std::size_t>(std::ranges::count_if(diag.entries, [](const auto& entry) {
+      return entry.severity == noctalia::config::schema::Diagnostics::Severity::Warning;
+    }));
+  }
+
+  [[nodiscard]] toml::table parse(std::string_view text) { return toml::parse(text); }
+
+} // namespace
+
+int main() {
+  using noctalia::config::collectShadowedPlacementOverrides;
+
+  {
+    // Same value on both sides: the sidecar restates the hand-authored value, nothing is ignored.
+    const auto base = parse(R"(
+[desktop_widgets.widget.a]
+cx = 100.0
+cy = 200.0
+type = "clock"
+)");
+    const auto overlay = parse(R"(
+[desktop_widgets.widget.a]
+cx = 100.0
+cy = 200.0
+type = "clock"
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(warningCount(diag) == 0, "identical values should not warn");
+  }
+
+  {
+    // Differing placement values plus an overlay-only field: only the shadowed key warns.
+    const auto base = parse(R"(
+[desktop_widgets.widget.a]
+cx = 100.0
+cy = 200.0
+type = "clock"
+)");
+    const auto overlay = parse(R"(
+[desktop_widgets.widget.a]
+cx = 640.0
+cy = 360.0
+output = "DP-1"
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(hasWarning(diag, "desktop_widgets.widget.a.cx"), "differing cx should warn");
+    expect(hasWarning(diag, "desktop_widgets.widget.a.cy"), "differing cy should warn");
+    expect(!hasWarning(diag, "desktop_widgets.widget.a.type"), "overlay missing type should not warn");
+    expect(!hasWarning(diag, "desktop_widgets.widget.a.output"), "overlay-only key should not warn");
+    expect(warningCount(diag) == 2, "exactly two warnings expected");
+  }
+
+  {
+    // Overlay-only widget: pure state, no hand-authored config to shadow.
+    const auto base = parse(R"(
+[desktop_widgets]
+widget_order = []
+)");
+    const auto overlay = parse(R"(
+[desktop_widgets.widget.b]
+cx = 1.0
+cy = 2.0
+type = "clock"
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(warningCount(diag) == 0, "overlay-only widget should not warn");
+  }
+
+  {
+    // Lockscreen placement sections are covered too.
+    const auto base = parse(R"(
+[lockscreen_widgets.widget.c]
+cx = 10.0
+cy = 20.0
+)");
+    const auto overlay = parse(R"(
+[lockscreen_widgets.widget.c]
+cx = 30.0
+cy = 20.0
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(hasWarning(diag, "lockscreen_widgets.widget.c.cx"), "lockscreen cx should warn");
+    expect(!hasWarning(diag, "lockscreen_widgets.widget.c.cy"), "identical cy should not warn");
+  }
+
+  {
+    // Other sections are deliberately out of scope: settings-UI overrides there are normal.
+    const auto base = parse(R"(
+[theme]
+mode = "dark"
+)");
+    const auto overlay = parse(R"(
+[theme]
+mode = "light"
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(warningCount(diag) == 0, "non-placement sections should not warn");
+  }
+
+  {
+    // A table replaced by a scalar (or vice versa) shadows the whole key once.
+    const auto base = parse(R"(
+[desktop_widgets.widget.d]
+settings = { background = true }
+)");
+    const auto overlay = parse(R"(
+[desktop_widgets.widget.d]
+settings = false
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(hasWarning(diag, "desktop_widgets.widget.d.settings"), "kind change should warn once");
+    expect(warningCount(diag) == 1, "kind change should produce a single warning");
+  }
+
+  {
+    // Nested settings tables only warn for the leaves that actually differ.
+    const auto base = parse(R"(
+[desktop_widgets.widget.e.settings]
+background = true
+visualization_mode = "wave_rings"
+)");
+    const auto overlay = parse(R"(
+[desktop_widgets.widget.e.settings]
+background = true
+visualization_mode = "bars"
+)");
+    noctalia::config::schema::Diagnostics diag;
+    collectShadowedPlacementOverrides(base, overlay, diag);
+    expect(hasWarning(diag, "desktop_widgets.widget.e.settings.visualization_mode"), "differing setting should warn");
+    expect(!hasWarning(diag, "desktop_widgets.widget.e.settings.background"), "identical setting should not warn");
+    expect(warningCount(diag) == 1, "exactly one nested warning expected");
+  }
+
+  if (g_failures != 0) {
+    std::println(stderr, "config_shadowed_override_test: {} failure(s)", g_failures);
+    return 1;
+  }
+  std::println("config_shadowed_override_test: all checks passed");
+  return 0;
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Emit a config diagnostic (Warning, code `config.shadowed-override`) for every `[desktop_widgets.*]` / `[lockscreen_widgets.*]` key that is defined in **both** the config directory and the state-dir `settings.toml` with differing values. The warnings flow through the standard diagnostics sink, so they appear in the reload log and in `noctalia config validate`, with the winning `settings.toml` position annotated by the existing origin machinery:

```text
WARN settings.toml:15:10: desktop_widgets.widget.<id>.cx: overridden by state-dir settings.toml (where the widget
     editor and placement remaps save state); the value in the config directory is ignored
```

Implementation: `collectShadowedPlacementOverrides()` in `config_merge`, called right before the sidecar `deepMerge` in both the runtime load path and `validateConfigSources`. A table-vs-scalar kind change counts as a single shadowed key at that path; warnings are capped at 24 plus a `+N more` summary.

## Motivation

Widget placement is captured wholesale into `settings.toml` by widget-editor saves **and** by the automatic placement remaps that run on output geometry changes. After that, the same keys in the config directory are dead config: `deepMerge` applies the sidecar last, per key, so hand edits there are silently ignored — and `noctalia config validate` reported nothing. This is a nasty trap for dotfiles-managed configs (see #4123, where a stale `cx` additionally could not be corrected by editing `config.toml`).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Addresses problem 2 of #4123 (silent shadowing). Problem 1 (stale placement locked in by the backfill) stays open there for discussion — it has no deterministic retroactive fix.

## Testing

```sh
meson setup build --reconfigure -Dtests=enabled
ninja -C build
meson test -C build            # 93/93 OK, includes the new config_shadowed_override_test
find src \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 clang-format --dry-run -Werror   # clean
```

Manual, against a real two-layer setup (Niri, single 3440x1440 output): diverging a placement key in `config.toml` makes `noctalia config validate` name it — it also caught a pre-existing shadowed `lockscreen_widgets.widget_order` on my machine. Identical values in both layers produce no warnings; removing the divergence silences them.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

(The scaling entry comes from the #4123 investigation — live output scale 1 ↔ 2 — though this PR itself touches no rendering or placement code.)

## Screenshots / Videos

No UI change; see the `noctalia config validate` output block in **Summary**.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Compositor / bar-position / multi-monitor coverage is not applicable: the change lives entirely in the config merge layer and touches no rendering, layout, or compositor-specific code.
- The new warnings are log/CLI-only English diagnostics like the existing schema warnings; they never reach the on-screen notification path (that is driven by `ConfigProblem` errors, not warnings), so no translation entries are needed.
- The warning is emitted on every load while the divergence exists, including after the app's own `settings.toml` writes — intentional, since the stale hand-authored value is precisely what the user should be told about. Happy to gate it behind a "changed since last load" check if maintainers prefer quieter logs.
- If wanted, I can follow up with a docs paragraph explaining the two-layer override behavior for placement keys.