### PR TITLE
fix(tooltip): hide bar tooltips while a widget's panel is open

### DIFF
--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -680,7 +680,6 @@ void Application::initPanelManagerAndPanels() {
   });
   m_panelManager.setPanelClosedCallback([this]() {
     m_overviewLauncherCapture.sync();
-    TooltipManager::instance().setSuppressedArea(nullptr);
     m_bar.rearmTooltipForHoveredWidget();
     m_bar.reevaluateAutoHide();
     // Widgets that stay visible while their panel is open re-evaluate on the next update.

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -680,6 +680,8 @@ void Application::initPanelManagerAndPanels() {
   });
   m_panelManager.setPanelClosedCallback([this]() {
     m_overviewLauncherCapture.sync();
+    TooltipManager::instance().setSuppressedArea(nullptr);
+    m_bar.rearmTooltipForHoveredWidget();
     m_bar.reevaluateAutoHide();
     // Widgets that stay visible while their panel is open re-evaluate on the next update.
     m_bar.refresh();

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -297,14 +297,9 @@ namespace {
         || pointInsideNode(instance.sceneRoot.get(), sceneX, sceneY);
   }
 
-  // A widget whose panel will not show a tooltip: the pointer stays
-  // on the widget, so no hover-leave arrives, and bar surfaces remain whitelisted
-  // in the panel's focus grab. Held until the panel closes, so hovering away and
-  // back cannot raise a tooltip over the open panel either.
-  void suppressTooltipForOpenPanel(BarInstance& instance) {
-    if (auto* hovered = instance.inputDispatcher.hoveredArea(); hovered != nullptr) {
-      TooltipManager::instance().setSuppressedArea(hovered);
-    }
+  // Bar tooltips stay suppressed while any panel opened from the bar is alive.
+  void suppressTooltipForOpenPanel(std::string_view panelId) {
+    TooltipManager::instance().suppressBarTooltipsForPanel(panelId);
   }
 
   // The dead zone has no widget to anchor to, so a panel action anchors at the pointer instead.
@@ -1837,7 +1832,7 @@ void Bar::rearmTooltipForHoveredWidget() {
   }
   // Same path a real hover takes, so the usual show delay still applies — the
   // tooltip must not blink into existence the instant the panel disappears.
-  TooltipManager::instance().onHoverChange(
+  TooltipManager::instance().onBarHoverChange(
       hovered, m_hoveredInstance->surface->layerSurface(), m_hoveredInstance->output
   );
 }
@@ -2670,7 +2665,7 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
           PanelManager::instance().togglePanel(std::string(panelId), request);
         }
         if (PanelManager::instance().isOpenPanel(panelId)) {
-          suppressTooltipForOpenPanel(*inst);
+          suppressTooltipForOpenPanel(panelId);
         }
       });
       if (auto* tray = dynamic_cast<TrayWidget*>(widget.get())) {
@@ -3337,7 +3332,7 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
       if (next != nullptr) {
         next->setTooltipPlacement(tooltipPlacementAwayFromEdge(inst->barConfig.position));
       }
-      TooltipManager::instance().onHoverChange(next, inst->surface->layerSurface(), inst->output);
+      TooltipManager::instance().onBarHoverChange(next, inst->surface->layerSurface(), inst->output);
       updateWidgetHoverHighlight(*inst, next);
       updateAccordionExpansion(*inst, next);
     });

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -297,6 +297,16 @@ namespace {
         || pointInsideNode(instance.sceneRoot.get(), sceneX, sceneY);
   }
 
+  // A widget whose panel will not show a tooltip: the pointer stays
+  // on the widget, so no hover-leave arrives, and bar surfaces remain whitelisted
+  // in the panel's focus grab. Held until the panel closes, so hovering away and
+  // back cannot raise a tooltip over the open panel either.
+  void suppressTooltipForOpenPanel(BarInstance& instance) {
+    if (auto* hovered = instance.inputDispatcher.hoveredArea(); hovered != nullptr) {
+      TooltipManager::instance().setSuppressedArea(hovered);
+    }
+  }
+
   // The dead zone has no widget to anchor to, so a panel action anchors at the pointer instead.
   void openPanelAtBarPointer(
       BarInstance& instance, float sx, float sy, CompositorPlatform* platform, std::string_view sourceBarName,
@@ -1817,6 +1827,21 @@ void Bar::reevaluateAutoHide() {
   }
 }
 
