### PR TITLE
feat(input): add toggle in settings for readline-style shortcuts

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2365,6 +2365,10 @@
           "description": "Fetch rates from third party online sources",
           "label": "Currency Exchange Conversion"
         },
+        "launcher-readline-enabled": {
+          "description": "Use GNU Readline-style shortcuts in the launcher (e.g. Ctrl+A moves the cursor to the start of the line)",
+          "label": "Readline shortcuts"
+        },
         "launcher-global-calculator": {
           "description": "Also show calculator results in unprefixed search",
           "label": "Calculator in Global Search"

--- a/example.toml
+++ b/example.toml
@@ -79,6 +79,7 @@ app_grid      = false                   # show app icon grid view when results a
 sort_by_usage = true                    # sort apps by usage frequency
 pinned        = []                      # e.g. ["firefox", "code", "kitty"] (launcher only)
 fetch_exchange_rates = true             # refresh currency rates from third-party sources
+line_editing = true                     # use readline-style shortcuts in the launcher
 provider_prefix = "/"                     # common prefix character for provider trigger words (e.g. "/" or ".")
 auto_paste = "auto"                       # off | auto | ctrl_v | ctrl_shift_v | shift_insert (copy activations)
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1004,6 +1004,8 @@ struct ShellConfig {
     std::vector<std::string> pinned;
     /// When true, refresh currency exchange rates from libqalculate's online sources.
     bool fetchExchangeRates = true;
+    // Enables/disables readline-style shortcuts
+    bool lineEditing = true;
     std::string providerPrefix = "/";
     /// Paste shortcut after a copy-style launcher activation (calculator, emoji, …).
     ClipboardAutoPasteMode autoPaste = ClipboardAutoPasteMode::Auto;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1352,6 +1352,7 @@ namespace noctalia::config::schema {
           field(&ShellConfig::LauncherConfig::sortByUsage, "sort_by_usage"),
           field(&ShellConfig::LauncherConfig::pinned, "pinned"),
           field(&ShellConfig::LauncherConfig::fetchExchangeRates, "fetch_exchange_rates"),
+          field(&ShellConfig::LauncherConfig::lineEditing, "line_editing"),
           field(&ShellConfig::LauncherConfig::providerPrefix, "provider_prefix"),
           enumField(&ShellConfig::LauncherConfig::autoPaste, "auto_paste", kClipboardAutoPasteModes),
           subTable(&ShellConfig::LauncherConfig::dmenu, "dmenu", shellLauncherDmenuSchema()),

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1071,7 +1071,7 @@ void LauncherPanel::create() {
           .controlHeight = Style::controlHeight * scale,
           .horizontalPadding = Style::spaceMd * scale,
           .clearButtonEnabled = true,
-          .lineEditing = true,
+          .lineEditing = shouldUseLineEditing(),
           .surfaceOpacity = panelCardOpacity(),
           .onChange =
               [this](const std::string& text) {
@@ -1237,6 +1237,13 @@ bool LauncherPanel::shouldUseAppGrid() const {
   return std::ranges::all_of(m_results, [](const LauncherResult& result) {
     return result.providerId == kApplicationsProviderId;
   });
+}
+
+bool LauncherPanel::shouldUseLineEditing() const {
+  if (m_config == nullptr || !m_config->config().shell.launcher.lineEditing) {
+    return false;
+  }
+  return m_config->config().shell.launcher.lineEditing;
 }
 
 void LauncherPanel::syncLauncherViewLayout(Renderer* renderer) {

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -95,6 +95,7 @@ private:
   void syncLauncherListStyle();
   void syncLauncherViewLayout(Renderer* renderer = nullptr);
   [[nodiscard]] bool shouldUseAppGrid() const;
+  [[nodiscard]] bool shouldUseLineEditing() const;
   void refreshLauncherAppIconColorization();
   void updateLauncherGridMetrics(Renderer& renderer);
   void updatePinnedApplicationState();

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1262,6 +1262,11 @@ namespace settings {
         enumSelect(kClipboardAutoPasteModes, cfg.shell.launcher.autoPaste), "launcher auto paste"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Launcher, "launcher", tr("settings.schema.panels.launcher-readline-enabled.label"),
+        tr("settings.schema.panels.launcher-readline-enabled.description"), {"shell", "launcher", "line_editing"},
+        ToggleSetting{cfg.shell.launcher.lineEditing}, "launcher readline line editing shortcut"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Launcher, "providers", tr("settings.schema.panels.launcher-prefix-character.label"),
         tr("settings.schema.panels.launcher-prefix-character.description"), {"shell", "launcher", "provider_prefix"},
         TextSetting{.value = cfg.shell.launcher.providerPrefix, .placeholder = "/"}, "launcher common prefix character"

--- a/src/ui/controls/input.h
+++ b/src/ui/controls/input.h
@@ -232,7 +232,7 @@ private:
   bool m_clearButtonEnabled = false;
   bool m_passwordMode = false;
   bool m_multiline = false;
-  bool m_lineEditing = false;
+  bool m_lineEditing = true;
   bool m_invalid = false;
   bool m_frameVisible = true;
   bool m_embeddedOnSolidPrimary = false;


### PR DESCRIPTION
## Summary

Added toggle in Launcher settings panel to enable/disable [readline-style](https://en.wikipedia.org/wiki/GNU_Readline#Emacs_keyboard_shortcuts) shortcuts in the launcher. They are enabled by default, so no change from before.

## Motivation

None of the other input fields in the UI have Readline shortcuts enabled, so I wanted to add a setting so that people who want consistency across the fields can disable them. However, as they were enabled by default before, I set the default to enabled.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

#3946 is the PR where these were added.

## Testing

- manually checked functionality when toggle is on and off.
- `just format`, `just test`, `just lint`, `python3 tools/i18n-check.py`

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="1630" height="220" alt="satty-2026-08-27_18:06:31" src="https://github.com/user-attachments/assets/644ff5ae-f976-4f06-bac5-f7f6ab27546f" />

https://github.com/user-attachments/assets/636c27b2-067c-4bb2-b3c2-0ff50103d94d



## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes


