### PR TITLE
feat(lockscreen): make the PAM service configurable

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -220,6 +220,8 @@ blur_intensity          = 0.5         # lock screen background blur (0.0 = none,
 tint_intensity          = 0.3         # surface-color tint over the lock screen background
 # wallpaper             = ""          # optional image path for the lock screen; empty uses the desktop wallpaper
 # monitors              = ["DP-1"]    # connectors that show the lock screen; empty shows all monitors, others stay black
+# pam_service            = "login"     # PAM service to authenticate against; override when the distro's login
+                                       # stack blocks on modules a lock screen can't satisfy (e.g. pam_fprintd)
 
 # ── System Monitor ────────────────────────────────────────────────────────────
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -538,6 +538,10 @@ struct LockscreenConfig {
   bool lockBeforeSuspend = true;
   bool fingerprint = true;
   bool allowEmptyPassword = false;
+  // PAM service (under /etc/pam.d/) the lock screen authenticates against.
+  // "login" suits most distros; a custom service avoids distro stacks that
+  // block on modules the lock screen cannot satisfy (e.g. pam_fprintd).
+  std::string pamService = "login";
   bool blurredDesktop = false;
   float blurIntensity = 0.5F;
   float tintIntensity = 0.3F;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -93,6 +93,7 @@ namespace noctalia::config::schema {
         field(&LockscreenConfig::lockBeforeSuspend, "lock_before_suspend"),
         field(&LockscreenConfig::fingerprint, "fingerprint"),
         field(&LockscreenConfig::allowEmptyPassword, "allow_empty_password"),
+        field(&LockscreenConfig::pamService, "pam_service"),
         field(&LockscreenConfig::blurredDesktop, "blurred_desktop"),
         field(&LockscreenConfig::blurIntensity, "blur_intensity", kUnitRange),
         field(&LockscreenConfig::tintIntensity, "tint_intensity", kUnitRange),

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -866,10 +866,12 @@ void LockScreen::tryAuthenticate() {
   updatePromptOnSurfaces();
 
   const PamAuthenticator authenticator = m_authenticator;
-  // Authenticate against the "login" stack. If fingerprint is enabled, strip
-  // pam_fprintd from it: noctalia drives the reader itself over D-Bus and the
-  // two can't share the sensor. See docs/fingerprint.md.
-  const std::string pamService = "login";
+  // Authenticate against the configured PAM stack ([lockscreen].pam_service,
+  // "login" by default). Noctalia drives the fingerprint reader itself over
+  // D-Bus when fingerprint is enabled, so a stack whose pam_fprintd would
+  // block the password conversation is better replaced by a custom service.
+  const std::string pamService =
+      m_configService != nullptr ? m_configService->config().lockscreen.pamService : std::string("login");
   std::thread([this, generation, password = std::move(password), authenticator, pamService]() mutable {
     const auto result = authenticator.authenticateCurrentUser(password, pamService);
     clearSensitiveString(password);

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -347,6 +347,7 @@ location = "https://example.invalid/bad"
     c.backdrop = BackdropConfig{true, 0.8f, 0.2f};
     c.lockscreen = LockscreenConfig{
         .lockBeforeSuspend = false,
+        .pamService = "noctalia",
         .blurredDesktop = true,
         .blurIntensity = 0.6f,
         .tintIntensity = 0.25f,


### PR DESCRIPTION
## Summary

Adds `[lockscreen].pam_service` (default `"login"`, existing behaviour
unchanged) so the lock screen can authenticate against a PAM service other
than the distro's login stack. Plumbing: config field + schema entry,
`LockScreen::tryAuthenticate` reads it instead of the hardcoded literal,
`example.toml` documents it, and the schema round-trip test covers it.

## Motivation

`tryAuthenticate()` passes a hardcoded `"login"` to `PamAuthenticator`.
Distro login stacks routinely pull in modules a lock screen cannot satisfy
— the recurring case is `pam_fprintd` (via `system-local-login` on Arch
and others) blocking the password conversation for its full timeout
before `pam_unix` finally runs (#3277). Today the only recourse is
editing the system login stack, which affects real logins too.

With a configurable service, the fix is a two-line dedicated stack:

```ini
# /etc/pam.d/noctalia
auth    required  pam_unix.so
account required  pam_unix.so
```

```toml
[lockscreen]
pam_service = "noctalia"
```

This also gives mixed-environment setups (e.g. running a Nix-built shell
on a non-NixOS host, where the nixpkgs-linked libpam cannot parse the
distro's `/etc/pam.d` includes) a principled escape hatch that stays
inside PAM, instead of shelling out to an external authenticator.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3277

## Testing

- `just format`
- `just configure` (debug) + full build + `meson test -C build-debug`:
  **92/92 OK** (including the extended `config_schema_roundtrip_test`
  covering `pam_service = "noctalia"` round-tripping through TOML)
- `noctalia config validate` exercised implicitly by the schema tests;
  unknown-key rejection verified by the existing schema test suite.

## Manual Coverage

Config plumbing only; no visual or compositor-facing change.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

None — no visual change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- While here, the comment above the old hardcoded literal claimed
  pam_fprintd is "stripped" from the login stack when fingerprint is
  enabled; nothing in the code does that, so the rewritten comment no
  longer makes the claim.
- No settings-UI entry added: `pam_service` is an advanced/deployment
  knob like `monitors`, which is also config-only. Happy to add one if
  maintainers prefer it visible in Settings.

Disclaimer: AI-assisted tooling was used.
