### PR TITLE
fix(bluetooth): bound rescan discovery

### DIFF
--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -10,6 +10,7 @@
 #include "ui/style.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -21,6 +22,9 @@ using namespace control_center;
 namespace {
 
   constexpr float kRowMinHeight = Style::controlHeightLg;
+
+  // Bounds an explicit Rescan: BlueZ discovery is stopped again when this window elapses.
+  constexpr auto kDiscoveryTimeout = std::chrono::seconds(10);
 
   const char* glyphFor(BluetoothDeviceKind kind) {
     switch (kind) {
@@ -503,6 +507,7 @@ void BluetoothTab::doLayout(Renderer& renderer, float contentWidth, float bodyHe
 }
 
 void BluetoothTab::doUpdate(Renderer& renderer) {
+  syncDiscoveryLease();
   syncPairingCard();
   rebuildDeviceList(renderer);
   // A metric pill's text changes its width, so the list has to be laid out again.
@@ -541,13 +546,41 @@ void BluetoothTab::onClose() {
   m_lastListWidth = -1.0F;
 }
 
-void BluetoothTab::stopRequestedDiscovery() {
-  if (!m_discoveryRequested) {
+void BluetoothTab::syncDiscoveryLease() {
+  if (m_discoveryLease == DiscoveryLease::None || m_service == nullptr) {
     return;
   }
 
-  m_discoveryRequested = false;
+  const BluetoothState& s = m_service->state();
+  if (!s.adapterPresent || !s.powered) {
+    // A powered-down adapter cannot be discovering, so BlueZ already dropped the session.
+    releaseDiscoveryLease();
+    return;
+  }
+  if (m_discoveryLease == DiscoveryLease::Pending) {
+    // StartDiscovery is async; the lease is only confirmed once BlueZ reports Discovering.
+    if (s.discovering) {
+      m_discoveryLease = DiscoveryLease::Active;
+    }
+    return;
+  }
+  if (!s.discovering) {
+    // Discovery ended outside the tab: drop the lease so the next Rescan starts a new one.
+    releaseDiscoveryLease();
+  }
+}
+
+void BluetoothTab::releaseDiscoveryLease() {
+  m_discoveryLease = DiscoveryLease::None;
   m_discoveryTimer.stop();
+}
+
+void BluetoothTab::stopRequestedDiscovery() {
+  if (m_discoveryLease == DiscoveryLease::None) {
+    return;
+  }
+
+  releaseDiscoveryLease();
   if (m_service != nullptr) {
     m_service->stopDiscovery();
   }
@@ -800,14 +833,12 @@ void BluetoothTab::rebuildDeviceList(Renderer& renderer) {
               if (m_service == nullptr) {
                 return;
               }
-              if (!m_discoveryRequested) {
-                m_service->stopDiscovery();
-                m_discoveryRequested = true;
+              // Repeated clicks renew the scan window instead of restarting discovery.
+              if (m_discoveryLease == DiscoveryLease::None) {
+                m_discoveryLease = DiscoveryLease::Pending;
                 m_service->startDiscovery();
               }
-              m_discoveryTimer.start(kDiscoveryTimeout, [this]() {
-                stopRequestedDiscovery();
-              });
+              m_discoveryTimer.start(kDiscoveryTimeout, [this]() { stopRequestedDiscovery(); });
             },
         })
     );

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -513,12 +513,16 @@ void BluetoothTab::doUpdate(Renderer& renderer) {
 }
 
 void BluetoothTab::setActive(bool active) {
+  if (!active) {
+    m_discoveryTimer.stop();
+  }
   if (!active && m_service != nullptr && m_service->state().discovering) {
     m_service->stopDiscovery();
   }
 }
 
 void BluetoothTab::onClose() {
+  m_discoveryTimer.stop();
   m_rootLayout = nullptr;
   m_pairingCard = nullptr;
   m_pairingTitle = nullptr;
@@ -789,6 +793,11 @@ void BluetoothTab::rebuildDeviceList(Renderer& renderer) {
               }
               m_service->stopDiscovery();
               m_service->startDiscovery();
+              m_discoveryTimer.start(kDiscoveryTimeout, [this]() {
+                if (m_service != nullptr) {
+                  m_service->stopDiscovery();
+                }
+              });
             },
         })
     );

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -514,15 +514,12 @@ void BluetoothTab::doUpdate(Renderer& renderer) {
 
 void BluetoothTab::setActive(bool active) {
   if (!active) {
-    m_discoveryTimer.stop();
-  }
-  if (!active && m_service != nullptr && m_service->state().discovering) {
-    m_service->stopDiscovery();
+    stopRequestedDiscovery();
   }
 }
 
 void BluetoothTab::onClose() {
-  m_discoveryTimer.stop();
+  stopRequestedDiscovery();
   m_rootLayout = nullptr;
   m_pairingCard = nullptr;
   m_pairingTitle = nullptr;
@@ -542,6 +539,18 @@ void BluetoothTab::onClose() {
   m_deviceRows.clear();
   m_lastStructureKey.clear();
   m_lastListWidth = -1.0F;
+}
+
+void BluetoothTab::stopRequestedDiscovery() {
+  if (!m_discoveryRequested) {
+    return;
+  }
+
+  m_discoveryRequested = false;
+  m_discoveryTimer.stop();
+  if (m_service != nullptr) {
+    m_service->stopDiscovery();
+  }
 }
 
 void BluetoothTab::syncHeader() {
@@ -791,12 +800,13 @@ void BluetoothTab::rebuildDeviceList(Renderer& renderer) {
               if (m_service == nullptr) {
                 return;
               }
-              m_service->stopDiscovery();
-              m_service->startDiscovery();
+              if (!m_discoveryRequested) {
+                m_service->stopDiscovery();
+                m_discoveryRequested = true;
+                m_service->startDiscovery();
+              }
               m_discoveryTimer.start(kDiscoveryTimeout, [this]() {
-                if (m_service != nullptr) {
-                  m_service->stopDiscovery();
-                }
+                stopRequestedDiscovery();
               });
             },
         })

--- a/src/shell/control_center/tabs/bluetooth_tab.h
+++ b/src/shell/control_center/tabs/bluetooth_tab.h
@@ -5,7 +5,7 @@
 #include "dbus/bluetooth/bluetooth_service.h"
 #include "shell/control_center/tab.h"
 
-#include <chrono>
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -30,11 +30,24 @@ public:
   void setActive(bool active) override;
 
 private:
-  void stopRequestedDiscovery();
-
   void doLayout(Renderer& renderer, float contentWidth, float bodyHeight) override;
   void doUpdate(Renderer& renderer) override;
   void onPanelCardOpacityChanged(float opacity) override;
+
+  // Discovery started by this tab's Rescan. Pending until BlueZ confirms Discovering,
+  // so a stop still fires while StartDiscovery is in flight.
+  enum class DiscoveryLease : std::uint8_t {
+    None,
+    Pending,
+    Active,
+  };
+
+  // Reconciles the lease with the adapter state; drops it when discovery ended elsewhere.
+  void syncDiscoveryLease();
+  // Forgets the lease without asking BlueZ to stop.
+  void releaseDiscoveryLease();
+  // Releases the lease and stops the discovery this tab started.
+  void stopRequestedDiscovery();
 
   void syncHeader();
   void syncPairingCard();
@@ -65,10 +78,9 @@ private:
   Toggle* m_discoverableToggle = nullptr;
   Button* m_rescanButton = nullptr;
   Spinner* m_scanSpinner = nullptr;
-  Timer m_discoveryTimer;
-  bool m_discoveryRequested = false;
 
-  static constexpr auto kDiscoveryTimeout = std::chrono::seconds(10);
+  Timer m_discoveryTimer;
+  DiscoveryLease m_discoveryLease = DiscoveryLease::None;
 
   std::unordered_map<std::string, BluetoothDeviceRow*> m_deviceRows;
 

--- a/src/shell/control_center/tabs/bluetooth_tab.h
+++ b/src/shell/control_center/tabs/bluetooth_tab.h
@@ -30,6 +30,8 @@ public:
   void setActive(bool active) override;
 
 private:
+  void stopRequestedDiscovery();
+
   void doLayout(Renderer& renderer, float contentWidth, float bodyHeight) override;
   void doUpdate(Renderer& renderer) override;
   void onPanelCardOpacityChanged(float opacity) override;
@@ -64,6 +66,7 @@ private:
   Button* m_rescanButton = nullptr;
   Spinner* m_scanSpinner = nullptr;
   Timer m_discoveryTimer;
+  bool m_discoveryRequested = false;
 
   static constexpr auto kDiscoveryTimeout = std::chrono::seconds(10);
 

--- a/src/shell/control_center/tabs/bluetooth_tab.h
+++ b/src/shell/control_center/tabs/bluetooth_tab.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "core/timer_manager.h"
 #include "dbus/bluetooth/bluetooth_agent.h"
 #include "dbus/bluetooth/bluetooth_service.h"
 #include "shell/control_center/tab.h"
 
+#include <chrono>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -61,6 +63,9 @@ private:
   Toggle* m_discoverableToggle = nullptr;
   Button* m_rescanButton = nullptr;
   Spinner* m_scanSpinner = nullptr;
+  Timer m_discoveryTimer;
+
+  static constexpr auto kDiscoveryTimeout = std::chrono::seconds(10);
 
   std::unordered_map<std::string, BluetoothDeviceRow*> m_deviceRows;
 


### PR DESCRIPTION
## Summary

Bounds the Bluetooth control-center **Rescan** action to a ten-second discovery window. The pending timeout is cancelled when the tab becomes inactive or the control center closes.

## Motivation

An explicit Rescan currently starts BlueZ discovery without a bounded lifetime, so discovery can remain active while the tab stays open.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #4120

## Testing

- `just configure`
- `just build`
- `just test` — 93 passed, 0 failed
- Manual Hyprland smoke test: the patched Rescan spinner stopped after about ten seconds.

## Manual Coverage

- [x] Tested on Hyprland
- [ ] Tested on Niri
- [ ] Tested on Sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Not applicable; this changes discovery lifetime only.

## Checklist

- [x] This PR is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran the relevant build and test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR adds no new user-facing strings, configuration, or documentation.
- [x] I used the existing canonical names for identifiers.

## Additional Notes

The timer uses the existing `Timer` infrastructure. Repeated Rescan clicks replace the prior timeout rather than accumulating callbacks.