### PR TITLE
feat(bar): reserve layout only while visible during auto-hide

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1917,6 +1917,10 @@
           "description": "Briefly reveal the bar when the active workspace changes",
           "label": "Show on Workspace Switch"
         },
+        "auto-hide-reserve-space": {
+          "description": "With auto-hide or smart auto-hide, reserve layout only while the bar is visible so hidden windows use the full screen",
+          "label": "Reserve Space While Visible"
+        },
         "start-widgets": {
           "description": "Widgets on the start (left/top) side of the bar",
           "label": "Start Widgets"

--- a/example.toml
+++ b/example.toml
@@ -355,6 +355,7 @@ font_scale         = 1.0            # text-only scale multiplier across widgets
 shadow             = true
 auto_hide          = false
 # smart_auto_hide    = false       # show when the active workspace is empty; hide when it has windows
+# auto_hide_reserve_space = false  # with auto_hide/smart_auto_hide: reserve layout only while the bar is visible
 # show_on_workspace_switch = true   # with auto_hide: briefly reveal when the active workspace changes
 reserve_space      = true
 capsule            = false

--- a/meson.build
+++ b/meson.build
@@ -1143,6 +1143,7 @@ if build_tests
     'app_identity',
     'audio_glyphs',
     'audio_route_selection',
+    'bar_exclusive_zone',
     'battery_health',
     'battery_hook_state',
     'button_layout',

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -141,6 +141,8 @@ namespace config_export {
         resolved.autoHide = *ovr.autoHide;
       if (ovr.smartAutoHide)
         resolved.smartAutoHide = *ovr.smartAutoHide;
+      if (ovr.autoHideReserveSpace)
+        resolved.autoHideReserveSpace = *ovr.autoHideReserveSpace;
       if (ovr.showOnWorkspaceSwitch)
         resolved.showOnWorkspaceSwitch = *ovr.showOnWorkspaceSwitch;
       if (ovr.reserveSpace)

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -175,6 +175,9 @@ namespace {
     if (ovr.smartAutoHide) {
       resolved.smartAutoHide = *ovr.smartAutoHide;
     }
+    if (ovr.autoHideReserveSpace) {
+      resolved.autoHideReserveSpace = *ovr.autoHideReserveSpace;
+    }
     if (ovr.showOnWorkspaceSwitch) {
       resolved.showOnWorkspaceSwitch = *ovr.showOnWorkspaceSwitch;
     }

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -937,6 +937,8 @@ BarConfig ConfigService::resolveForOutput(const BarConfig& base, const WaylandOu
       resolved.autoHide = *ovr.autoHide;
     if (ovr.smartAutoHide)
       resolved.smartAutoHide = *ovr.smartAutoHide;
+    if (ovr.autoHideReserveSpace)
+      resolved.autoHideReserveSpace = *ovr.autoHideReserveSpace;
     if (ovr.showOnWorkspaceSwitch)
       resolved.showOnWorkspaceSwitch = *ovr.showOnWorkspaceSwitch;
     if (ovr.reserveSpace)

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -67,6 +67,7 @@ struct BarMonitorOverride {
   std::optional<bool> enabled;
   std::optional<bool> autoHide;
   std::optional<bool> smartAutoHide;
+  std::optional<bool> autoHideReserveSpace;
   std::optional<bool> showOnWorkspaceSwitch;
   std::optional<bool> reserveSpace;
   std::optional<std::string> layer; // top | overlay
@@ -133,6 +134,7 @@ struct BarConfig {
   bool enabled = true;
   bool autoHide = false;             // slide out when the pointer leaves; reveal on edge approach
   bool smartAutoHide = false;        // hide while the active workspace has windows; show when it is empty
+  bool autoHideReserveSpace = false; // with auto_hide/smart_auto_hide: reserve layout only while the bar is visible
   bool showOnWorkspaceSwitch = true; // with auto_hide: briefly reveal when the active workspace changes
 
   [[nodiscard]] constexpr bool isAutoHideEnabled() const noexcept { return autoHide || smartAutoHide; }

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -2213,6 +2213,7 @@ namespace noctalia::config::schema {
         field(&BarConfig::smartAutoHide, "smart_auto_hide"),
         field(&BarConfig::showOnWorkspaceSwitch, "show_on_workspace_switch"),
         field(&BarConfig::reserveSpace, "reserve_space"),
+        field(&BarConfig::autoHideReserveSpace, "auto_hide_reserve_space"),
         barLayerField(),
         field(&BarConfig::thickness, "thickness", kBarThicknessRange),
         field(&BarConfig::backgroundOpacity, "background_opacity", kBarOpacityRange),
@@ -2269,6 +2270,7 @@ namespace noctalia::config::schema {
         optionalBoolField(&BarMonitorOverride::smartAutoHide, "smart_auto_hide"),
         optionalBoolField(&BarMonitorOverride::showOnWorkspaceSwitch, "show_on_workspace_switch"),
         optionalBoolField(&BarMonitorOverride::reserveSpace, "reserve_space"),
+        optionalBoolField(&BarMonitorOverride::autoHideReserveSpace, "auto_hide_reserve_space"),
         // layer accepts top|overlay; anything else warns and leaves it unset.
         custom<BarMonitorOverride>(
             "layer",

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1967,10 +1967,9 @@ bool Bar::barContentVisuallyShown(const BarInstance& instance) const noexcept {
 }
 
 bool Bar::shouldReserveExclusiveZone(const BarInstance& instance) const noexcept {
-  if (instance.ipcLayoutReleased) {
-    return false;
-  }
-  return instance.barConfig.reserveSpace;
+  return barShouldReserveExclusiveZone(
+      instance.barConfig, instance.ipcLayoutReleased, barContentVisuallyShown(instance)
+  );
 }
 
 void Bar::syncBarExclusiveZone(BarInstance& instance) {

--- a/src/shell/bar/bar_reserved_zone.h
+++ b/src/shell/bar/bar_reserved_zone.h
@@ -73,9 +73,8 @@ reservedBarEdgeDistance(const BarConfig& barConfig, const ShellConfig::ShadowCon
 
 /// Whether the bar should publish a non-zero layer-shell exclusive zone right now.
 /// With auto_hide_reserve_space enabled, reserve_space applies only while the bar is shown.
-[[nodiscard]] inline bool barShouldReserveExclusiveZone(
-    const BarConfig& barConfig, bool ipcLayoutReleased, bool contentVisuallyShown
-) noexcept {
+[[nodiscard]] inline bool
+barShouldReserveExclusiveZone(const BarConfig& barConfig, bool ipcLayoutReleased, bool contentVisuallyShown) noexcept {
   if (ipcLayoutReleased || !barConfig.reserveSpace) {
     return false;
   }

--- a/src/shell/bar/bar_reserved_zone.h
+++ b/src/shell/bar/bar_reserved_zone.h
@@ -70,3 +70,17 @@ barEdgeLayerMargin(const BarConfig& barConfig, const ShellConfig::ShadowConfig& 
 reservedBarEdgeDistance(const BarConfig& barConfig, const ShellConfig::ShadowConfig& shadowConfig) {
   return reservedBarExclusiveZone(barConfig, shadowConfig) + barEdgeLayerMargin(barConfig, shadowConfig);
 }
+
+/// Whether the bar should publish a non-zero layer-shell exclusive zone right now.
+/// With auto_hide_reserve_space enabled, reserve_space applies only while the bar is shown.
+[[nodiscard]] inline bool barShouldReserveExclusiveZone(
+    const BarConfig& barConfig, bool ipcLayoutReleased, bool contentVisuallyShown
+) noexcept {
+  if (ipcLayoutReleased || !barConfig.reserveSpace) {
+    return false;
+  }
+  if (barConfig.isAutoHideEnabled() && barConfig.autoHideReserveSpace) {
+    return contentVisuallyShown;
+  }
+  return true;
+}

--- a/src/shell/settings/settings_content_common.cpp
+++ b/src/shell/settings/settings_content_common.cpp
@@ -53,6 +53,9 @@ namespace settings {
     if (key == "smart_auto_hide") {
       return override->smartAutoHide.has_value();
     }
+    if (key == "auto_hide_reserve_space") {
+      return override->autoHideReserveSpace.has_value();
+    }
     if (key == "show_on_workspace_switch") {
       return override->showOnWorkspaceSwitch.has_value();
     }

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -3016,6 +3016,19 @@ namespace settings {
           tr("settings.schema.bar.reserve-space.description"), path("reserve_space"), ToggleSetting{bar.reserveSpace},
           "exclusive zone"
       ));
+      const SettingVisibility reserveSpaceOn = [barName = bar.name](const Config& c) {
+        const BarConfig* b = findBar(c, barName);
+        return b != nullptr && b->reserveSpace;
+      };
+      {
+        auto e = makeEntry(
+            section, "general", tr("settings.schema.bar.auto-hide-reserve-space.label"),
+            tr("settings.schema.bar.auto-hide-reserve-space.description"), path("auto_hide_reserve_space"),
+            ToggleSetting{bar.autoHideReserveSpace}, "autohide immersive exclusive zone"
+        );
+        e.visibleWhen = reserveSpaceOn;
+        entries.push_back(std::move(e));
+      }
       entries.push_back(makeEntry(
           section, "general", tr("settings.schema.bar.layer.label"), tr("settings.schema.bar.layer.description"),
           path("layer"),
@@ -3339,6 +3352,24 @@ namespace settings {
             tr("settings.schema.bar.reserve-space.description"), monitorPath("reserve_space"),
             ToggleSetting{ovr.reserveSpace.value_or(bar.reserveSpace)}, "exclusive zone"
         ));
+        const SettingVisibility monitorReserveSpaceOn = [barName = bar.name, match = ovr.match](const Config& c) {
+          const BarConfig* b = findBar(c, barName);
+          if (b == nullptr) {
+            return false;
+          }
+          const BarMonitorOverride* o = findMonitorOverride(*b, match);
+          return o != nullptr ? o->reserveSpace.value_or(b->reserveSpace) : b->reserveSpace;
+        };
+        {
+          auto e = makeEntry(
+              section, "general", tr("settings.schema.bar.auto-hide-reserve-space.label"),
+              tr("settings.schema.bar.auto-hide-reserve-space.description"), monitorPath("auto_hide_reserve_space"),
+              ToggleSetting{ovr.autoHideReserveSpace.value_or(bar.autoHideReserveSpace)},
+              "autohide immersive exclusive zone"
+          );
+          e.visibleWhen = monitorReserveSpaceOn;
+          entries.push_back(std::move(e));
+        }
         entries.push_back(makeEntry(
             section, "general", tr("settings.schema.bar.layer.label"), tr("settings.schema.bar.layer.description"),
             monitorPath("layer"),

--- a/tests/bar_exclusive_zone_test.cpp
+++ b/tests/bar_exclusive_zone_test.cpp
@@ -1,0 +1,74 @@
+#include "shell/bar/bar_reserved_zone.h"
+
+#include <iostream>
+
+namespace {
+
+  bool check(bool cond, const char* msg) {
+    if (!cond) {
+      std::cerr << "FAIL: " << msg << '\n';
+    }
+    return cond;
+  }
+
+  BarConfig autoHideBar() {
+    BarConfig cfg;
+    cfg.reserveSpace = true;
+    cfg.autoHide = true;
+    return cfg;
+  }
+
+  BarConfig smartHideBar() {
+    BarConfig cfg;
+    cfg.reserveSpace = true;
+    cfg.smartAutoHide = true;
+    return cfg;
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  BarConfig alwaysOn;
+  alwaysOn.reserveSpace = true;
+  ok &= check(barShouldReserveExclusiveZone(alwaysOn, false, false), "always-on bar reserves even when not shown");
+  ok &= check(barShouldReserveExclusiveZone(alwaysOn, false, true), "always-on bar reserves when shown");
+
+  auto autoHide = autoHideBar();
+  ok &= check(barShouldReserveExclusiveZone(autoHide, false, false), "auto-hide hidden still reserves space by default");
+  ok &= check(barShouldReserveExclusiveZone(autoHide, false, true), "auto-hide shown still reserves space by default");
+  ok &= check(!barShouldReserveExclusiveZone(autoHide, true, true), "ipc hide releases reserve space");
+
+  autoHide.autoHideReserveSpace = true;
+  ok &= check(
+      !barShouldReserveExclusiveZone(autoHide, false, false),
+      "auto-hide with reserve-while-visible releases space when hidden"
+  );
+  ok &= check(
+      barShouldReserveExclusiveZone(autoHide, false, true),
+      "auto-hide with reserve-while-visible reserves space when shown"
+  );
+
+  auto smartHide = smartHideBar();
+  ok &= check(
+      barShouldReserveExclusiveZone(smartHide, false, false), "smart auto-hide hidden keeps static reserve by default"
+  );
+  ok &= check(barShouldReserveExclusiveZone(smartHide, false, true), "smart auto-hide shown reserves space by default");
+
+  smartHide.autoHideReserveSpace = true;
+  ok &= check(
+      !barShouldReserveExclusiveZone(smartHide, false, false),
+      "smart auto-hide with reserve-while-visible releases space when hidden"
+  );
+  ok &= check(
+      barShouldReserveExclusiveZone(smartHide, false, true),
+      "smart auto-hide with reserve-while-visible reserves space when shown"
+  );
+
+  BarConfig noReserve = smartHideBar();
+  noReserve.reserveSpace = false;
+  ok &= check(!barShouldReserveExclusiveZone(noReserve, false, true), "reserve_space off never reserves");
+
+  return ok ? 0 : 1;
+}

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -199,6 +199,7 @@ location = "https://example.invalid/bad"
     bar.enabled = false;
     bar.autoHide = true;
     bar.smartAutoHide = false;
+    bar.autoHideReserveSpace = false;
     bar.showOnWorkspaceSwitch = true;
     bar.reserveSpace = false;
     bar.layer = "overlay";
@@ -270,6 +271,7 @@ location = "https://example.invalid/bad"
     ovr.enabled = true;
     ovr.autoHide = false;
     ovr.smartAutoHide = false;
+    ovr.autoHideReserveSpace = false;
     ovr.showOnWorkspaceSwitch = true;
     ovr.reserveSpace = true;
     ovr.layer = "top";
@@ -986,6 +988,7 @@ int main() {
 
 [default]
 auto_hide = true
+auto_hide_reserve_space = false
 background_opacity = 0.85000002384185791
 border = "#123456"
 border_width = 2.0
@@ -1044,6 +1047,7 @@ widget_spacing = 8
 
     [default.monitor.DP-1]
     auto_hide = false
+    auto_hide_reserve_space = false
     background_opacity = 0.69999998807907104
     border = "#A1A2A3"
     border_width = 3.0


### PR DESCRIPTION
## Summary

- Add opt-in `auto_hide_reserve_space` bar setting (disabled by default) that releases the compositor exclusive zone while the bar is hidden and restores it when shown
- Applies with `auto_hide` or `smart_auto_hide` when `reserve_space = true`, giving full-screen layout when the bar is away and normal reserved layout when it appears
- Expose **Reserve Space While Visible** in bar settings below **Reserve Space**, shown only when layout reservation is enabled (including per-monitor overrides)
- Add unit tests for static vs dynamic exclusive-zone decisions

**Credit:** Idea from [this Discord message](https://discord.com/channels/1401598189823590460/1488281777041575946/1537825469985062932) in the Noctalia community server:

> So when the bar is hidden the whole screen is occupied, but when the bar drops down, either via autohide-off, smart, or on, the bar gets the reserve space again, and when the bar collapses, it removes the reserve space it should take — this would provide good immersion.

## Test plan

- [x] `bar_exclusive_zone_test` and `config_schema_roundtrip_test` pass
- [x] Manual test on KineticWE: `reserve_space = true`, `smart_auto_hide = true`, `auto_hide_reserve_space = true` — windows use full screen when bar hidden, layout shifts when bar appears
- [x] Verified default off: without `auto_hide_reserve_space`, behavior unchanged (static reserve)

[Screencast_20260828_211211.webm](https://github.com/user-attachments/assets/b6e15b9e-4d92-454f-b3cb-a325dfdb84f5)


Made with [Cursor](https://cursor.com)