### PR TITLE
feat(media): add playback controls to desktop media widget

### DIFF
--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -8,6 +8,7 @@
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "ui/builders.h"
+#include "ui/controls/button.h"
 #include "ui/palette.h"
 #include "ui/style.h"
 
@@ -90,8 +91,45 @@ void MediaWidget::create() {
       })
   );
 
+  area->addChild(
+      ui::button({
+          .out = &m_previousButton,
+          .glyph = "media-prev",
+          .variant = ButtonVariant::Ghost,
+          .onClick = [this]() {
+            if (m_mpris != nullptr)
+              m_mpris->previousActive();
+          },
+      })
+  );
+
+  area->addChild(
+      ui::button({
+          .out = &m_playPauseButton,
+          .glyph = "media-play",
+          .variant = ButtonVariant::Ghost,
+          .onClick = [this]() {
+            if (m_mpris != nullptr)
+              m_mpris->playPauseActive();
+          },
+      })
+  );
+
+  area->addChild(
+      ui::button({
+          .out = &m_nextButton,
+          .glyph = "media-next",
+          .variant = ButtonVariant::Ghost,
+          .onClick = [this]() {
+            if (m_mpris != nullptr)
+              m_mpris->nextActive();
+          },
+      })
+  );
+
   setRoot(std::move(area));
 }
+
 
 void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
@@ -190,6 +228,35 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
                                          : (showArtSlot ? artSize : (showEmptyGlyph ? m_emptyGlyph->width() : 0.0F));
     rootNode->setSize(std::clamp(contentWidth, minLength, maxLength), contentHeight);
   }