+void Bar::rearmTooltipForHoveredWidget() {
+  if (m_hoveredInstance == nullptr || !m_hoveredInstance->pointerInside) {
+    return;
+  }
+  auto* hovered = m_hoveredInstance->inputDispatcher.hoveredArea();
+  if (hovered == nullptr || m_hoveredInstance->surface == nullptr) {
+    return;
+  }
+  // Same path a real hover takes, so the usual show delay still applies — the
+  // tooltip must not blink into existence the instant the panel disappears.
+  TooltipManager::instance().onHoverChange(
+      hovered, m_hoveredInstance->surface->layerSurface(), m_hoveredInstance->output
+  );
+}
+
 void Bar::reevaluateAutoHideAfterPopup() {
   for (const auto& instance : m_instances) {
     if (instance == nullptr || instance->surface == nullptr) {
@@ -2643,6 +2668,9 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
           PanelManager::instance().openPanel(std::string(panelId), request);
         } else {
           PanelManager::instance().togglePanel(std::string(panelId), request);
+        }
+        if (PanelManager::instance().isOpenPanel(panelId)) {
+          suppressTooltipForOpenPanel(*inst);
         }
       });
       if (auto* tray = dynamic_cast<TrayWidget*>(widget.get())) {

--- a/src/shell/bar/bar.h
+++ b/src/shell/bar/bar.h
@@ -75,6 +75,10 @@ public:
   void setAutoHideSuppressionCallback(std::function<bool(const BarInstance&)> callback);
   // Re-run auto-hide after a panel closes so unrelated bars are not left visible.
   void reevaluateAutoHide();
+  // A panel closed without the pointer moving (key press, etc.). Hover state is
+  // unchanged, so no hover event will re-arm the tooltip for the widget the pointer
+  // is still sitting on — do it here. No-op when the pointer is not on a bar.
+  void rearmTooltipForHoveredWidget();
   // Grabbed popups often swallow Leave; resync pointerInside from the compositor
   // then re-run auto-hide (tray menus, same pattern as dock context menus).
   void reevaluateAutoHideAfterPopup();

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -363,6 +363,7 @@ namespace {
 PanelManager::PanelManager() { s_instance = this; }
 
 PanelManager::~PanelManager() {
+  m_persistentHost.setPanelClosedCallback(nullptr);
   if (s_instance == this) {
     s_instance = nullptr;
   }
@@ -462,6 +463,11 @@ void PanelManager::setFocusGrabBarSurfacesProvider(std::function<std::vector<wl_
 
 void PanelManager::setPanelClosedCallback(std::function<void()> callback) {
   m_panelClosedCallback = std::move(callback);
+  m_persistentHost.setPanelClosedCallback([this]() {
+    if (m_panelClosedCallback) {
+      m_panelClosedCallback();
+    }
+  });
 }
 
 void PanelManager::setPanelOpenedCallback(std::function<void()> callback) {
@@ -1382,6 +1388,7 @@ void PanelManager::destroyPanel() {
   m_inputDispatcher.setSceneRoot(nullptr);
   // Hover leave only fades tooltips asynchronously. Destroy them (and any
   // open context menu) before the layer surface — xdg_popup must die first.
+  TooltipManager::instance().restoreBarTooltipsForPanel(m_activePanelId);
   TooltipManager::instance().forceDestroy();
   if (m_activePopup != nullptr) {
     m_activePopup->close();

--- a/src/shell/panel/persistent_panel_host.cpp
+++ b/src/shell/panel/persistent_panel_host.cpp
@@ -31,7 +31,10 @@ namespace {
 
 PersistentPanelHost::PersistentPanelHost() = default;
 
-PersistentPanelHost::~PersistentPanelHost() { closeAll(); }
+PersistentPanelHost::~PersistentPanelHost() {
+  m_panelClosedCallback = nullptr;
+  closeAll();
+}
 
 void PersistentPanelHost::initialize(
     CompositorPlatform& platform, ConfigService* config, RenderContext* renderContext
@@ -43,6 +46,10 @@ void PersistentPanelHost::initialize(
 
 void PersistentPanelHost::registerPanel(const std::string& id, std::unique_ptr<Panel> content) {
   m_panels[id] = std::move(content);
+}
+
+void PersistentPanelHost::setPanelClosedCallback(std::function<void()> callback) {
+  m_panelClosedCallback = std::move(callback);
 }
 
 void PersistentPanelHost::unregisterPanel(const std::string& id) {
@@ -280,6 +287,7 @@ void PersistentPanelHost::destroyInstance(std::vector<std::unique_ptr<Instance>>
 
   instance->animations.cancelAll();
   instance->inputDispatcher.setSceneRoot(nullptr);
+  TooltipManager::instance().restoreBarTooltipsForPanel(instance->id);
   // Tooltips are xdg_popups parented to this surface; they must die before it.
   TooltipManager::instance().forceDestroy();
   if (instance->panel != nullptr) {
@@ -294,6 +302,9 @@ void PersistentPanelHost::destroyInstance(std::vector<std::unique_ptr<Instance>>
     m_platform->stopKeyRepeat();
   }
   kLog.debug("closed \"{}\"", instance->id);
+  if (m_panelClosedCallback) {
+    m_panelClosedCallback();
+  }
 }
 
 void PersistentPanelHost::toggle(const std::string& id, wl_output* output, std::string_view context) {

--- a/src/shell/panel/persistent_panel_host.h
+++ b/src/shell/panel/persistent_panel_host.h
@@ -6,6 +6,7 @@
 #include "wayland/layer_surface.h"
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -63,6 +64,7 @@ public:
   void onConfigReloaded();
   void onIconThemeChanged();
   void refresh();
+  void setPanelClosedCallback(std::function<void()> callback);
 
 private:
   struct Instance {
@@ -101,4 +103,5 @@ private:
   RenderContext* m_renderContext = nullptr;
   std::unordered_map<std::string, std::unique_ptr<Panel>> m_panels;
   std::vector<std::unique_ptr<Instance>> m_instances;
+  std::function<void()> m_panelClosedCallback;
 };

--- a/src/shell/tooltip/tooltip_manager.cpp
+++ b/src/shell/tooltip/tooltip_manager.cpp
@@ -201,6 +201,7 @@ void TooltipManager::forceDestroy() {
   m_showTimer.stop();
   m_refreshTimer.stop();
   m_pendingArea = nullptr;
+  m_suppressedArea = nullptr;
   m_pendingContent = {};
   m_pendingLayerParent = nullptr;
   m_pendingXdgParent = nullptr;
@@ -224,7 +225,11 @@ void TooltipManager::shutdown() {
 }
 
 void TooltipManager::onHoverChange(InputArea* area, zwlr_layer_surface_v1* parentLayerSurface, wl_output* output) {
-  if (area != nullptr && area->hasTooltip() && parentLayerSurface != nullptr && output != nullptr) {
+  if (area != nullptr
+      && area != m_suppressedArea
+      && area->hasTooltip()
+      && parentLayerSurface != nullptr
+      && output != nullptr) {
     m_pendingContent = area->tooltipContent();
     m_pendingLayerParent = parentLayerSurface;
     m_pendingXdgParent = nullptr;
@@ -237,7 +242,11 @@ void TooltipManager::onHoverChange(InputArea* area, zwlr_layer_surface_v1* paren
 }
 
 void TooltipManager::onHoverChange(InputArea* area, xdg_surface* parentXdgSurface, wl_output* output) {
-  if (area != nullptr && area->hasTooltip() && parentXdgSurface != nullptr && output != nullptr) {
+  if (area != nullptr
+      && area != m_suppressedArea
+      && area->hasTooltip()
+      && parentXdgSurface != nullptr
+      && output != nullptr) {
     m_pendingContent = area->tooltipContent();
     m_pendingLayerParent = nullptr;
     m_pendingXdgParent = parentXdgSurface;
@@ -247,6 +256,17 @@ void TooltipManager::onHoverChange(InputArea* area, xdg_surface* parentXdgSurfac
   }
 
   dismissPopup();
+}
+
+void TooltipManager::setSuppressedArea(InputArea* area) {
+  m_suppressedArea = area;
+  if (area == nullptr) {
+    return;
+  }
+  // Dismiss anything already showing (or drop a pending show) for the area.
+  if (m_pendingArea == area || m_state != State::Idle) {
+    dismissPopup();
+  }
 }
 
 void TooltipManager::handleHoverChange(InputArea* area) {
@@ -518,7 +538,7 @@ void TooltipManager::destroyPopup() {
 }
 
 void TooltipManager::refreshFromArea(InputArea* area) {
-  if (area == nullptr || area != m_pendingArea || !area->hovered()) {
+  if (area == nullptr || area != m_pendingArea || !area->hovered() || area == m_suppressedArea) {
     return;
   }
 

--- a/src/shell/tooltip/tooltip_manager.cpp
+++ b/src/shell/tooltip/tooltip_manager.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <string>
 
 namespace {
 
@@ -201,7 +202,6 @@ void TooltipManager::forceDestroy() {
   m_showTimer.stop();
   m_refreshTimer.stop();
   m_pendingArea = nullptr;
-  m_suppressedArea = nullptr;
   m_pendingContent = {};
   m_pendingLayerParent = nullptr;
   m_pendingXdgParent = nullptr;
@@ -219,17 +219,14 @@ void TooltipManager::forceDestroy() {
 
 void TooltipManager::shutdown() {
   forceDestroy();
+  m_suppressedBarTooltipPanels.clear();
   m_wayland = nullptr;
   m_config = nullptr;
   m_renderContext = nullptr;
 }
 
 void TooltipManager::onHoverChange(InputArea* area, zwlr_layer_surface_v1* parentLayerSurface, wl_output* output) {
-  if (area != nullptr
-      && area != m_suppressedArea
-      && area->hasTooltip()
-      && parentLayerSurface != nullptr
-      && output != nullptr) {
+  if (area != nullptr && area->hasTooltip() && parentLayerSurface != nullptr && output != nullptr) {
     m_pendingContent = area->tooltipContent();
     m_pendingLayerParent = parentLayerSurface;
     m_pendingXdgParent = nullptr;
@@ -242,11 +239,7 @@ void TooltipManager::onHoverChange(InputArea* area, zwlr_layer_surface_v1* paren
 }
 
 void TooltipManager::onHoverChange(InputArea* area, xdg_surface* parentXdgSurface, wl_output* output) {
-  if (area != nullptr
-      && area != m_suppressedArea
-      && area->hasTooltip()
-      && parentXdgSurface != nullptr
-      && output != nullptr) {
+  if (area != nullptr && area->hasTooltip() && parentXdgSurface != nullptr && output != nullptr) {
     m_pendingContent = area->tooltipContent();
     m_pendingLayerParent = nullptr;
     m_pendingXdgParent = parentXdgSurface;
@@ -258,15 +251,23 @@ void TooltipManager::onHoverChange(InputArea* area, xdg_surface* parentXdgSurfac
   dismissPopup();
 }
 
-void TooltipManager::setSuppressedArea(InputArea* area) {
-  m_suppressedArea = area;
-  if (area == nullptr) {
+void TooltipManager::onBarHoverChange(InputArea* area, zwlr_layer_surface_v1* parentLayerSurface, wl_output* output) {
+  if (!m_suppressedBarTooltipPanels.empty()) {
+    dismissPopup();
     return;
   }
-  // Dismiss anything already showing (or drop a pending show) for the area.
-  if (m_pendingArea == area || m_state != State::Idle) {
-    dismissPopup();
+  onHoverChange(area, parentLayerSurface, output);
+}
+
+void TooltipManager::suppressBarTooltipsForPanel(std::string_view panelId) {
+  if (panelId.empty() || !m_suppressedBarTooltipPanels.emplace(panelId).second) {
+    return;
   }
+  dismissPopup();
+}
+
+void TooltipManager::restoreBarTooltipsForPanel(std::string_view panelId) {
+  m_suppressedBarTooltipPanels.erase(std::string(panelId));
 }
 
 void TooltipManager::handleHoverChange(InputArea* area) {
@@ -538,7 +539,7 @@ void TooltipManager::destroyPopup() {
 }
 
 void TooltipManager::refreshFromArea(InputArea* area) {
-  if (area == nullptr || area != m_pendingArea || !area->hovered() || area == m_suppressedArea) {
+  if (area == nullptr || area != m_pendingArea || !area->hovered()) {
     return;
   }
 

--- a/src/shell/tooltip/tooltip_manager.h
+++ b/src/shell/tooltip/tooltip_manager.h
@@ -32,6 +32,13 @@ public:
   void onHoverChange(InputArea* area, xdg_surface* parentXdgSurface, wl_output* output);
   void syncAnchor(InputArea* area);
 
+  // Suppress the tooltip for one area for as long as its own panel is open, and
+  // fade out any tooltip already up for it. The suppression deliberately outlives
+  // hovering away and back: the widget stays "active" the whole time its panel is
+  // open, so a return visit must not raise a tooltip over the panel. Only the
+  // matching setSuppressedArea(nullptr) on panel close (or forceDestroy) lifts it.
+  void setSuppressedArea(InputArea* area);
+
 private:
   TooltipManager() = default;
 
@@ -70,6 +77,8 @@ private:
   bool m_showAfterDestroy = false;
   Timer m_showTimer;
   Timer m_refreshTimer;
+
+  InputArea* m_suppressedArea = nullptr;
 
   TooltipContent m_pendingContent;
   zwlr_layer_surface_v1* m_pendingLayerParent = nullptr;

--- a/src/shell/tooltip/tooltip_manager.h
+++ b/src/shell/tooltip/tooltip_manager.h
@@ -6,6 +6,9 @@
 #include "ui/signal.h"
 
 #include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_set>
 
 class InputArea;
 class Node;
@@ -30,14 +33,11 @@ public:
 
   void onHoverChange(InputArea* area, zwlr_layer_surface_v1* parentLayerSurface, wl_output* output);
   void onHoverChange(InputArea* area, xdg_surface* parentXdgSurface, wl_output* output);
+  void onBarHoverChange(InputArea* area, zwlr_layer_surface_v1* parentLayerSurface, wl_output* output);
   void syncAnchor(InputArea* area);
 
-  // Suppress the tooltip for one area for as long as its own panel is open, and
-  // fade out any tooltip already up for it. The suppression deliberately outlives
-  // hovering away and back: the widget stays "active" the whole time its panel is
-  // open, so a return visit must not raise a tooltip over the panel. Only the
-  // matching setSuppressedArea(nullptr) on panel close (or forceDestroy) lifts it.
-  void setSuppressedArea(InputArea* area);
+  void suppressBarTooltipsForPanel(std::string_view panelId);
+  void restoreBarTooltipsForPanel(std::string_view panelId);
 
 private:
   TooltipManager() = default;
@@ -78,7 +78,7 @@ private:
   Timer m_showTimer;
   Timer m_refreshTimer;
 
-  InputArea* m_suppressedArea = nullptr;
+  std::unordered_set<std::string> m_suppressedBarTooltipPanels;
 
   TooltipContent m_pendingContent;
   zwlr_layer_surface_v1* m_pendingLayerParent = nullptr;


### PR DESCRIPTION
## Summary
Clicking a bar widget opened its panel underneath the tooltip, which then covered most of the panel. The pointer never leaves the widget, so no hover-leave arrives to take the tooltip down, and bar surfaces stay whitelisted in the panel's focus grab — hover, or the widget's next content tick, would just raise it again.

Suppress the tooltip for the widget that owns the open panel, held for the panel's whole lifetime so hovering away and back cannot raise one over it either. All three revival routes check it: both onHoverChange overloads and refreshFromArea, which content providers reach directly on each tick. Lifted from the panel-closed callback, which every close path funnels through; persistent panels self-heal via forceDestroy.

Suppression is applied after the open call, since opening a panel tears down whichever one was already open and that close path clears it.

Dismissal fades via dismissPopup instead of forceDestroy. Teardown paths keep forceDestroy — the popup must not outlive its parent surface.

Closing a panel by keyboard moves no pointer, so no hover event follows to re-arm the tooltip for the widget still under the cursor; the bar re-arms it from live hover state, no-op when the pointer is not on a bar.

## Type of Change

- [x] Bug fix

## Related Issue

Closes https://github.com/noctalia-dev/noctalia/issues/3817

## Testing
Ok:                93  
Fail:              0

- [x] Tested on Niri
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos
Before:
<video src="https://github.com/user-attachments/assets/79de98f2-b8b9-4ebe-9ad7-f57d348ed530" controls width="100%">
</video>
After:
<video src="https://github.com/user-attachments/assets/7f6c3d27-1f3d-479c-af81-44e149fc1d71" controls width="100%">
</video>