### PR TITLE
feat(plugins): add pointer tracking callbacks to graph nodes

### DIFF
--- a/docs/user/plugins/development/declarative-ui.mdx
+++ b/docs/user/plugins/development/declarative-ui.mdx
@@ -64,7 +64,7 @@ to size it explicitly).
 | `ui.spacer` | flexible filler (use `flexGrow`) |
 | `ui.progress` | `progress` (0–1), `fill`, `track`, `radius`, `width`, `height` |
 | `ui.button` | `text`, `glyph`, `fontSize`, `glyphSize`, `variant` (`default`/`primary`/`secondary`/`destructive`/`outline`/`ghost`), `contentAlign` (`start`/`center`/`end`), `controlSize` (`sm`/`md`/`lg`), `tooltip`, `enabled`, `selected`, `onClick`, `onRightClick`, `onHover` |
-| `ui.graph` | `values` / `values2` (arrays of 0–1 numbers), `color` / `color2`, `lineWidth`, `fillOpacity`, `width`, `height` |
+| `ui.graph` | `values` / `values2` (arrays of 0–1 numbers), `color` / `color2`, `lineWidth`, `fillOpacity`, `width`, `height`, `onPointerMove`, `onPointerLeave` |
 | `ui.toggle` | `checked` (bool), `enabled`, `onChange` |
 | `ui.slider` | `min`, `max`, `step`, `value`, `controlSize` (`sm`/`md`/`lg`), `enabled`, `onChange`, `onDragEnd` |
 | `ui.select` | `options` (array of strings), `selectedIndex`, `placeholder`, `controlSize` (`sm`/`md`/`lg`), `enabled`, `width`, `height`, `onChange` |
@@ -122,6 +122,30 @@ prop is logged and skipped - typos surface in the log instead of failing silentl
   child, hovering that child makes *it* the hover target and the container reports `"false"`. Every `"true"` is
   matched by a `"false"`, including when the hovered node disappears in a later render, so a hover flag never gets
   stuck on.
+- **Graph pointer tracking**: `onPointerMove` on `ui.graph` fires while the pointer is over the graph and receives the
+  position normalized to the graph's own box as two strings, `"0.0000"` to `"1.0000"`, with `0,0` at the top-left, so
+  `normY` grows downward. Map the x-position onto your own data: the graph does not know what its samples mean.
+  `onPointerLeave` is independent and fires with no arguments.
+  ```lua
+  function onGraphMove(normX)
+    hoveredIndex = math.floor(tonumber(normX) * #series) + 1
+    render()
+  end
+
+  function onGraphLeave()
+    hoveredIndex = nil
+    render()
+  end
+
+  ui.graph({ values = series, onPointerMove = "onGraphMove", onPointerLeave = "onGraphLeave" })
+  ```
+  Positions are coalesced: a graph never has more than one pending pointer event, so a fast pointer cannot flood a slow
+  script, and the newest event always wins. Both edges share that stream, so a leave can never arrive before a position
+  it followed. Every entered graph reports its leave, including when the graph disappears from a later render or its
+  callbacks are rewired, so a hover highlight never gets stuck on; that teardown leave needs a **named** handler,
+  because a closure from the render that dropped the graph is already superseded. A graph with neither prop takes no
+  pointer input at all; an empty callback name counts as unset.
+  Requires <PluginApiBadge feature="graph-pointer-tracking" />.
 - **Clickable containers**: `onClick` on `ui.row` and `ui.column` makes the whole container a click target while
   keeping its layout and sizing, so an entire chip (glyph + label) activates as one unit rather than only a bare
   `ui.box`. The same applies to `ui.image` and `ui.box` (thumbnail grids, placeholder tiles). A clickable container

