### PR TITLE
fix(osd): show brightness pill for wildcard IPC changes

### DIFF
--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -93,7 +93,6 @@
 #include "util/string_utils.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <csignal>
 #include <cstdint>
@@ -567,9 +566,7 @@ void Application::initIpc() {
   m_osdOverlay.registerIpc(m_ipcService);
 
   if (m_brightnessService != nullptr) {
-    m_brightnessService->registerIpc(m_ipcService, [this]() {
-      m_brightnessOsd.suppressFor(std::chrono::milliseconds(250));
-    });
+    m_brightnessService->registerIpc(m_ipcService);
   }
   if (m_keyboardBacklightService != nullptr) {
     m_keyboardBacklightService->registerIpc(m_ipcService);

--- a/src/shell/osd/brightness_osd.cpp
+++ b/src/shell/osd/brightness_osd.cpp
@@ -43,13 +43,8 @@ void BrightnessOsd::primeFromService(const BrightnessService& service) {
   }
 }
 
-void BrightnessOsd::suppressFor(std::chrono::milliseconds duration) {
-  m_suppressUntil = std::chrono::steady_clock::now() + duration;
-}
-
 void BrightnessOsd::onBrightnessChanged(const BrightnessService& service) {
   const auto& displays = service.displays();
-  const auto now = std::chrono::steady_clock::now();
 
   // Find the display whose brightness actually changed
   const BrightnessDisplay* changed = nullptr;
@@ -78,7 +73,7 @@ void BrightnessOsd::onBrightnessChanged(const BrightnessService& service) {
     }
   }
 
-  if (changed == nullptr || now < m_suppressUntil) {
+  if (changed == nullptr) {
     return;
   }
 

--- a/src/shell/osd/brightness_osd.h
+++ b/src/shell/osd/brightness_osd.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <string>
 #include <vector>
 
@@ -11,7 +10,6 @@ class BrightnessOsd {
 public:
   void bindOverlay(OsdOverlay& overlay);
   void primeFromService(const BrightnessService& service);
-  void suppressFor(std::chrono::milliseconds duration);
   void onBrightnessChanged(const BrightnessService& service);
   void showValue(float brightness);
 
@@ -23,5 +21,4 @@ private:
 
   OsdOverlay* m_overlay = nullptr;
   std::vector<DisplaySnapshot> m_snapshots;
-  std::chrono::steady_clock::time_point m_suppressUntil;
 };

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -1532,7 +1532,7 @@ void BrightnessService::reload(const BrightnessConfig& config) { m_impl->reload(
 
 void BrightnessService::onOutputsChanged() { m_impl->onOutputsChanged(); }
 
-void BrightnessService::registerIpc(IpcService& ipc, std::function<void()> onBatchChange) {
+void BrightnessService::registerIpc(IpcService& ipc) {
   auto resolveTargets = [this,
                          &ipc](std::string_view token, std::vector<std::string>& ids, std::string& error) -> bool {
     if (!available()) {
@@ -1613,15 +1613,11 @@ void BrightnessService::registerIpc(IpcService& ipc, std::function<void()> onBat
     return false;
   };
 
-  auto applyToTargets = [this, resolveTargets, onBatchChange](const std::string& target, auto&& apply) -> std::string {
+  auto applyToTargets = [this, resolveTargets](const std::string& target, auto&& apply) -> std::string {
     std::vector<std::string> ids;
     std::string error;
     if (!resolveTargets(target, ids, error)) {
       return error;
-    }
-
-    if (ids.size() > 1 && onBatchChange) {
-      onBatchChange();
     }
 
     for (const auto& id : ids) {

--- a/src/system/brightness_service.h
+++ b/src/system/brightness_service.h
@@ -45,7 +45,7 @@ public:
   void requestDdcRefresh();
   void reload(const BrightnessConfig& config);
   void onOutputsChanged();
-  void registerIpc(IpcService& ipc, std::function<void()> onBatchChange = {});
+  void registerIpc(IpcService& ipc);
 
   void setChangeCallback(ChangeCallback callback);
 


### PR DESCRIPTION
## Summary

Removes the 250 ms brightness OSD suppression that fired on every multi-target IPC command. All resulting brightness change callbacks land within that window, so commands like `noctalia msg brightness-up '*' 0.1` produced no visual feedback at all. With the suppression gone, the existing shared `OsdOverlay` coalesces the per-display `show()` calls into one normal pill.

Also drops the now-unused `onBatchChange` parameter from `BrightnessService::registerIpc`, the `BrightnessOsd::suppressFor` API, and the `<chrono>` includes they required.

## Motivation

Brightness changes made over IPC showed no OSD pill, unlike volume changes (issue #4149). The suppression was presumably meant to prevent multiple pill flashes during batch changes, but the overlay already handles repeated shows by updating the pill in place, so the mechanism only ever swallowed the feedback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4149

## Testing

- `just build` (debug): clean.
- `just test`: 93/93 pass.
- `clang-format --dry-run --Werror` (v22.1.8) on all changed files: clean.
- Manual: on Hyprland with two external DDC monitors (AOC CU34G2XP on DP-2, MSI G241 on HDMI-A-2), ran `noctalia msg brightness-down '*' 0.1` and `brightness-up '*' 0.1` against the patched build. The OSD pill now appears (verified via screenshots on both outputs); before the fix these commands gave no feedback. Both displays' brightness changed correctly and DDC readback confirmed the final values.
- Grep confirms no remaining references to `suppressFor`, `onBatchChange`, or `m_suppressUntil` in the brightness path (the audio OSD's separate suppression is untouched).

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

If maintainers prefer a distinct presentation for batch changes (e.g. an aggregate pill) rather than showing the last-changed display's value, that can layer on top — but the single-pill behavior matches what the volume OSD does today.
