### PR TITLE
fix(notifications): refresh toast input region after frame-callback stalls

### DIFF
--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -2089,17 +2089,11 @@ void NotificationToast::ensureSurfaces() {
       prepareFrame(*instPtr, needsUpdate, needsLayout);
     });
     inst->surface->setFrameTickCallback([this, instPtr](float /*deltaMs*/) {
-      // Cards animate horizontally during entry/exit slides; the input and blur regions
-      // must follow the visible position or the rounded right edge bleeds.
-      // Unconditional on purpose: the tick that COMPLETES an animation must also
-      // refresh the regions. After a frame-callback stall (session locked, monitor
-      // off, output temporarily gone) the first post-stall tick advances every
-      // animation to its end in a single huge-delta jump, and hasActive() is already
-      // false by the time this callback runs — guarding on it would leave the
-      // reveal-0 region latched on a fully drawn card. A freshly added card is
-      // zero-width at reveal 0, so that stale region is empty: the toast renders
-      // but never takes pointer input (close button, action buttons, hover) and
-      // every click falls through to the windows underneath.
+      // Cards animate horizontally during entry/exit slides, so the input and blur regions
+      // must follow the visible position. Runs after the animation tick, so the tick that
+      // completes a slide already reports hasActive() == false: refresh unconditionally or
+      // a finished reveal keeps the region it had at reveal 0 (zero-width card, empty
+      // region, click-through toast).
       updateInputRegion(*instPtr);
     });
     inst->surface->setAnimationManager(&inst->animations);

--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -2091,9 +2091,16 @@ void NotificationToast::ensureSurfaces() {
     inst->surface->setFrameTickCallback([this, instPtr](float /*deltaMs*/) {
       // Cards animate horizontally during entry/exit slides; the input and blur regions
       // must follow the visible position or the rounded right edge bleeds.
-      if (instPtr->animations.hasActive()) {
-        updateInputRegion(*instPtr);
-      }
+      // Unconditional on purpose: the tick that COMPLETES an animation must also
+      // refresh the regions. After a frame-callback stall (session locked, monitor
+      // off, output temporarily gone) the first post-stall tick advances every
+      // animation to its end in a single huge-delta jump, and hasActive() is already
+      // false by the time this callback runs — guarding on it would leave the
+      // reveal-0 region latched on a fully drawn card. A freshly added card is
+      // zero-width at reveal 0, so that stale region is empty: the toast renders
+      // but never takes pointer input (close button, action buttons, hover) and
+      // every click falls through to the windows underneath.
+      updateInputRegion(*instPtr);
     });
     inst->surface->setAnimationManager(&inst->animations);
 


### PR DESCRIPTION
## Problem

Toasts whose notification arrived while the session was locked (or the monitor off / output temporarily gone) render fully but never take pointer input — close button, action buttons and hover are all dead, and every click falls through to the window underneath. This is #3338 (niri); the "dismiss one from the panel and the rest become clickable again" observation there matches this root cause exactly, since any card add/remove re-runs `updateInputRegion()` and repairs the region for the whole stack.

## Root cause

1. A newly added card starts its entry slide at reveal 0, where it is zero-width. `updateInputRegion()` skips zero-sized card nodes, so a fresh single-card toast latches an **empty input region** onto the surface.
2. During a frame-callback stall (ext-session-lock active, monitor off) the reveal animation cannot advance.
3. When frames resume, `Surface::processQueuedFrameWork()` ticks the animation manager with the full accumulated delta — the entry animation jumps to completion — and `hasActive()` is already false when the toast's frame-tick callback runs. The callback guarded the region refresh on `animations.hasActive()`, so the completing tick skipped it.
4. Result: the first post-stall commit draws the fully revealed card while keeping the empty input region latched. No later code path refreshes it (the surface is idle), so the toast stays click-through until some other card add/remove triggers a rebuild.

Timed notifications mostly self-heal here — their countdown also jumps by the stall duration and expires the toast on unlock — which is why the visible symptom concentrates on **persistent** notifications (timeout 0), e.g. calendar reminders with action buttons.

## Reproduction (niri, v5.0.0-beta.9)

```sh
noctalia msg session lock
notify-send -t 0 test "arrived while locked"
sleep 3
loginctl unlock-session   # or unlock by hand
# toast is visible; clicking the × does nothing, clicks hit the window underneath
```

## Fix

Make the per-tick input/blur region refresh unconditional. It already runs after the animation tick and before the frame's commit, only fires when the surface actually has frame work (never on a fully idle surface), and costs a handful of rect computations per card.

Verified on niri 26.04 with the repro above: locked-arrival toast dismisses via its × after this change; normal-path toasts unaffected.