--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -28,7 +28,8 @@ namespace scripting {
   inline constexpr std::uint32_t kGetSettingPluginApiVersion = 26;
   inline constexpr std::uint32_t kInputFrameVisibilityPluginApiVersion = 27;
   inline constexpr std::uint32_t kPanelContextMenuPluginApiVersion = 28;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = kPanelContextMenuPluginApiVersion;
+  inline constexpr std::uint32_t kGraphPointerTrackingPluginApiVersion = 29;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = kGraphPointerTrackingPluginApiVersion;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/scripting/script_runtime.cpp
+++ b/src/scripting/script_runtime.cpp
@@ -346,15 +346,16 @@ namespace scripting {
           return false;
         }
 
-        // Supersede an already-queued coalescing CallArgs for the same callback
+        // Supersede an already-queued coalescing CallArgs on the same stream
         // with the newer payload instead of appending. Bounds the queue to a
-        // single pending event per callback (e.g. onAudioSpectrum at 60Hz), so a
-        // slow script can never accumulate stale spectrum frames.
+        // single pending event per stream (e.g. onAudioSpectrum at 60Hz), so a
+        // slow script can never accumulate stale spectrum frames, and callbacks
+        // sharing a stream stay in true order: the newest state wins.
         if (event.kind == ScriptEventKind::CallArgs && event.coalesce) {
           const auto existing = std::ranges::find_if(queue, [&event](const auto& queued) {
             return queued.kind == ScriptEventKind::CallArgs
                 && queued.coalesce
-                && queued.functionName == event.functionName;
+                && queued.coalesceKey == event.coalesceKey;
           });
           if (existing != queue.end()) {
             event.generation = generation;
@@ -1130,6 +1131,7 @@ namespace scripting {
     event.snapshot = std::move(snapshot);
     event.budget = kCallBudget;
     event.coalesce = options.coalesce;
+    event.coalesceKey = options.coalesceKey.empty() ? event.functionName : std::move(options.coalesceKey);
     event.droppable = options.droppable;
     return m_state != nullptr && m_state->enqueue(std::move(event));
   }
@@ -1141,10 +1143,12 @@ namespace scripting {
   }
 
   bool ScriptRuntime::enqueueCallStrings(
-      std::string functionName, std::string first, std::string second, ScriptSnapshot snapshot, bool coalesce
+      std::string functionName, std::string first, std::string second, ScriptSnapshot snapshot, bool coalesce,
+      std::string coalesceKey
   ) {
     return enqueueCallArgs(
-        std::move(functionName), {std::move(first), std::move(second)}, std::move(snapshot), {.coalesce = coalesce}
+        std::move(functionName), {std::move(first), std::move(second)}, std::move(snapshot),
+        {.coalesce = coalesce, .coalesceKey = std::move(coalesceKey)}
     );
   }
 

--- a/src/scripting/script_runtime.h
+++ b/src/scripting/script_runtime.h
@@ -68,8 +68,11 @@ namespace scripting {
     [[nodiscard]] bool
     enqueueCallArgs(std::string functionName, ScriptArgs args, ScriptSnapshot snapshot, ScriptCallOptions options = {});
     [[nodiscard]] bool enqueueCallBool(std::string functionName, bool value, ScriptSnapshot snapshot);
+    // `coalesceKey` names the coalescing stream when several callbacks must
+    // supersede one another in order; empty means the callback's own name.
     [[nodiscard]] bool enqueueCallStrings(
-        std::string functionName, std::string first, std::string second, ScriptSnapshot snapshot, bool coalesce = false
+        std::string functionName, std::string first, std::string second, ScriptSnapshot snapshot, bool coalesce = false,
+        std::string coalesceKey = {}
     );
     [[nodiscard]] bool enqueueAsyncCommandResult(std::uint64_t hostId, int callbackRef, process::RunResult result);
     // Swap the live settings snapshot and, if the script defines a global

--- a/src/scripting/script_runtime_types.h
+++ b/src/scripting/script_runtime_types.h
@@ -234,10 +234,14 @@ namespace scripting {
 
   // Queue policy for a callback invocation.
   struct ScriptCallOptions {
-    // A newer queued call to the same callback replaces this one.
+    // A newer queued call on the same coalescing stream replaces this one.
     bool coalesce = false;
     // This call may be dropped when the queue is full.
     bool droppable = false;
+    // Coalescing stream this call belongs to; empty means the callback name.
+    // Callbacks whose relative order matters (a graph's pointer position and
+    // its pointer leave) share one key so the newest event always wins.
+    std::string coalesceKey;
   };
 
   struct ScriptEvent {
@@ -252,11 +256,13 @@ namespace scripting {
     // CallArgs payload: the callback's argument list, pushed in order.
     ScriptArgs args;
     bool processMatchResult = false;
-    // When true, a newer CallArgs event with the same functionName supersedes
+    // When true, a newer CallArgs event on the same coalescing stream supersedes
     // this one while it is still queued (only the latest payload matters, e.g.
     // onAudioSpectrum frames). IPC and other callbacks leave this false so every
     // event is delivered.
     bool coalesce = false;
+    // Coalescing stream identity, defaulted to the callback name.
+    std::string coalesceKey;
     // When true, this event may be dropped to make room once the queue is full
     // (state-echo callbacks such as onHover, where a missed edge is harmless).
     bool droppable = false;

--- a/src/shell/bar/widgets/plugin_widget.cpp
+++ b/src/shell/bar/widgets/plugin_widget.cpp
@@ -245,7 +245,7 @@ void PluginWidget::create() {
   m_reconciler.setCallbackSink([this](const ui::UiTreeReconciler::ControlCallback& callback) {
     if (m_runtime != nullptr) {
       (void)m_runtime->enqueueCallStrings(
-          callback.fn, callback.arg1, callback.arg2, makeScriptSnapshot(), callback.coalesce
+          callback.fn, callback.arg1, callback.arg2, makeScriptSnapshot(), callback.coalesce, callback.coalesceKey
       );
     }
   });

--- a/src/shell/desktop/widgets/plugin_desktop_widget.cpp
+++ b/src/shell/desktop/widgets/plugin_desktop_widget.cpp
@@ -61,7 +61,7 @@ void PluginDesktopWidget::create() {
   m_reconciler.setCallbackSink([this](const ui::UiTreeReconciler::ControlCallback& callback) {
     if (m_runtime != nullptr) {
       (void)m_runtime->enqueueCallStrings(
-          callback.fn, callback.arg1, callback.arg2, makeScriptSnapshot(), callback.coalesce
+          callback.fn, callback.arg1, callback.arg2, makeScriptSnapshot(), callback.coalesce, callback.coalesceKey
       );
     }
   });

--- a/src/shell/panel/plugin_panel.cpp
+++ b/src/shell/panel/plugin_panel.cpp
@@ -181,7 +181,7 @@ void PluginPanel::create() {
         };
       }
       (void)m_runtime->enqueueCallStrings(
-          callback.fn, callback.arg1, callback.arg2, std::move(snapshot), callback.coalesce
+          callback.fn, callback.arg1, callback.arg2, std::move(snapshot), callback.coalesce, callback.coalesceKey
       );
     }
   });

--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -363,17 +363,27 @@ namespace ui {
       return name != nullptr && !name->empty() ? name : nullptr;
     }
 
-    // Box/image and row/column get an InputArea wrapper only when clickable (see
-    // createControl). If a reconcile flips that need, the existing node can't
-    // be reused — its structure no longer matches — so it must be rebuilt like
-    // a type change.
+    // Only these types can carry an InputArea wrapper (see createControl).
+    bool wrappableType(const std::string& type) {
+      return type == "box" || type == "image" || type == "row" || type == "column" || type == "graph";
+    }
+
+    // The props that make a wrappable type need its InputArea: pointer tracking
+    // for a graph, click/hover for the rest.
+    bool wantsInputAreaWrapper(const UiTreeNode& want) {
+      if (want.type == "graph") {
+        return callbackProp(want, "onPointerMove") != nullptr || callbackProp(want, "onPointerLeave") != nullptr;
+      }
+      return callbackProp(want, "onClick") != nullptr || callbackProp(want, "onHover") != nullptr;
+    }
+
+    // If a reconcile flips that need, the existing node cannot be reused (its
+    // structure no longer matches), so it is rebuilt like a type change.
     bool clickableWrapMismatch(const UiTreeNode& want, Node* node) {
-      if (want.type != "box" && want.type != "image" && want.type != "row" && want.type != "column") {
+      if (!wrappableType(want.type)) {
         return false;
       }
-      const bool wantsWrapper = callbackProp(want, "onClick") != nullptr || callbackProp(want, "onHover") != nullptr;
-      const bool hasWrapper = inputAreaFromSlot(node) != nullptr;
-      return wantsWrapper != hasWrapper;
+      return wantsInputAreaWrapper(want) != (inputAreaFromSlot(node) != nullptr);
     }
 
     // InputArea never self-sizes; box/image mirror explicit sizes, but a
@@ -473,9 +483,10 @@ namespace ui {
                                                               "glyphSize",   "variant", "contentAlign", "enabled",
                                                               "selected",    "onClick", "onRightClick", "tooltip",
                                                               "controlSize", "onHover"};
-      static const std::unordered_set<std::string> kGraph = {"width",   "height",    "flexGrow",   "opacity",
-                                                             "visible", "values",    "values2",    "color",
-                                                             "color2",  "lineWidth", "fillOpacity"};
+      static const std::unordered_set<std::string> kGraph = {
+          "width", "height", "flexGrow",  "opacity",     "visible",       "values",        "values2",
+          "color", "color2", "lineWidth", "fillOpacity", "onPointerMove", "onPointerLeave"
+      };
       static const std::unordered_set<std::string> kInput = {"width",       "height",   "flexGrow",    "opacity",
                                                              "visible",     "value",    "placeholder", "fontSize",
                                                              "enabled",     "password", "multiline",   "focus",
@@ -569,15 +580,18 @@ namespace ui {
     std::string type;
     std::string key;
     Node* node = nullptr;
-    std::string callbackName;           // last-wired button onClick / control onChange target
-    std::string rightCallbackName;      // last-wired button onRightClick target
-    std::string hoverCallbackName;      // last-wired onHover target (button/box/image/row/column)
-    std::string submitCallbackName;     // last-wired input onSubmit target
-    std::string dragEndCallbackName;    // last-wired slider onDragEnd target
-    std::string imagePath;              // last-applied resolved image source
-    std::string lastText;               // markdown source cache - setMarkdown re-parses, only call on change
-    float lastMarkdownScale = 0.0F;     // content scale baked into the parsed markdown
-    float lastMarkdownFontScale = 0.0F; // text-only multiplier baked into the parsed markdown
+    std::string callbackName;             // last-wired button onClick / control onChange target
+    std::string rightCallbackName;        // last-wired button onRightClick target
+    std::string hoverCallbackName;        // last-wired onHover target (button/box/image/row/column)
+    std::string submitCallbackName;       // last-wired input onSubmit target
+    std::string dragEndCallbackName;      // last-wired slider onDragEnd target
+    std::string pointerMoveCallbackName;  // last-wired graph onPointerMove target
+    std::string pointerLeaveCallbackName; // last-wired graph onPointerLeave target
+    std::string pointerStreamKey;         // coalescing stream shared by this graph's pointer callbacks
+    std::string imagePath;                // last-applied resolved image source
+    std::string lastText;                 // markdown source cache - setMarkdown re-parses, only call on change
+    float lastMarkdownScale = 0.0F;       // content scale baked into the parsed markdown
+    float lastMarkdownFontScale = 0.0F;   // text-only multiplier baked into the parsed markdown
     float imageTargetSize = 0.0F;
     // Controlled-with-change-detection: a value-driven control (toggle/slider/
     // select) only re-applies its declared value when it differs from the last
@@ -625,9 +639,11 @@ namespace ui {
 
   void UiTreeReconciler::reset() {
     m_dragDropController->cancel();
-    // The host tree is gone, so any hover it was reporting has ended. The slots
-    // still name it; the Nodes they point at are already freed.
+    // The host tree is gone, so any hover or graph pointer session it was
+    // reporting has ended. The slots still name it; the Nodes they point at are
+    // already freed.
     closeHover();
+    closePointer();
     m_rootSlots.clear();
   }
 
@@ -701,6 +717,9 @@ namespace ui {
       return std::make_unique<Button>();
     }
     if (desired.type == "graph") {
+      if (wantsInputAreaWrapper(desired)) {
+        return wrapClickable(std::make_unique<Graph>(), /*acceptClicks=*/false);
+      }
       return std::make_unique<Graph>();
     }
     if (desired.type == "input") {
@@ -801,9 +820,14 @@ namespace ui {
       }
 
       for (const auto& leftover : detached) {
-        if (!leftover.used && subtreeOwnsHover(leftover.slot)) {
+        if (leftover.used) {
+          continue;
+        }
+        if (subtreeOwnsHover(leftover.slot)) {
           closeHover();
-          break;
+        }
+        if (subtreeOwnsPointer(leftover.slot)) {
+          closePointer();
         }
       }
     }
@@ -920,6 +944,99 @@ namespace ui {
     }
     for (const Slot& child : slot.children) {
       if (subtreeOwnsHover(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Both edges of a graph's pointer session are wired together: the enter/motion
+  // reporter and the leave share one coalescing stream key, so the script queue
+  // holds a single pending event per graph and the newest one always wins. A
+  // fresh key per rewire keeps a superseded stream from swallowing the leave the
+  // old wiring owes.
+  void UiTreeReconciler::syncGraphPointerCallbacks(Slot& slot, const UiTreeNode& desired, Node* node) {
+    const std::string* move = callbackProp(desired, "onPointerMove");
+    const std::string* leave = callbackProp(desired, "onPointerLeave");
+    const std::string moveName = move != nullptr ? *move : std::string{};
+    const std::string leaveName = leave != nullptr ? *leave : std::string{};
+    if (moveName == slot.pointerMoveCallbackName && leaveName == slot.pointerLeaveCallbackName) {
+      return;
+    }
+    releasePointer(node);
+    slot.pointerMoveCallbackName = moveName;
+    slot.pointerLeaveCallbackName = leaveName;
+
+    InputArea* inputArea = inputAreaFromSlot(node);
+    if (inputArea == nullptr) {
+      return; // no wrapper: clickableWrapMismatch rebuilds instead of rewiring
+    }
+    if (moveName.empty() && leaveName.empty()) {
+      slot.pointerStreamKey.clear();
+      inputArea->setOnEnter(nullptr);
+      inputArea->setOnMotion(nullptr);
+      inputArea->setOnLeave(nullptr);
+      return;
+    }
+    slot.pointerStreamKey = std::format("graph-pointer:{}", ++m_pointerStreamSeq);
+
+    // Position is normalized to [0,1] over the graph's content area, which fills
+    // the whole control (Graph::setSize puts the render node at 0,0, no inset).
+    auto report = [this, name = moveName, key = slot.pointerStreamKey,
+                   inputArea](const InputArea::PointerData& pointer) {
+      if (!m_sink || name.empty() || inputArea->width() <= 0.0F || inputArea->height() <= 0.0F) {
+        return;
+      }
+      const float normX = std::clamp(pointer.localX / inputArea->width(), 0.0F, 1.0F);
+      const float normY = std::clamp(pointer.localY / inputArea->height(), 0.0F, 1.0F);
+      m_sink(ControlCallback{name, std::format("{:.4F}", normX), std::format("{:.4F}", normY), true, key});
+    };
+    inputArea->setOnEnter([this, node, leaveName, key = slot.pointerStreamKey,
+                           report](const InputArea::PointerData& pointer) {
+      openPointer(node, leaveName, key);
+      report(pointer);
+    });
+    inputArea->setOnMotion(report);
+    inputArea->setOnLeave([this, node]() { releasePointer(node); });
+  }
+
+  void UiTreeReconciler::openPointer(const Node* owner, std::string leaveCallback, std::string streamKey) {
+    if (m_pointerOwner == owner) {
+      return;
+    }
+    closePointer();
+    m_pointerLeaveCallback = std::move(leaveCallback);
+    m_pointerStreamKey = std::move(streamKey);
+    m_pointerOwner = owner;
+  }
+
+  void UiTreeReconciler::closePointer() {
+    if (m_pointerOwner == nullptr) {
+      return;
+    }
+    const std::string name = std::exchange(m_pointerLeaveCallback, std::string{});
+    const std::string key = std::exchange(m_pointerStreamKey, std::string{});
+    m_pointerOwner = nullptr;
+    if (m_sink && !name.empty()) {
+      m_sink(ControlCallback{name, {}, {}, true, key});
+    }
+  }
+
+  void UiTreeReconciler::releasePointer(const Node* owner) {
+    if (owner != nullptr && owner == m_pointerOwner) {
+      closePointer();
+    }
+  }
+
+  bool UiTreeReconciler::subtreeOwnsPointer(const Slot& slot) const {
+    if (m_pointerOwner == nullptr) {
+      return false;
+    }
+    if (slot.node == m_pointerOwner) {
+      return true;
+    }
+    for (const Slot& child : slot.children) {
+      if (subtreeOwnsPointer(child)) {
         return true;
       }
     }
@@ -1414,7 +1531,10 @@ namespace ui {
     }
 
     if (desired.type == "graph") {
-      auto* graph = static_cast<Graph*>(node);
+      auto* graph = controlFromSlot<Graph>(node);
+      if (graph == nullptr) {
+        return;
+      }
       if (const std::vector<double>* values = arrayProp(desired, "values")) {
         graph->setValues(toFloatSeries(*values));
       }
@@ -1433,9 +1553,14 @@ namespace ui {
       if (const double* fillOpacity = numProp(desired, "fillOpacity")) {
         graph->setFillOpacity(std::clamp(static_cast<float>(*fillOpacity), 0.0F, 1.0F));
       }
-      graph->setSize(
-          width != nullptr ? scaled(*width) : node->width(), height != nullptr ? scaled(*height) : node->height()
-      );
+      const float graphWidth = width != nullptr ? scaled(*width) : graph->width();
+      const float graphHeight = height != nullptr ? scaled(*height) : graph->height();
+      graph->setSize(graphWidth, graphHeight);
+      InputArea* inputArea = inputAreaFromSlot(node);
+      if (inputArea != nullptr) {
+        inputArea->setSize(graphWidth, graphHeight);
+      }
+      syncGraphPointerCallbacks(slot, desired, node);
       return;
     }
 

--- a/src/ui/ui_tree_reconciler.h
+++ b/src/ui/ui_tree_reconciler.h
@@ -34,7 +34,9 @@ namespace ui {
     // callbacks like button clicks. onHover sends state in `arg1` and the node's
     // `key` in `arg2`, so one handler can serve a whole keyed list. `coalesce`
     // is set for high-frequency streams (slider drag, input typing) where only
-    // the latest value matters.
+    // the latest value matters; `coalesceKey` groups callbacks that must
+    // supersede one another in order (a graph's pointer move and pointer
+    // leave), and defaults to `fn` when empty.
     struct ControlCallback {
       struct PointerContext {
         float x = 0.0F;
@@ -44,14 +46,17 @@ namespace ui {
       };
 
       explicit ControlCallback(
-          std::string fnName, std::string firstArg = {}, std::string secondArg = {}, bool coalesceStream = false
+          std::string fnName, std::string firstArg = {}, std::string secondArg = {}, bool coalesceStream = false,
+          std::string coalesceStreamKey = {}
       )
-          : fn(std::move(fnName)), arg1(std::move(firstArg)), arg2(std::move(secondArg)), coalesce(coalesceStream) {}
+          : fn(std::move(fnName)), arg1(std::move(firstArg)), arg2(std::move(secondArg)), coalesce(coalesceStream),
+            coalesceKey(std::move(coalesceStreamKey)) {}
 
       std::string fn;
       std::string arg1;
       std::string arg2;
       bool coalesce = false;
+      std::string coalesceKey;
       std::optional<PointerContext> pointerContext;
     };
     using CallbackSink = std::function<void(const ControlCallback& callback)>;
@@ -115,6 +120,17 @@ namespace ui {
     void closeHover();
     void releaseHover(const Node* owner);
     [[nodiscard]] bool subtreeOwnsHover(const Slot& slot) const;
+    // Graph pointer tracking (onPointerMove/onPointerLeave) wiring, wired as one
+    // unit so both edges of a graph's pointer session share a coalescing stream.
+    void syncGraphPointerCallbacks(Slot& slot, const UiTreeNode& desired, Node* node);
+    // A pointer session is state the plugin mirrors, so every entered graph owes
+    // a leave. Same reason as hover: the dispatcher only delivers leave to areas
+    // still in the scene, so the reconciler ends the session itself when the
+    // graph is dropped, rewired, or reset away.
+    void openPointer(const Node* owner, std::string leaveCallback, std::string streamKey);
+    void closePointer();
+    void releasePointer(const Node* owner);
+    [[nodiscard]] bool subtreeOwnsPointer(const Slot& slot) const;
     [[nodiscard]] std::unique_ptr<Node> createControl(const UiTreeNode& desired);
 
     CallbackSink m_sink;
@@ -132,6 +148,14 @@ namespace ui {
     std::string m_hoveredCallback;
     std::string m_hoveredKey;
     const Node* m_hoveredOwner = nullptr;
+    // The graph reporting pointer position, with the leave callback and
+    // coalescing stream its wiring opened with. Compared, never dereferenced.
+    std::string m_pointerLeaveCallback;
+    std::string m_pointerStreamKey;
+    const Node* m_pointerOwner = nullptr;
+    // Source of per-graph coalescing stream keys. Monotonic so a rebuilt or
+    // rewired graph never inherits a stream that still has an event queued.
+    std::uint64_t m_pointerStreamSeq = 0;
     std::unique_ptr<DragDropController> m_dragDropController;
     std::vector<Slot> m_rootSlots;
   };

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -8,6 +8,7 @@
 #include "ui/controls/drag_source.h"
 #include "ui/controls/drop_zone.h"
 #include "ui/controls/flex.h"
+#include "ui/controls/graph.h"
 #include "ui/controls/input.h"
 #include "ui/controls/label.h"
 #include "ui/controls/scroll_view.h"
@@ -2312,6 +2313,355 @@ int main() {
             20.0f, 20.0f, WL_POINTER_AXIS_HORIZONTAL_SCROLL, WL_POINTER_AXIS_SOURCE_WHEEL, 15.0, 1, 120, 3.0f
         );
     ok = expect(!horizontalAxisConsumed, "non-scrollable horizontal view does not consume wheel input") && ok;
+  }
+
+  // Graph: no pointer callback declared -> plain Graph, no InputArea wrapper
+  // (existing values/size behaviour is unaffected by the new capability).
+  {
+    ui::UiTreeReconciler reconciler;
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("values", std::vector<double>{0.0, 0.5, 1.0, 0.5});
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    (void)reconciler.reconcile(host, tree, renderer);
+
+    auto* graph = dynamic_cast<Graph*>(host.children().front().get());
+    ok = expect(graph != nullptr, "callback-less graph is a bare Graph") && ok;
+    ok = expect(
+             dynamic_cast<InputArea*>(host.children().front().get()) == nullptr,
+             "callback-less graph has no InputArea wrapper"
+         )
+        && ok;
+    ok = expect(graph != nullptr && graph->width() == 100.0f && graph->height() == 50.0f, "graph size applied") && ok;
+  }
+
+  // Graph: onPointerMove wraps the control in a hover-only InputArea (no
+  // clicks accepted, not focusable) that forwards its size to the graph.
+  {
+    ui::UiTreeReconciler reconciler;
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("values", std::vector<double>{0.0, 1.0});
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    tree.props.emplace("onPointerMove", std::string("track"));
+    (void)reconciler.reconcile(host, tree, renderer);
+
+    auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+    ok = expect(
+             area != nullptr && area->acceptedButtons() == 0 && !area->focusable(),
+             "onPointerMove wraps the graph in a hover-only InputArea"
+         )
+        && ok;
+    auto* graph =
+        area != nullptr && !area->children().empty() ? dynamic_cast<Graph*>(area->children().front().get()) : nullptr;
+    ok = expect(graph != nullptr, "wrapped graph control is reachable through the InputArea") && ok;
+    ok = expect(
+             area != nullptr && area->width() == 100.0f && area->height() == 50.0f,
+             "wrapper mirrors the graph's explicit size"
+         )
+        && ok;
+  }
+
+  // Graph: pointer motion reports coordinates normalized to the graph's own
+  // content area [0,1], coalesced so a fast pointer never floods the plugin
+  // queue; onEnter reports the same way as onMotion for the first position.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    tree.props.emplace("onPointerMove", std::string("track"));
+    (void)reconciler.reconcile(host, tree, renderer);
+    auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+
+    if (area != nullptr) {
+      area->dispatchEnter(25.0f, 10.0f);
+    }
+    ok = expect(
+             fired.size() == 1
+                 && fired[0].fn == "track"
+                 && fired[0].arg1 == "0.2500"
+                 && fired[0].arg2 == "0.2000"
+                 && fired[0].coalesce,
+             "enter reports normalized coordinates through the coalesced sink"
+         )
+        && ok;
+
+    fired.clear();
+    if (area != nullptr) {
+      area->dispatchMotion(90.0f, 45.0f);
+    }
+    ok = expect(
+             fired.size() == 1 && fired[0].fn == "track" && fired[0].arg1 == "0.9000" && fired[0].arg2 == "0.9000",
+             "motion reports updated normalized coordinates"
+         )
+        && ok;
+
+    // Coordinates outside the control clamp to [0,1] instead of going
+    // negative or past 1 (the dispatcher only delivers points inside the
+    // hit area in practice, but the callback must never leak raw pixels).
+    fired.clear();
+    if (area != nullptr) {
+      area->dispatchMotion(-5.0f, 200.0f);
+    }
+    ok = expect(
+             fired.size() == 1 && fired[0].arg1 == "0.0000" && fired[0].arg2 == "1.0000",
+             "out-of-bounds pixels clamp to the [0,1] normalized range"
+         )
+        && ok;
+  }
+
+  // Graph: onPointerLeave is wired independently of onPointerMove and fires
+  // with no arguments.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    tree.props.emplace("onPointerMove", std::string("track"));
+    tree.props.emplace("onPointerLeave", std::string("gone"));
+    (void)reconciler.reconcile(host, tree, renderer);
+    auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+
+    if (area != nullptr) {
+      area->dispatchEnter(10.0f, 10.0f);
+    }
+    fired.clear();
+    if (area != nullptr) {
+      area->dispatchLeave();
+    }
+    ok = expect(fired.size() == 1 && fired[0].fn == "gone" && fired[0].arg1.empty(), "leave fires its own callback")
+        && ok;
+  }
+
+  // Graph: resizing changes the normalization basis for the same raw pixel.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    tree.props.emplace("onPointerMove", std::string("track"));
+    (void)reconciler.reconcile(host, tree, renderer);
+    auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+    if (area != nullptr) {
+      area->dispatchMotion(50.0f, 25.0f);
+    }
+    ok = expect(fired.size() == 1 && fired[0].arg1 == "0.5000", "midpoint at 100px wide reports 0.5") && ok;
+
+    fired.clear();
+    tree.props["width"] = 200.0;
+    (void)reconciler.reconcile(host, tree, renderer);
+    if (area != nullptr) {
+      area->dispatchMotion(50.0f, 25.0f);
+    }
+    ok = expect(
+             fired.size() == 1 && fired[0].arg1 == "0.2500", "the same raw pixel renormalizes after a resize to 200px"
+         )
+        && ok;
+  }
+
+  // Graph: removing the callback prop tears down wiring on the retained
+  // wrapper instead of leaving a stale handler.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    tree.props.emplace("onPointerMove", std::string("track"));
+    (void)reconciler.reconcile(host, tree, renderer);
+    Node* wrapperBefore = host.children().front().get();
+
+    tree.props.erase("onPointerMove");
+    (void)reconciler.reconcile(host, tree, renderer);
+    ok = expect(
+             dynamic_cast<InputArea*>(host.children().front().get()) == nullptr,
+             "dropping the callback rebuilds the graph unwrapped"
+         )
+        && ok;
+    ok = expect(host.children().front().get() != wrapperBefore, "the InputArea wrapper is torn down") && ok;
+  }
+
+  // Graph: onPointerLeave alone still wraps the graph and reports the exit.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("graph");
+    tree.props.emplace("width", 100.0);
+    tree.props.emplace("height", 50.0);
+    tree.props.emplace("onPointerLeave", std::string("gone"));
+    (void)reconciler.reconcile(host, tree, renderer);
+    auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+    ok = expect(area != nullptr, "a leave-only graph is still wrapped") && ok;
+
+    if (area != nullptr) {
+      area->dispatchEnter(10.0f, 10.0f);
+    }
+    ok = expect(fired.empty(), "a leave-only graph reports nothing on enter") && ok;
+    if (area != nullptr) {
+      area->dispatchLeave();
+    }
+    ok = expect(fired.size() == 1 && fired[0].fn == "gone", "a leave-only graph reports its exit") && ok;
+  }
+
+  // Graph: a pointer session the plugin is mirroring is closed by the
+  // reconciler when the graph leaves the tree, is rebuilt unwrapped, or is
+  // reset away. The dispatcher never delivers leave for a node it no longer
+  // sees, so without this the plugin's hover state would stick on.
+  {
+    const auto enteredGraphTree = []() {
+      ui::UiTreeNode tree = makeNode("graph");
+      tree.props.emplace("width", 100.0);
+      tree.props.emplace("height", 50.0);
+      tree.props.emplace("onPointerMove", std::string("track"));
+      tree.props.emplace("onPointerLeave", std::string("gone"));
+      return tree;
+    };
+
+    {
+      ui::UiTreeReconciler reconciler;
+      std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+      reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+      Flex host;
+      ui::UiTreeNode tree = enteredGraphTree();
+      (void)reconciler.reconcile(host, tree, renderer);
+      if (auto* area = dynamic_cast<InputArea*>(host.children().front().get())) {
+        area->dispatchEnter(10.0f, 10.0f);
+      }
+      fired.clear();
+      ui::UiTreeNode replacement = makeNode("label");
+      (void)reconciler.reconcile(host, replacement, renderer);
+      ok = expect(fired.size() == 1 && fired[0].fn == "gone", "a hovered graph dropped from the tree reports its leave")
+          && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+      reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+      Flex host;
+      ui::UiTreeNode tree = enteredGraphTree();
+      (void)reconciler.reconcile(host, tree, renderer);
+      if (auto* area = dynamic_cast<InputArea*>(host.children().front().get())) {
+        area->dispatchEnter(10.0f, 10.0f);
+      }
+      fired.clear();
+      tree.props.erase("onPointerMove");
+      tree.props.erase("onPointerLeave");
+      (void)reconciler.reconcile(host, tree, renderer);
+      ok = expect(fired.size() == 1 && fired[0].fn == "gone", "a hovered graph rebuilt unwrapped reports its leave")
+          && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+      reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+      Flex host;
+      ui::UiTreeNode tree = enteredGraphTree();
+      (void)reconciler.reconcile(host, tree, renderer);
+      if (auto* area = dynamic_cast<InputArea*>(host.children().front().get())) {
+        area->dispatchEnter(10.0f, 10.0f);
+      }
+      fired.clear();
+      tree.props["onPointerLeave"] = std::string("goneRenamed");
+      (void)reconciler.reconcile(host, tree, renderer);
+      ok = expect(fired.size() == 1 && fired[0].fn == "gone", "rewiring a hovered graph closes the old session first")
+          && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+      reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+      Flex host;
+      ui::UiTreeNode tree = enteredGraphTree();
+      (void)reconciler.reconcile(host, tree, renderer);
+      if (auto* area = dynamic_cast<InputArea*>(host.children().front().get())) {
+        area->dispatchEnter(10.0f, 10.0f);
+      }
+      fired.clear();
+      reconciler.reset();
+      ok = expect(fired.size() == 1 && fired[0].fn == "gone", "reset closes an open pointer session") && ok;
+    }
+  }
+
+  // Graph: a graph's position and leave share one coalescing stream, so the
+  // newest of the two always wins in the script queue, and two graphs never
+  // supersede each other even when they name the same handler.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<ui::UiTreeReconciler::ControlCallback> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired.push_back(cb); });
+    Flex host;
+
+    ui::UiTreeNode first = makeNode("graph");
+    first.key = "a";
+    first.props.emplace("width", 100.0);
+    first.props.emplace("height", 50.0);
+    first.props.emplace("onPointerMove", std::string("track"));
+    first.props.emplace("onPointerLeave", std::string("gone"));
+    ui::UiTreeNode second = first;
+    second.key = "b";
+    ui::UiTreeNode row = makeNode("row");
+    row.children.push_back(first);
+    row.children.push_back(second);
+    (void)reconciler.reconcile(host, row, renderer);
+
+    auto* rowNode = dynamic_cast<Flex*>(host.children().front().get());
+    auto* areaA = rowNode != nullptr ? dynamic_cast<InputArea*>(rowNode->children()[0].get()) : nullptr;
+    auto* areaB = rowNode != nullptr ? dynamic_cast<InputArea*>(rowNode->children()[1].get()) : nullptr;
+    if (areaA != nullptr && areaB != nullptr) {
+      areaA->dispatchEnter(50.0f, 25.0f);
+      areaA->dispatchLeave();
+      areaB->dispatchEnter(50.0f, 25.0f);
+    }
+    ok = expect(fired.size() == 3, "both graphs report through the same handler names") && ok;
+    if (fired.size() == 3) {
+      ok = expect(
+               !fired[0].coalesceKey.empty() && fired[0].coalesceKey == fired[1].coalesceKey,
+               "a graph's move and leave share one coalescing stream"
+           )
+          && ok;
+      ok = expect(fired[2].coalesceKey != fired[0].coalesceKey, "sibling graphs get their own coalescing stream") && ok;
+      ok = expect(fired[1].fn == "gone" && fired[1].coalesce, "leave coalesces on the graph's stream") && ok;
+    }
+
+    // A re-render that leaves the callback names alone keeps the stream, so a
+    // pending position is not stranded behind a fresh key every frame.
+    const std::string streamBefore = fired.empty() ? std::string{} : fired[0].coalesceKey;
+    fired.clear();
+    (void)reconciler.reconcile(host, row, renderer);
+    if (areaA != nullptr) {
+      areaA->dispatchMotion(50.0f, 25.0f);
+    }
+    ok = expect(
+             fired.size() == 1 && fired[0].coalesceKey == streamBefore,
+             "an unchanged re-render keeps the graph's coalescing stream"
+         )
+        && ok;
   }
 
   return ok ? 0 : 1;


### PR DESCRIPTION
## Summary

Adds `onPointerMove` and `onPointerLeave` callback props to declarative
`ui.graph` nodes. A graph that declares either callback is wrapped in a
hover-only `InputArea` (no clicks accepted, not focusable) — the same
wrapper mechanism box, image, row, and column already use for
`onClick`/`onHover` (#3470). A graph without pointer callbacks stays a
bare `Graph` node with zero new cost.

`onPointerMove` receives the pointer position normalized to `[0,1]` over
the graph's content area, delivered as the two callback string arguments
(the convention slider `onChange` and friends already use). Motion is
coalesced to at most one pending callback per script frame (the same
mechanism slider drags use), so a fast pointer cannot flood the plugin
event queue. `onEnter` routes through the same emitter so the first
position inside the graph is reported immediately, without waiting for a
separate motion event. `onPointerLeave` is independently optional and
fires with no arguments.

```lua
ui.graph({
  values = series,
  onPointerMove = function(normX, normY)
    -- normX/normY arrive as strings; tonumber() them
    local x = tonumber(normX)
  end,
  onPointerLeave = function() end,
})
```

## Motivation

Declarative graph nodes render data but receive no pointer input, so
plugins cannot implement hover inspection, value scrubbing, or tooltips
over a graph — the most basic interactions users expect from a time
series. Normalized coordinates rather than data indices keep the
primitive generic: the plugin maps the x-position onto its own data
model (evenly spaced, timestamped, or otherwise), and the graph node
stays unaware of what its data means.

Removing a callback rebuilds the graph unwrapped via the existing
`clickableWrapMismatch` path, so no stale invisible handler can survive
a re-render — matching the wrapper lifecycle semantics documented in
#3470.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None found — searched issues and PRs for graph hover/pointer
interaction before implementing.

## Testing

- `just format`
- `just configure` (debug) + full `meson test -C build-debug`:
  **92/92 OK** (includes 7 new test blocks in `ui_tree_reconciler_test`
  covering: callback-less graph stays unwrapped and keeps size
  behaviour; hover-only wrapper flags; normalized coordinates on
  enter/motion; out-of-bounds clamping; independent leave wiring;
  re-normalization after a resize; wrapper teardown on callback
  removal)
- `just lint` (clang-tidy, warnings-as-errors): clean

## Manual Coverage

Unit-tested at the reconciler/input-area level (same layer as #3470);
no shell-visible surface changes for stock graphs, so compositor
coverage is not affected. Not yet exercised in a live plugin panel on
each compositor — happy to do a pass if maintainers want it.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

No visual change — graphs render identically unless a plugin opts into
the callbacks.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Coordinates follow the scene convention: `0,0` is the top-left of the
  graph's content area, which fills the whole control (`Graph::setSize`
  positions the render node at `0,0` with no inset), so `normY` grows
  downward.
- Wrapper input handlers clear on removal rather than being retained,
  consistent with the deviation #3470 established for wrapper callbacks.
- After merge, `onPointerMove`/`onPointerLeave` should be documented
  alongside `onClick`/`onHover` in the plugin UI reference.

Disclaimer: AI-assisted tooling was used.