### PR TITLE
feat(lockscreen): add a password reveal toggle to the login box

### DIFF
--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -502,6 +502,28 @@ LockSurface::LockSurface(WaylandConnection& connection, ConfigService* config) :
 
   m_loginContentRow->addChild(
       ui::button({
+          .out = &m_passwordRevealButton,
+          .text = "",
+          .glyph = "eye",
+          .glyphSize = 16.0F,
+          .variant = ButtonVariant::Ghost,
+          .onClick =
+              [this]() {
+                if (m_passwordField == nullptr) {
+                  return;
+                }
+                m_passwordRevealed = !m_passwordRevealed;
+                m_passwordField->setPasswordMode(!m_passwordRevealed);
+                if (m_passwordRevealButton != nullptr) {
+                  m_passwordRevealButton->setGlyph(m_passwordRevealed ? "eye-off" : "eye");
+                }
+              },
+          .configure = [](Button& button) { button.setZIndex(2); },
+      })
+  );
+
+  m_loginContentRow->addChild(
+      ui::button({
           .out = &m_loginButton,
           .text = "",
           .glyph = "check",
@@ -630,6 +652,16 @@ void LockSurface::setLockedState(bool locked) {
   }
   m_locked = locked;
   if (m_locked) {
+    // Never carry a revealed password across lock cycles.
+    if (m_passwordRevealed) {
+      m_passwordRevealed = false;
+      if (m_passwordField != nullptr) {
+        m_passwordField->setPasswordMode(true);
+      }
+      if (m_passwordRevealButton != nullptr) {
+        m_passwordRevealButton->setGlyph("eye");
+      }
+    }
     focusPasswordField();
   } else {
     m_inputDispatcher.setFocus(nullptr);
@@ -926,6 +958,9 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
     m_widgetLayer->setVisible(false);
     m_loginPanel->setVisible(false);
     m_passwordField->setVisible(false);
+    if (m_passwordRevealButton != nullptr) {
+      m_passwordRevealButton->setVisible(false);
+    }
     m_loginButton->setVisible(false);
     if (m_infoRow != nullptr) {
       m_infoRow->setVisible(false);
@@ -951,6 +986,9 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
   m_loginPanel->setVisible(loginVisible);
   m_loginContentRow->setVisible(loginVisible);
   m_passwordField->setVisible(loginVisible);
+  if (m_passwordRevealButton != nullptr) {
+    m_passwordRevealButton->setVisible(loginVisible);
+  }
   m_loginButton->setVisible(loginVisible && loginStyle.showLoginButton);
 
   const bool regular = loginVisible && loginStyle.layout == lockscreen_login_box::LayoutMode::Regular;
@@ -1218,6 +1256,12 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
     m_loginButton->setGlyphSize(sessionGlyphSize);
   }
 
+  if (m_passwordRevealButton != nullptr) {
+    m_passwordRevealButton->setRadius(Style::scaledRadius(loginStyle.inputRadius));
+    m_passwordRevealButton->setSize(controlHeight, controlHeight);
+    m_passwordRevealButton->setGlyphSize(sessionGlyphSize);
+  }
+
   m_loginPanel->arrange(renderer, LayoutRect{panelX, panelY, panelWidth, panelHeight});
 
   // Auth panel: sibling above/below the login box (flips below when near the top edge).
@@ -1264,6 +1308,9 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
 void LockSurface::updateCopy() {
   m_passwordField->setValue(m_password);
   m_passwordField->setEnabled(!m_authenticating);
+  if (m_passwordRevealButton != nullptr) {
+    m_passwordRevealButton->setEnabled(!m_authenticating);
+  }
   if (m_loginButton != nullptr) {
     m_loginButton->setEnabled(!m_authenticating);
   }

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -151,6 +151,8 @@ private:
   Label* m_authLabel = nullptr;
   Flex* m_loginContentRow = nullptr;
   Input* m_passwordField = nullptr;
+  Button* m_passwordRevealButton = nullptr;
+  bool m_passwordRevealed = false;
   Button* m_loginButton = nullptr;
   Button* m_layoutChip = nullptr;
   Flex* m_sessionRow = nullptr;


### PR DESCRIPTION
## Summary

Adds the same eye/eye-off password reveal toggle the control-center
Wi-Fi password prompt already has (`network_tab.cpp`) to the lock
screen's login box — a ghost button between the password field and the
login button that flips `setPasswordMode` and swaps its glyph.

## Motivation

The Wi-Fi prompt lets you briefly check a long password while typing;
the lock screen — where typos cost a full retype and an unlock attempt —
offers no such check. The interaction pattern already exists in-shell,
so this ports it to the one password field that lacked it.

Behaviour details:

- concealed by default; reveal is a momentary toggle, never persisted;
- the reveal state resets on every lock (`setLockedState(true)`), so a
  revealed password never survives into the next unlock;
- disabled while authentication is in flight, alongside the field and
  the login button;
- follows the login box's visibility (blackout, `loginVisible`) and
  picks up the same radius/size/glyph sizing as the login button.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None found; searched issues/PRs for lock-screen reveal/show-password.

## Testing

- `just format`
- `just configure` (debug) + full build + `meson test -C build-debug`:
  **92/92 OK**
- Manual: code-path review only so far — I can attach a screenshot of
  the lock screen login box with the toggle before review if wanted
  (avoided locking a live session while preparing this PR).

The `setPasswordMode` primitive this reuses is covered by
`tests/input_password_mode_test.cpp`; the lock surface itself has no
unit-test scaffolding upstream (scene/wallpaper machinery), matching
the Wi-Fi prompt's reveal button, which is also untested at that layer.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Can provide on request (requires locking a session to capture).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No new settings key: the Wi-Fi prompt's toggle is unconditional, so
this mirrors it rather than growing the login-box style surface. Happy
to add a `show_reveal_password_button` style flag if maintainers prefer
configurability.

Disclaimer: AI-assisted tooling was used.