+  // Media controls follow the artwork and stay aligned on the bar.
+  const float controlsGap = Style::spaceXs * m_contentScale;
+  const float buttonSize = Style::baseGlyphSize * 1.8F * m_contentScale;
+  const float contentEnd = showLabel
+      ? m_label->x() + m_label->width()
+      : (showArtSlot ? artSize : (showEmptyGlyph ? m_emptyGlyph->width() : 0.0F));
+
+  const float controlsX = contentEnd > 0.0F
+      ? contentEnd + controlsGap
+      : 0.0F;
+  const float controlsY = std::round((contentHeight - buttonSize) * 0.5F);
+
+  if (!artOnly) {
+    const float requiredWidth = controlsX + buttonSize * 3.0F;
+    rootNode->setSize(
+        std::max(rootNode->width(), requiredWidth),
+        rootNode->height()
+    );
+  }
+
+  m_previousButton->setSize(buttonSize, buttonSize);
+  m_previousButton->setPosition(controlsX, controlsY);
+
+  m_playPauseButton->setSize(buttonSize, buttonSize);
+  m_playPauseButton->setPosition(controlsX + buttonSize, controlsY);
+
+  m_nextButton->setSize(buttonSize, buttonSize);
+  m_nextButton->setPosition(controlsX + buttonSize * 2.0F, controlsY);
+
   m_progressBar->setVisible(showProgressFill);
   if (showProgressFill) {
     const float fillWidth = rootNode->width();
@@ -305,6 +372,9 @@ void MediaWidget::syncState(Renderer& renderer, const std::optional<MprisPlayerI
 
   if (playbackChanged && !textChanged && !artChanged && !artAwaitingDecode) {
     m_lastPlaybackStatus = playbackStatus;
+  m_playPauseButton->setGlyph(
+      m_lastPlaybackStatus == "Playing" ? "media-pause" : "media-play"
+  );
     m_label->setColor(
         m_lastPlaybackStatus == "Playing" ? widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))
                                           : colorSpecFromRole(ColorRole::OnSurfaceVariant)
@@ -316,6 +386,9 @@ void MediaWidget::syncState(Renderer& renderer, const std::optional<MprisPlayerI
   m_lastText = displayText;
   m_lastArtUrl = artUrl;
   m_lastPlaybackStatus = playbackStatus;
+  m_playPauseButton->setGlyph(
+      m_lastPlaybackStatus == "Playing" ? "media-pause" : "media-play"
+  );
 
   if (textChanged) {
     m_label->setText(m_lastText);

--- a/src/shell/bar/widgets/media_widget.h
+++ b/src/shell/bar/widgets/media_widget.h
@@ -17,6 +17,7 @@ class Label;
 class MprisService;
 class Renderer;
 class ProgressBar;
+class Button;
 struct MprisPlayerInfo;
 struct wl_output;
 
@@ -78,6 +79,9 @@ private:
   Glyph* m_emptyGlyph = nullptr;
   Label* m_label = nullptr;
   ProgressBar* m_progressBar = nullptr;
+  Button* m_previousButton = nullptr;
+  Button* m_playPauseButton = nullptr;
+  Button* m_nextButton = nullptr;
 
   std::string m_lastText;
   std::string m_lastArtUrl;

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -928,25 +928,33 @@ void MediaTab::refresh(Renderer& renderer) {
         loaded = true;
       }
 
+      // The foreground artwork changed, so force the blurred background
+      // to be regenerated from the new artwork texture.
+      if (loaded) {
+        m_artworkBlurCache.invalidate();
+      }
+
       // Only lock this URL once we actually have an image.
       // Otherwise keep retrying while metadata/download catches up.
-            if (loaded && m_artworkBackground != nullptr && m_renderContext != nullptr) {
+      if (loaded && m_artworkBackground != nullptr && m_renderContext != nullptr) {
         const auto artworkTexture = m_artwork->textureHandle();
 
         if (artworkTexture.valid()) {
           m_renderContext->backend().makeCurrentNoSurface();
 
-          const std::uint32_t blurWidth = static_cast<std::uint32_t>(artworkTexture.width);
-          const std::uint32_t blurHeight = static_cast<std::uint32_t>(artworkTexture.height);
+          const std::uint32_t blurWidth =
+             std::max(1U, static_cast<std::uint32_t>(artworkTexture.width / 2));
+          const std::uint32_t blurHeight =
+             std::max(1U, static_cast<std::uint32_t>(artworkTexture.height / 2));
 
-         const auto blurredTexture = m_artworkBlurCache.get(
-             m_renderContext->backend(),
-             artworkTexture,
-             blurWidth,
-             blurHeight,
-             8.0F,
-             1
-         );
+          const auto blurredTexture = m_artworkBlurCache.get(
+              m_renderContext->backend(),
+              artworkTexture,
+              blurWidth,
+              blurHeight,
+              8.0F,
+              1
+          );
 
           if (blurredTexture.valid()) {
             m_artworkBackground->setExternalTexture(renderer, blurredTexture);

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -9,13 +9,13 @@
 #include "net/http_client.h"
 #include "pipewire/pipewire_spectrum.h"
 #include "render/core/renderer.h"
+#include "render/render_context.h"
 #include "render/scene/node.h"
 #include "shell/control_center/tab.h"
 #include "shell/panel/panel_manager.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu.h"
 #include "ui/controls/context_menu_popup.h"
-#include "ui/visuals/audio_visualizer.h"
 
 #include <algorithm>
 #include <chrono>
@@ -25,6 +25,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
 
 using namespace control_center;
 using namespace mpris;
@@ -66,7 +67,6 @@ namespace {
   std::string repeatGlyph(const std::string& loopStatus) { return loopStatus == "Track" ? "repeat-once" : "repeat"; }
 
   ButtonVariant toggleVariant(bool active) { return active ? ButtonVariant::Primary : ButtonVariant::Ghost; }
-  constexpr int kVisualizerBandCount = 32;
 
 } // namespace
 
@@ -111,8 +111,7 @@ void MediaTab::openPlayerMenu() {
     );
   }
 
-  Flex* anchor = m_playerMenuButton->parent() != nullptr ? static_cast<Flex*>(m_playerMenuButton->parent())
-                                                         : static_cast<Flex*>(m_nowCard);
+ Flex* anchor = m_playerMenuButton;
   if (anchor == nullptr) {
     return;
   }
@@ -236,20 +235,30 @@ std::unique_ptr<Flex> MediaTab::create() {
   });
 
   auto artworkRow = ui::row(
-      {.out = &m_artworkRow, .align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = 0.0F, .flexGrow = 1.0F},
-      ui::image({
-          .out = &m_artwork,
-          .fit = ImageFit::Cover,
-          .radius = Style::scaledRadiusXl(scale),
-          .width = kArtworkSize * scale,
-          .height = kArtworkSize * scale,
-      })
-  );
+    {.out = &m_artworkRow, .align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = 0.0F, .flexGrow = 1.0F},
+ui::image({
+    .out = &m_artworkBackground,
+    .fit = ImageFit::Cover,
+    .participatesInLayout = false,
+    .configure = [](Image& image) {
+        image.setZIndex(-1);
+        image.setOpacity(0.80F);
+    },
+}),
+    ui::image({
+        .out = &m_artwork,
+        .fit = ImageFit::Cover,
+        .radius = Style::scaledRadiusXl(scale),
+        .width = kArtworkSize * scale,
+        .height = kArtworkSize * scale,
+        .configure = [](Image& image) { image.setZIndex(1); },
+    })
+);
   mediaStack->addChild(std::move(artworkRow));
 
   mediaStack->addChild(
       ui::column(
-          {.align = FlexAlign::Stretch, .gap = Style::spaceSm * scale},
+          {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
           ui::label({
               .out = &m_trackTitle,
               .text = i18n::tr("control-center.media.nothing-playing"),
@@ -280,7 +289,7 @@ std::unique_ptr<Flex> MediaTab::create() {
           .maxValue = 100.0F,
           .step = 1.0F,
           .trackHeight = 7.0F * scale,
-          .thumbSize = 16.0F * scale,
+          .thumbSize = 20.0F * scale,
           .controlHeight = (Style::controlHeight + Style::spaceXs) * scale,
           .onValueChanged =
               [this](double value) {
@@ -439,38 +448,8 @@ std::unique_ptr<Flex> MediaTab::create() {
   nowCard->addChild(std::move(mediaStack));
   mediaColumn->addChild(std::move(nowCard));
 
-  auto visualizerColumn = ui::column({
-      .out = &m_visualizerColumn,
-      .align = FlexAlign::Stretch,
-      .gap = Style::spaceMd * scale,
-      .clipChildren = true,
-      .flexGrow = 2.0F,
-      .configure = [scale, opacity = panelCardOpacity()](Flex& column) {
-        applySectionCardStyle(column, scale, opacity);
-      },
-  });
-
-  auto visualizerBody = ui::row({
-      .out = &m_visualizerBody,
-      .align = FlexAlign::Stretch,
-      .justify = FlexJustify::Start,
-      .fillWidth = true,
-      .flexGrow = 1.0F,
-  });
-
-  auto visualizerSpectrum = std::make_unique<AudioVisualizer>();
-  visualizerSpectrum->setGradient(colorForRole(ColorRole::Secondary), colorForRole(ColorRole::Tertiary));
-  visualizerSpectrum->setOrientation(AudioSpectrumOrientation::Vertical);
-  visualizerSpectrum->setMirrored(true);
-  visualizerSpectrum->setCentered(true);
-  visualizerSpectrum->setValues(std::vector<float>(kVisualizerBandCount, 0.0F));
-  visualizerSpectrum->tick(0.0F);
-  visualizerSpectrum->setFlexGrow(1.0F);
-  m_visualizerSpectrum = visualizerSpectrum.get();
-  visualizerBody->addChild(std::move(visualizerSpectrum));
-  visualizerColumn->addChild(std::move(visualizerBody));
   tab->addChild(std::move(mediaColumn));
-  tab->addChild(std::move(visualizerColumn));
+
 
   if (m_wayland != nullptr && m_renderContext != nullptr) {
     m_playerMenuPopup = std::make_unique<ContextMenuPopup>(*m_wayland, *m_renderContext);
@@ -507,7 +486,7 @@ void MediaTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
 
   const float cardInnerWidth =
       std::max(0.0F, m_nowCard->width() - (m_nowCard->paddingLeft() + m_nowCard->paddingRight()));
-  const float mediaWidth = std::clamp(cardInnerWidth, 1.0F, kMediaUnit * 11.0F * scale);
+  const float mediaWidth = std::max(1.0F, cardInnerWidth);
   const float mediaStackHeight = m_mediaStack->height();
   m_mediaStack->setSize(mediaWidth, mediaStackHeight);
 
@@ -551,36 +530,37 @@ void MediaTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
     m_trackAlbum->setMaxWidth(mediaWidth);
   }
   if (m_progressSlider != nullptr) {
-    m_progressSlider->setSize(mediaWidth, 0.0F);
+    m_progressSlider->setSize(mediaWidth * 0.70F, 0.0F);
   }
 
   m_mediaStack->layout(renderer);
 
   if (m_artwork != nullptr && m_artworkRow != nullptr) {
-    const float artWidth =
-        std::max(1.0F, m_artworkRow->width() - (m_artworkRow->paddingLeft() + m_artworkRow->paddingRight()));
-    const float artHeight = std::max(
-        kMediaArtworkMinHeight * scale,
-        m_artworkRow->height() - (m_artworkRow->paddingTop() + m_artworkRow->paddingBottom())
-    );
-    // Media art is always presented as a square (album-art convention).
-    const float side = std::min(artWidth, artHeight);
-    m_artwork->setSize(side, side);
-    m_artwork->setRadius(Style::scaledRadiusXl(scale));
-    m_mediaStack->layout(renderer);
-  }
+  const float artWidth =
+      std::max(1.0F, m_artworkRow->width() - (m_artworkRow->paddingLeft() + m_artworkRow->paddingRight()));
+  const float artHeight = std::max(
+      kMediaArtworkMinHeight * scale,
+      m_artworkRow->height() - (m_artworkRow->paddingTop() + m_artworkRow->paddingBottom())
+  );
 
-  if (m_visualizerBody != nullptr && m_visualizerSpectrum != nullptr) {
-    const float bodyWidth = std::max(
-        0.0F, m_visualizerBody->width() - (m_visualizerBody->paddingLeft() + m_visualizerBody->paddingRight())
-    );
-    const float bodyHeightAvail = std::max(
-        0.0F, m_visualizerBody->height() - (m_visualizerBody->paddingTop() + m_visualizerBody->paddingBottom())
-    );
-    const float spectrumWidth = std::max(1.0F, bodyWidth);
-    const float spectrumHeight = std::max(1.0F, bodyHeightAvail);
-    m_visualizerSpectrum->setSize(spectrumWidth, spectrumHeight);
-    m_visualizerBody->layout(renderer);
+  // Media art is always presented as a square (album-art convention).
+  const float side = std::min(artWidth, artHeight) * 0.75F;
+
+  m_artwork->setSize(side, side);
+  m_artwork->setRadius(side * 0.5F);
+
+  if (m_artworkBackground != nullptr) {
+    const float backgroundSide = side * 1.35F;
+
+    m_artworkBackground->setSize(backgroundSide, backgroundSide);
+    m_artworkBackground->setRadius(backgroundSide * 0.5F);
+
+    // Keep the blurred artwork centered behind the main artwork.
+    const float backgroundX = (artWidth - backgroundSide) * 0.5F;
+    const float backgroundY = (artHeight - backgroundSide) * 0.5F;
+
+    m_artworkBackground->setPosition(backgroundX, backgroundY);
+  }
   }
 }
 
@@ -589,11 +569,7 @@ void MediaTab::doUpdate(Renderer& renderer) {
     m_progressTimer.stop();
     return;
   }
-  if (m_visualizerSpectrum != nullptr && m_spectrum != nullptr && m_spectrumListenerId != 0) {
-    if (!m_spectrum->idle() || !m_visualizerSpectrum->converged()) {
-      m_visualizerSpectrum->setValues(m_spectrum->values(m_spectrumListenerId));
-    }
-  }
+
 
   const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
   const auto now = std::chrono::steady_clock::now();
@@ -623,22 +599,47 @@ void MediaTab::onFrameTick(float deltaMs) {
     return;
   }
 
-  if (m_visualizerSpectrum != nullptr) {
-    if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
-      if (!m_spectrum->idle() || !m_visualizerSpectrum->converged()) {
-        m_visualizerSpectrum->setValues(m_spectrum->values(m_spectrumListenerId));
-      }
+  if (m_artwork == nullptr) {
+    return;
+  }
+
+ // Continuous rotation
+constexpr float rotationSpeed = 0.0005F;
+m_artwork->setRotation(m_artwork->rotation() + deltaMs * rotationSpeed);
+
+// Smooth, bass-driven pulse
+if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
+  const auto values = m_spectrum->values(m_spectrumListenerId);
+
+  if (!values.empty()) {
+    const std::size_t bassBands = std::min<std::size_t>(4, values.size());
+
+    float bass = 0.0F;
+    for (std::size_t i = 0; i < bassBands; ++i) {
+      bass += values[i];
     }
-    m_visualizerSpectrum->tick(deltaMs);
+
+    bass /= static_cast<float>(bassBands);
+
+    // The low frequency defines the target of the pulse.
+    const float targetPulse = std::clamp(bass * 0.20F, 0.0F, 0.20F);
+
+    // Faster attack, smoother return.
+    const float smoothing = targetPulse > m_artworkPulse ? 0.16F : 0.055F;
+    m_artworkPulse += (targetPulse - m_artworkPulse) * smoothing;
+
+    m_artwork->setScale(1.0F + m_artworkPulse);
+  }
   }
 }
 
 void MediaTab::setActive(bool active) {
   const bool becameActive = active && !m_active;
   m_active = active;
+
   if (m_spectrum != nullptr) {
     if (active && m_spectrumListenerId == 0) {
-      m_spectrumListenerId = m_spectrum->addChangeListener(kVisualizerBandCount, [this]() {
+      m_spectrumListenerId = m_spectrum->addChangeListener(4, [this]() {
         if (!m_active || m_spectrum->idle()) {
           return;
         }
@@ -649,7 +650,14 @@ void MediaTab::setActive(bool active) {
       m_spectrumListenerId = 0;
     }
   }
+
   if (!active) {
+    m_artworkPulse = 0.0F;
+
+    if (m_artwork != nullptr) {
+      m_artwork->setScale(1.0F);
+    }
+
     m_progressTimer.stop();
     m_positionSampleAt = {};
     m_positionTrackSignature.clear();
@@ -657,34 +665,37 @@ void MediaTab::setActive(bool active) {
     m_nextRealtimeUpdateAt = {};
     m_lastRealtimeMprisPollAt = {};
   }
+
   if (becameActive && m_mpris != nullptr) {
     m_positionSampleAt = {};
   }
 }
 
+
 void MediaTab::onClose() {
   m_progressTimer.stop();
-  if (m_spectrum != nullptr) {
-    if (m_spectrumListenerId != 0) {
-      m_spectrum->removeChangeListener(m_spectrumListenerId);
-      m_spectrumListenerId = 0;
-    }
+
+  if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
+    m_spectrum->removeChangeListener(m_spectrumListenerId);
+    m_spectrumListenerId = 0;
   }
+
   m_active = false;
+  m_artworkPulse = 0.0F;
+
   m_rootLayout = nullptr;
   m_mediaColumn = nullptr;
-  m_visualizerColumn = nullptr;
-  m_visualizerBody = nullptr;
-  m_visualizerSpectrum = nullptr;
   m_artwork = nullptr;
   m_artworkRow = nullptr;
   m_nowCard = nullptr;
   m_mediaStack = nullptr;
   m_playerMenuButton = nullptr;
+
   if (m_playerMenuPopup != nullptr) {
     PanelManager::instance().clearActivePopup();
     m_playerMenuPopup->close();
   }
+
   m_playerMenuOpen = false;
   m_trackTitle = nullptr;
   m_trackArtist = nullptr;
@@ -695,6 +706,7 @@ void MediaTab::onClose() {
   m_nextButton = nullptr;
   m_repeatButton = nullptr;
   m_shuffleButton = nullptr;
+
   m_lastArtPath.clear();
   m_lastBusName.clear();
   m_lastPlaybackStatus.clear();
@@ -722,7 +734,14 @@ void MediaTab::clearArt(Renderer& renderer) {
   if (m_artwork != nullptr) {
     m_artwork->clear(renderer);
   }
+
+  if (m_artworkBackground != nullptr) {
+    m_artworkBackground->clear(renderer);
+  }
+
+  m_artworkBlurCache.invalidate();
 }
+
 
 void MediaTab::commitPendingSeek(double valueSeconds) {
   if (m_mpris == nullptr) {
@@ -881,11 +900,9 @@ void MediaTab::refresh(Renderer& renderer) {
     }
 
     m_trackTitle->setText(player.title.empty() ? player.identity : player.title);
-    m_trackArtist->setText(joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists));
-    if (m_trackAlbum != nullptr) {
-      m_trackAlbum->setText(player.album);
-      m_trackAlbum->setVisible(!player.album.empty());
-    }
+    m_trackArtist->setText(
+        joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists)
+    );
 
     const std::string resolvedArtUrl = effectiveArtUrl(player);
     const std::string artPath = resolveArtworkSource(
@@ -913,6 +930,30 @@ void MediaTab::refresh(Renderer& renderer) {
 
       // Only lock this URL once we actually have an image.
       // Otherwise keep retrying while metadata/download catches up.
+            if (loaded && m_artworkBackground != nullptr && m_renderContext != nullptr) {
+        const auto artworkTexture = m_artwork->textureHandle();
+
+        if (artworkTexture.valid()) {
+          m_renderContext->backend().makeCurrentNoSurface();
+
+          const std::uint32_t blurWidth = static_cast<std::uint32_t>(artworkTexture.width);
+          const std::uint32_t blurHeight = static_cast<std::uint32_t>(artworkTexture.height);
+
+         const auto blurredTexture = m_artworkBlurCache.get(
+             m_renderContext->backend(),
+             artworkTexture,
+             blurWidth,
+             blurHeight,
+             8.0F,
+             1
+         );
+
+          if (blurredTexture.valid()) {
+            m_artworkBackground->setExternalTexture(renderer, blurredTexture);
+          }
+        }
+      }
+
       m_lastArtPath = loaded ? resolvedArtUrl : std::string{};
       if (loaded) {
         PanelManager::instance().requestLayout();
@@ -928,6 +969,31 @@ void MediaTab::refresh(Renderer& renderer) {
     } else if (m_lastTrackLengthUs > 0 && samePlayerAsDisplayed) {
       trackLengthUs = m_lastTrackLengthUs;
     }
+
+   auto formatTime = [](std::int64_t microseconds) -> std::string {
+     const auto totalSeconds = std::max<std::int64_t>(0, microseconds / 1000000);
+     const auto minutes = totalSeconds / 60;
+     const auto seconds = totalSeconds % 60;
+
+    return std::format("{:02}:{:02}", minutes, seconds);
+   };
+
+   if (m_trackAlbum != nullptr) {
+    if (trackLengthUs > 0) {
+      m_trackAlbum->setText(
+         std::format(
+             "{} / {}",
+             formatTime(displayPositionUs),
+             formatTime(trackLengthUs)
+         )
+      );
+       m_trackAlbum->setVisible(true);
+     } else {
+      m_trackAlbum->setText("");
+      m_trackAlbum->setVisible(false);
+     }
+   }
+
     const bool progressInteracting = m_progressSlider->dragging() || seekPending || withinProgressSettle;
     const bool progressEnabled = player.canSeek && (trackLengthUs > 0 || progressInteracting);
 

--- a/src/shell/control_center/tabs/media_tab.h
+++ b/src/shell/control_center/tabs/media_tab.h
@@ -3,6 +3,7 @@
 #include "core/timer_manager.h"
 #include "dbus/mpris/mpris_service.h"
 #include "shell/control_center/tab.h"
+#include "render/core/blur_cache.h"
 
 #include <chrono>
 #include <cstdint>
@@ -21,7 +22,6 @@ class MprisService;
 class PipeWireSpectrum;
 class RenderContext;
 class Slider;
-class AudioVisualizer;
 class ConfigService;
 class WaylandConnection;
 
@@ -61,15 +61,15 @@ private:
   RenderContext* m_renderContext = nullptr;
   std::uint64_t m_spectrumListenerId = 0;
   bool m_active = false;
+  float m_artworkPulse = 0.0F;
 
   Flex* m_rootLayout = nullptr;
   Flex* m_mediaColumn = nullptr;
-  Flex* m_visualizerColumn = nullptr;
-  Flex* m_visualizerBody = nullptr;
-  AudioVisualizer* m_visualizerSpectrum = nullptr;
-  Image* m_artwork = nullptr;
-  Flex* m_artworkRow = nullptr;
   Flex* m_nowCard = nullptr;
+  Image* m_artwork = nullptr;
+  Image* m_artworkBackground = nullptr;
+  BlurCache m_artworkBlurCache;
+  Flex* m_artworkRow = nullptr;
   Flex* m_mediaStack = nullptr;
   Button* m_playerMenuButton = nullptr;
   std::unique_ptr<ContextMenuPopup> m_playerMenuPopup;
@@ -82,6 +82,7 @@ private:
   Button* m_nextButton = nullptr;
   Button* m_repeatButton = nullptr;
   Button* m_shuffleButton = nullptr;
+
 
   std::string m_lastArtPath;
   std::string m_lastBusName;

--- a/src/shell/desktop/widgets/desktop_media_player_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_media_player_widget.cpp
@@ -52,6 +52,8 @@ void DesktopMediaPlayerWidget::create() {
       .color = m_color,
       .maxLines = 1,
   });
+  m_title->setAutoScroll(true);
+  m_title->setAutoScrollSpeed(1.0F);
   rootNode->addChild(std::move(title));
 
   auto artist = ui::label({

--- a/src/shell/desktop/widgets/desktop_media_player_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_media_player_widget.cpp
@@ -219,14 +219,19 @@ void DesktopMediaPlayerWidget::layoutHorizontal(Renderer& renderer, float scale)
   const float artH = kArtSize * scale;
   const float spacing = kSpacing * scale;
   const float fontSize = Style::fontSizeBody * scale;
-  const float textWidth = artH * 1.5F;
 
   m_artwork->setSize(artH, artH);
   m_artwork->setRadius(Style::scaledRadiusMd(scale));
   m_artwork->setPosition(0.0F, 0.0F);
 
-  const float textX = artH + spacing;
-  const float totalWidth = textX + textWidth;
+  layoutButtons(renderer, scale);
+
+  const float controlsX = artH + spacing;
+  const float controlsY = std::round((artH - m_controls->height()) * 0.5F);
+  m_controls->setPosition(controlsX, controlsY);
+
+  const float textX = controlsX + m_controls->width() + spacing;
+  const float textWidth = artH * 1.5F;
 
   m_title->setFontSize(fontSize);
   m_title->setMaxWidth(textWidth);
@@ -236,22 +241,17 @@ void DesktopMediaPlayerWidget::layoutHorizontal(Renderer& renderer, float scale)
   m_artist->setMaxWidth(textWidth);
   m_artist->measure(renderer);
 
-  layoutButtons(renderer, scale);
-
   const float titleH = m_title->height();
   const float artistGap = m_artist->visible() ? spacing * 0.5F : 0.0F;
   const float artistH = m_artist->visible() ? m_artist->height() : 0.0F;
-  const float controlsH = m_controls->height();
-  const float textAreaH = std::max(0.0F, artH - controlsH - spacing);
+
   const float textBlockH = titleH + artistGap + artistH;
-  const float textY = std::round(std::max(0.0F, (textAreaH - textBlockH) * 0.5F));
+  const float textY = std::round((artH - textBlockH) * 0.5F);
 
   m_title->setPosition(textX, textY);
   m_artist->setPosition(textX, textY + titleH + artistGap);
 
-  const float controlsY = artH - controlsH;
-  const float controlsX = totalWidth - m_controls->width();
-  m_controls->setPosition(controlsX, controlsY);
+  const float totalWidth = textX + textWidth;
 
   root()->setSize(totalWidth, artH);
 }

--- a/src/ui/controls/image.h
+++ b/src/ui/controls/image.h
@@ -67,6 +67,7 @@ public:
   [[nodiscard]] const std::string& sourcePath() const noexcept { return m_sourcePath; }
   [[nodiscard]] bool hasImage() const noexcept { return m_texture.valid(); }
   [[nodiscard]] TextureId textureId() const noexcept { return m_texture.id; }
+  [[nodiscard]] TextureHandle textureHandle() const noexcept { return m_texture; }
   [[nodiscard]] int sourceWidth() const noexcept { return m_texture.sourceWidth; }
   [[nodiscard]] int sourceHeight() const noexcept { return m_texture.sourceHeight; }
   [[nodiscard]] float aspectRatio() const noexcept {

--- a/src/ui/controls/label.cpp
+++ b/src/ui/controls/label.cpp
@@ -372,7 +372,7 @@ void Label::startMarqueeLoop() {
   stopSnapAnimation();
 
   const float period = m_marqueeLoopPeriod;
-  const float durationMs = (period / m_scrollSpeedPxPerSec) * 1000.0F;
+  const float durationMs = (period / m_scrollSpeedPxPerSec) * 1000.0F * 3.0F;
   // Marquee scroll is content motion at a fixed px/sec rate, not a UI transition:
   // it must keep scrolling (and at its own speed) regardless of the global motion
   // enable/speed settings, so drive it off real elapsed time.


### PR DESCRIPTION
gh pr create \
  --repo noctalia-dev/noctalia \
  --head dinhokusanagi:pr-media-controls \
  --base main \
  --title "feat(media): add playback controls to desktop media widget" \
  --body "$(cat <<'EOF'
## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

The horizontal media widget now displays the album artwork, track information, and playback controls in a single horizontal layout.

Example:

`[ Artwork ] [ Title / Artist ] [ Previous  Play/Pause  Next ]`

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [ ] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

This PR adds playback controls to the horizontal desktop media widget and adjusts the layout so the controls are displayed alongside the track information. The existing vertical layout is preserved.
EOF
)"
Closes #4147

This PR implements the proposed media playback controls for the bar media widget and also improves the horizontal desktop media player layout.
