### PR TITLE
feat(calendar): notify before upcoming events

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -764,6 +764,9 @@
       "calendar-google-connect-start-failed": "Could not start Google authorization. Check your network connection and try again.",
       "calendar-google-connect-start-http": "Could not start Google authorization. The OAuth broker returned HTTP {status}.",
       "calendar-google-connect-timeout": "Google authorization timed out. Start the connection again when you are ready to sign in.",
+      "calendar-reminder-body": "Starts in {minutes} min",
+      "calendar-reminder-now": "Starting now",
+      "calendar-reminder-untitled": "Untitled event",
       "config-migration-body": "Update {path} in the source file. Noctalia is applying this replacement only temporarily. Run noctalia config validate to list every required change.",
       "config-migration-title": "Configuration update needed",
       "dbus-disabled": "DBus notifications disabled",
@@ -2575,6 +2578,14 @@
         "calendar-refresh-interval": {
           "description": "How often to sync calendar events (minutes)",
           "label": "Refresh Interval"
+        },
+        "calendar-reminder-lead": {
+          "description": "How many minutes before an event starts to send the reminder",
+          "label": "Reminder Lead Time"
+        },
+        "calendar-reminders": {
+          "description": "Send a desktop notification before a timed event starts",
+          "label": "Event Reminders"
         },
         "calendar-storage": {
           "button": "Retry",

--- a/example.toml
+++ b/example.toml
@@ -238,6 +238,8 @@ disk_poll_seconds = 10.0            # disk usage and swap usage; graph widgets u
 [calendar]
 enabled                     = false
 refresh_minutes             = 15
+reminders_enabled           = false         # notify before a timed event starts (all-day events excluded)
+reminder_lead_minutes       = 10            # how many minutes before the start to notify
 
 # Calendar tab of the control center.
 

--- a/meson.build
+++ b/meson.build
@@ -435,6 +435,7 @@ _noctalia_sources = files(
   'src/calendar/google_client.cpp',
   'src/calendar/google_oauth.cpp',
   'src/calendar/ical_parser.cpp',
+  'src/calendar/reminder_scheduler.cpp',
   'src/config/atomic_file.cpp',
   'src/config/config_export.cpp',
   'src/config/config_merge.cpp',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -148,6 +148,7 @@ namespace {
 Application::Application()
     : m_lockKeysService(m_wayland),
       m_calendarService(m_configService, m_httpClient, m_secretStore, m_storageKeyProvider, &m_notificationManager),
+      m_calendarReminderScheduler(m_configService, m_calendarService, &m_notificationManager),
       m_gammaService(m_wayland), m_locationService(m_configService, m_httpClient),
       m_weatherService(m_configService, m_httpClient) {
   m_notificationManager.loadPersistedHistory();

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -4,6 +4,8 @@
 #include "app/timer_poll_source.h"
 #include "calendar/calendar_poll_source.h"
 #include "calendar/calendar_service.h"
+#include "calendar/reminder_poll_source.h"
+#include "calendar/reminder_scheduler.h"
 #include "capture/screenshot_service.h"
 #include "compositors/compositor_platform.h"
 #include "compositors/workspace_alert_service.h"
@@ -244,6 +246,7 @@ private:
   LockKeysService m_lockKeysService;
   NotificationManager m_notificationManager;
   CalendarService m_calendarService;
+  CalendarReminderScheduler m_calendarReminderScheduler;
   std::unique_ptr<SessionBus> m_bus;
   std::unique_ptr<SystemBus> m_systemBus;
   std::unique_ptr<LogindService> m_logindService;
@@ -374,6 +377,7 @@ private:
   LocationPollSource m_locationPollSource{m_locationService};
   WeatherPollSource m_weatherPollSource{m_weatherService};
   CalendarPollSource m_calendarPollSource{m_calendarService};
+  ReminderPollSource m_reminderPollSource{m_calendarReminderScheduler};
   Timer m_trayInitTimer;
   Timer m_polkitInitTimer;
   Timer m_polkitIdleCloseTimer;

--- a/src/app/application_poll_sources.cpp
+++ b/src/app/application_poll_sources.cpp
@@ -62,6 +62,7 @@ std::vector<PollSource*> Application::currentPollSources() {
   sources.push_back(&m_locationPollSource);
   sources.push_back(&m_weatherPollSource);
   sources.push_back(&m_calendarPollSource);
+  sources.push_back(&m_reminderPollSource);
   sources.push_back(&m_thumbnailService);
   sources.push_back(&m_wallpaperScanner);
   sources.push_back(&m_asyncTextureCache);

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -1522,6 +1522,7 @@ void Application::initSessionBusServices() {
   m_locationService.initialize();
   m_weatherService.initialize();
   m_calendarService.initialize();
+  m_calendarReminderScheduler.initialize();
 
   // LocationService is the single source of "where am I": push its resolved coordinates to the
   // weather service, night light, and theme auto mode. Manual latitude/longitude and fixed

--- a/src/calendar/reminder_poll_source.h
+++ b/src/calendar/reminder_poll_source.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "app/poll_source.h"
+#include "calendar/reminder_scheduler.h"
+
+class ReminderPollSource final : public PollSource {
+public:
+  explicit ReminderPollSource(CalendarReminderScheduler& scheduler) : m_scheduler(scheduler) {}
+
+  [[nodiscard]] int pollTimeoutMs() const override { return m_scheduler.pollTimeoutMs(); }
+  void dispatch(const std::vector<pollfd>& /*fds*/, std::size_t /*startIdx*/) override { m_scheduler.tick(); }
+
+protected:
+  void doAddPollFds(std::vector<pollfd>& /*fds*/) override {}
+
+private:
+  CalendarReminderScheduler& m_scheduler;
+};

--- a/src/calendar/reminder_scheduler.cpp
+++ b/src/calendar/reminder_scheduler.cpp
@@ -1,0 +1,116 @@
+#include "calendar/reminder_scheduler.h"
+
+#include "config/config_service.h"
+#include "core/log.h"
+#include "i18n/i18n.h"
+#include "notification/notification_manager.h"
+
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+
+namespace {
+  constexpr Logger kLog("calendar-reminder");
+} // namespace
+
+CalendarReminderScheduler::CalendarReminderScheduler(
+    ConfigService& configService, CalendarService& calendar, NotificationManager* notifications
+)
+    : m_configService(configService), m_calendar(calendar), m_notifications(notifications) {}
+
+CalendarReminderScheduler::~CalendarReminderScheduler() {
+  if (m_changeCallbackId != 0) {
+    m_calendar.removeChangeCallback(m_changeCallbackId);
+  }
+}
+
+void CalendarReminderScheduler::initialize() {
+  // A refresh replaces the event set, so drop remembered reminders for instances that
+  // are no longer present. This bounds m_fired and lets the poll loop re-evaluate the
+  // next deadline on its following iteration.
+  m_changeCallbackId = m_calendar.addChangeCallback([this]() {
+    if (m_fired.empty()) {
+      return;
+    }
+    std::unordered_set<std::string> live;
+    live.reserve(m_calendar.snapshot().events.size());
+    for (const CalendarEvent& event : m_calendar.snapshot().events) {
+      live.insert(reminderKey(event));
+    }
+    for (auto it = m_fired.begin(); it != m_fired.end();) {
+      it = live.contains(*it) ? std::next(it) : m_fired.erase(it);
+    }
+  });
+}
+
+bool CalendarReminderScheduler::active() const {
+  const CalendarConfig& cfg = m_configService.config().calendar;
+  return m_notifications != nullptr && cfg.enabled && cfg.remindersEnabled && m_calendar.hasData();
+}
+
+std::chrono::system_clock::time_point CalendarReminderScheduler::fireTimeFor(const CalendarEvent& event) const {
+  const int lead = std::max<std::int32_t>(0, m_configService.config().calendar.reminderLeadMinutes);
+  return event.start - std::chrono::minutes{lead};
+}
+
+std::string CalendarReminderScheduler::reminderKey(const CalendarEvent& event) {
+  const auto startSeconds = std::chrono::duration_cast<std::chrono::seconds>(event.start.time_since_epoch()).count();
+  const std::string& base = event.id.empty() ? event.title : event.id;
+  return base + "@" + std::to_string(startSeconds);
+}
+
+int CalendarReminderScheduler::pollTimeoutMs() const {
+  if (!active()) {
+    return -1;
+  }
+  const auto now = std::chrono::system_clock::now();
+  std::int64_t best = -1;
+  for (const CalendarEvent& event : m_calendar.snapshot().events) {
+    if (event.allDay || now >= event.start || m_fired.contains(reminderKey(event))) {
+      continue;
+    }
+    std::int64_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(fireTimeFor(event) - now).count();
+    ms = std::max<std::int64_t>(0, ms);
+    best = best < 0 ? ms : std::min(best, ms);
+  }
+  if (best < 0) {
+    return -1;
+  }
+  // Cap so the loop re-evaluates periodically (freshly synced events, wall-clock jumps).
+  return static_cast<int>(std::min<std::int64_t>(best, 60000));
+}
+
+void CalendarReminderScheduler::tick() {
+  if (!active()) {
+    return;
+  }
+  const auto now = std::chrono::system_clock::now();
+  for (const CalendarEvent& event : m_calendar.snapshot().events) {
+    if (event.allDay || now >= event.start) {
+      continue;
+    }
+    const std::string key = reminderKey(event);
+    if (m_fired.contains(key) || now < fireTimeFor(event)) {
+      continue;
+    }
+    deliver(event, now);
+    m_fired.insert(key);
+  }
+}
+
+void CalendarReminderScheduler::deliver(const CalendarEvent& event, std::chrono::system_clock::time_point now) const {
+  // Round to the nearest minute so "in 10 minutes" reads cleanly regardless of sub-minute drift.
+  const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(event.start - now).count();
+  const std::int64_t minutes = (seconds + 30) / 60;
+
+  const std::string summary =
+      event.title.empty() ? i18n::tr("notifications.internal.calendar-reminder-untitled") : event.title;
+  const std::string body = minutes <= 0 ? i18n::tr("notifications.internal.calendar-reminder-now")
+                                        : i18n::tr("notifications.internal.calendar-reminder-body", "minutes", minutes);
+
+  kLog.info("event reminder: '{}' starts in {} min", summary, minutes);
+  m_notifications->addInternal(
+      i18n::tr("notifications.internal.calendar"), summary, body, Urgency::Normal, kDefaultNotificationTimeout,
+      std::string("noctalia-glyph:bell")
+  );
+}

--- a/src/calendar/reminder_scheduler.h
+++ b/src/calendar/reminder_scheduler.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "calendar/calendar_service.h"
+#include "calendar/calendar_types.h"
+
+#include <chrono>
+#include <string>
+#include <unordered_set>
+
+class ConfigService;
+class NotificationManager;
+
+// Raises a desktop notification a configurable number of minutes before each timed
+// calendar event starts. Timer-driven like CalendarService (pollTimeoutMs()/tick());
+// it owns no accounts or network of its own — it only reads CalendarService::snapshot()
+// and posts through NotificationManager. All-day events are skipped; each event
+// instance is reminded at most once per session, keyed by its id + start time.
+class CalendarReminderScheduler {
+public:
+  CalendarReminderScheduler(
+      ConfigService& configService, CalendarService& calendar, NotificationManager* notifications
+  );
+  ~CalendarReminderScheduler();
+
+  CalendarReminderScheduler(const CalendarReminderScheduler&) = delete;
+  CalendarReminderScheduler& operator=(const CalendarReminderScheduler&) = delete;
+
+  void initialize();
+
+  [[nodiscard]] int pollTimeoutMs() const;
+  void tick();
+
+private:
+  [[nodiscard]] bool active() const;
+  [[nodiscard]] std::chrono::system_clock::time_point fireTimeFor(const CalendarEvent& event) const;
+  [[nodiscard]] static std::string reminderKey(const CalendarEvent& event);
+  void deliver(const CalendarEvent& event, std::chrono::system_clock::time_point now) const;
+
+  ConfigService& m_configService;
+  CalendarService& m_calendar;
+  NotificationManager* m_notifications = nullptr;
+  CalendarService::ChangeCallbackId m_changeCallbackId = 0;
+  std::unordered_set<std::string> m_fired; // reminder keys already delivered this session
+};

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1161,6 +1161,9 @@ struct CalendarConfig {
 
   bool enabled = false;
   std::int32_t refreshMinutes = 15;
+  // Raise a desktop notification remindersLeadMinutes before each timed event starts.
+  bool remindersEnabled = false;
+  std::int32_t reminderLeadMinutes = 10;
   std::vector<Account> accounts;
 
   bool operator==(const CalendarConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1648,6 +1648,8 @@ namespace noctalia::config::schema {
     static const Schema<CalendarConfig> s = {
         field(&CalendarConfig::enabled, "enabled"),
         field(&CalendarConfig::refreshMinutes, "refresh_minutes", kRefreshMinutesRange),
+        field(&CalendarConfig::remindersEnabled, "reminders_enabled"),
+        field(&CalendarConfig::reminderLeadMinutes, "reminder_lead_minutes", kReminderLeadMinutesRange),
         namedMap<CalendarConfig, CalendarConfig::Account>(
             &CalendarConfig::accounts, "account", calendarAccountSchema(),
             [](CalendarConfig::Account& a, std::string_view id) { a.id = std::string(id); },

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -13,6 +13,7 @@ namespace noctalia::config::schema {
   inline constexpr Range<float> kUnitRange{0.0F, 1.0F, 0.01F};          // opacities, intensities, 0..1 factors
   inline constexpr Range<float> kScaleRange{0.5F, 2.5F, 0.05F};         // ui_scale, notification/osd scale
   inline constexpr Range<std::int64_t> kRefreshMinutesRange{5, 240, 5}; // calendar/weather refresh interval
+  inline constexpr Range<std::int64_t> kReminderLeadMinutesRange{0, 120, 1}; // calendar event reminder lead time
 
   // Shell.
   inline constexpr Range<float> kAnimationSpeedRange{0.1F, 4.0F, 0.05F};

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2655,6 +2655,25 @@ namespace settings {
       e.visibleWhen = calendarOn;
       entries.push_back(std::move(e));
     }
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-reminders.label"),
+          tr("settings.schema.services.calendar-reminders.description"), {"calendar", "reminders_enabled"},
+          ToggleSetting{cfg.calendar.remindersEnabled}, "calendar reminder notification alert event"
+      );
+      e.visibleWhen = calendarOn;
+      entries.push_back(std::move(e));
+    }
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-reminder-lead.label"),
+          tr("settings.schema.services.calendar-reminder-lead.description"), {"calendar", "reminder_lead_minutes"},
+          sliderFor(cfg.calendar.reminderLeadMinutes, noctalia::config::schema::kReminderLeadMinutesRange, true),
+          "calendar reminder lead minutes"
+      );
+      e.visibleWhen = [](const Config& c) { return c.calendar.enabled && c.calendar.remindersEnabled; };
+      entries.push_back(std::move(e));
+    }
 
     entries.push_back(makeEntry(
         SettingsSection::Services, "audio", tr("settings.schema.services.audio-overdrive.label"),


### PR DESCRIPTION
## Summary

Adds an optional **calendar event reminder**: a desktop notification raised a
configurable number of minutes before a timed event starts.

- **`CalendarReminderScheduler`** (`src/calendar/reminder_scheduler.{h,cpp}`) — a
  timer-driven `PollSource` modeled on `CalendarService` (`pollTimeoutMs()` /
  `tick()`). It reads `CalendarService::snapshot()`, subscribes to the existing
  change callback, and posts via `NotificationManager::addInternal()`. All-day
  events are skipped; each event instance reminds at most once per session
  (keyed by id + start time); the fired-set is pruned to the live snapshot on
  every refresh so it stays bounded.
- **Config** — new `[calendar]` keys `reminders_enabled` (bool) and
  `reminder_lead_minutes` (int, range `0..120`), added to `config_types.h`, the
  schema, and `ranges.h` following the existing `enabled` / `refresh_minutes`
  pattern.
- **Settings** — *Services → Calendar* gains a reminders toggle and a lead-time
  slider (the slider is shown only when reminders are enabled).
- `example.toml` and `assets/translations/en.json` updated.

## Motivation

The calendar service syncs and displays events but never proactively alerts
before one. A lead-time reminder ("Standup in 10 minutes") is the main reason
most people rely on a calendar — it's the one thing the current read-only sync
can't do. This closes that gap by reusing infrastructure that already exists
(event snapshot, refresh fan-out, the internal notification API, the poll-source
timer pattern).

## Type of Change

- [x] New feature

## Related Issue

None — opened directly as a PR.

## Testing

- `meson setup build && ninja -C build` — clean build, `noctalia` links, no new
  warnings from the added code.
- `meson test -C build` — **91/92 pass**, including `config_validate_cli`,
  `calendar_*`, `caldav_client`, and `ical_parser`. The single failure is the
  pre-existing `process` test (`completion-only async command stdout was wrong`),
  which fails in my sandboxed build environment and is unrelated to this change
  (no files it exercises were touched).
- `clang-format` (v22) run on the new files; no diff.

> **Not yet runtime-tested on a live session.** I could not exercise the actual
> notification firing in a running compositor in my build environment. Marking
> this as **Draft** until I verify a reminder fires end-to-end on my session.
> Feedback on the approach in the meantime is very welcome.

## Manual Coverage

- [ ] Runtime verification pending (see note above).

## Additional Notes

Scoped intentionally to a **global lead time**. Honoring each event's own iCal
`VALARM` trigger is a natural follow-up but needs a parser change — today
`ical_parser` explicitly ignores `VALARM` components — plus a new field on
`CalendarEvent` and its cache serialization. Happy to do that in a second PR if
maintainers want per-event reminder times.
