### PR TITLE
fix(launcher): only reset-on-edit, not focus

### DIFF
--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -891,7 +891,7 @@ namespace settings {
         .submitOnFocusLoss = true,
     });
     input->setOnChange([inputPtr](const std::string& /*text*/) { inputPtr->setInvalid(false); });
-    input->setOnSubmit([configService = ctx.configService, setOverride = ctx.setOverride, path,
+    input->setOnSubmit([configService = ctx.configService, setOverride = ctx.setOverride, path, effectiveValue = value,
                         inputPtr](const std::string& text) {
       if (configService != nullptr && !configService->validateOverride(path, ConfigOverrideValue{text})) {
         inputPtr->setInvalid(true);
@@ -901,6 +901,9 @@ namespace settings {
         return;
       }
       inputPtr->setInvalid(false);
+      if (text == effectiveValue) {
+        return;
+      }
       setOverride(path, text);
     });
     return input;


### PR DESCRIPTION
## Summary

This PR fix a bug where just clicking in the text input field in the Launcher's providers  without typing anything the Reset option appear.

Just added a change guard in `makeText` which checks if there is any text entry, if yes then show Reset button otherwise no.

## Motivation

Its a weird behaviour to show Reset button even though there was no text input.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Report from discord

## Testing

- `just build debug`, `just format`, `just test`, `just lint` all clean
- Tested on build debug mode and bug is fixed

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:-

https://github.com/user-attachments/assets/3f2eae3b-b104-4812-9871-56d0be0c4ede

<img width="772" height="600" alt="image" src="https://github.com/user-attachments/assets/7ed5800f-c2c0-4a7b-86a6-3ab81c22a051" />

After:-


https://github.com/user-attachments/assets/1635d387-d39a-4150-9206-e3df19a913a0



## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
