### PR TITLE
feat(widgets/workspaces): Add "ID and Name" option for label source

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3298,6 +3298,7 @@
         "icon-only": "Icon Only",
         "icons": "Icons",
         "id": "ID",
+        "id-and-name": "ID and Name",
         "input": "Input",
         "instance": "Per Placement",
         "kilobytes": "kB/s",
@@ -3642,6 +3643,10 @@
         "label-min-width": {
           "description": "Minimum label width in pixels to prevent resizing",
           "label": "Label Min Width"
+        },
+        "label-separator": {
+          "description": "Separator when label source is set to ID and Name",
+          "label": "Label Separator"
         },
         "label-show-units": {
           "description": "Show units like percent / GiB / °C",

--- a/docs/user/bar/widgets/workspaces.mdx
+++ b/docs/user/bar/widgets/workspaces.mdx
@@ -18,7 +18,8 @@ Pill styling and `capsule_radius` apply only when `style = "regular"`.
 |---------|------|---------|-------------|
 | `style` | string | `"regular"` | Pill style: `"regular"` (animated pills), `"minimal"` (labels drawn without pill backgrounds), or `"focus_hint"` (inactive dots + expanded active pill with focused app icon). |
 | `show_labels` | bool | `true` | Draw text labels on workspaces. Minimal renders labels and nothing else, so turning them off leaves its workspaces as empty slots. |
-| `label_source` | string | `"id"` | What labels show: `"id"` (workspace number, falling back to its name when no numeric identity exists) or `"name"` (workspace name). |
+| `label_source` | string | `"id"` | What labels show: `"id"` (workspace number, falling back to its name when no numeric identity exists), `"name"` (workspace name), or `"id_and_name"` (both). |
+| `label_separator` | string | `" "` | Separator between workspace ID and name, if `label_source` is `id_and_name`. |
 | `max_label_chars` | int | `1` | Maximum characters for non-numeric workspace labels, including names used as the `"id"` fallback. Numeric labels such as `10` and `11` are never truncated. |
 | `pill_scale` | float | `1.0` | Scale workspace pill thickness (cross-axis size; regular style only). |
 | `active_pill_size` | float | `2.2` | Minimum active pill length along the bar, as a multiple of pill thickness. Labels may expand beyond this. |

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -79,9 +79,9 @@ WorkspacesWidget::WorkspacesWidget(
     CompositorPlatform& platform, ConfigService& config, wl_output* output, Options options
 )
     : m_platform(platform), m_configService(config), m_output(output), m_labelSource(options.labelSource),
-      m_showLabels(options.showLabels), m_maxLabelChars(options.maxLabelChars),
-      m_labelsOnlyWhenOccupied(options.labelsOnlyWhenOccupied), m_hideWhenEmpty(options.hideWhenEmpty),
-      m_showAllOutputs(options.showAllOutputs), m_pillScale(options.pillScale),
+      m_labelSeparator(options.labelSeparator), m_showLabels(options.showLabels),
+      m_maxLabelChars(options.maxLabelChars), m_labelsOnlyWhenOccupied(options.labelsOnlyWhenOccupied),
+      m_hideWhenEmpty(options.hideWhenEmpty), m_showAllOutputs(options.showAllOutputs), m_pillScale(options.pillScale),
       m_activePillSize(std::clamp(options.activePillSize, 0.25F, 8.0F)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25F, 8.0F)), m_style(options.style),
       m_focusedOutputOnly(options.focusedOutputOnly), m_changeColorOnHover(options.changeColorOnHover),
@@ -1427,8 +1427,14 @@ std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::si
     } else {
       label = std::to_string(displayIndex + 1);
     }
-  } else {
+  } else if (m_labelSource == WorkspacesLabelSource::Name) {
     label = !workspace.name.empty() ? workspace.name : workspace.id;
+  } else {
+    if (workspace.name != std::to_string(workspace.index)) {
+      label = std::to_string(workspace.index) + m_labelSeparator + workspace.name;
+    } else {
+      label = std::to_string(workspace.index);
+    }
   }
 
   // Only truncate non-numeric labels (words like "VESKTOP" → "VE").

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -29,6 +29,7 @@ enum class WorkspacesStyle : std::uint8_t {
 enum class WorkspacesLabelSource : std::uint8_t {
   Id,
   Name,
+  IdAndName,
 };
 
 class WorkspacesWidget : public Widget {
@@ -36,6 +37,7 @@ public:
   struct Options {
     WorkspacesStyle style = WorkspacesStyle::Regular;
     WorkspacesLabelSource labelSource = WorkspacesLabelSource::Id;
+    std::string labelSeparator = " ";
     bool showLabels = true;
     ColorSpec focusedColor = colorSpecFromRole(ColorRole::Primary);
     ColorSpec occupiedColor = colorSpecFromRole(ColorRole::Secondary);
@@ -157,6 +159,7 @@ private:
   ConfigService& m_configService;
   wl_output* m_output = nullptr;
   WorkspacesLabelSource m_labelSource = WorkspacesLabelSource::Id;
+  std::string m_labelSeparator = " ";
   bool m_showLabels = true;
   std::size_t m_maxLabelChars = 1;
   bool m_labelsOnlyWhenOccupied = false;

--- a/src/shell/bar/widgets/workspaces_widget_definition.cpp
+++ b/src/shell/bar/widgets/workspaces_widget_definition.cpp
@@ -8,6 +8,12 @@ namespace {
     return visibility;
   }
 
+  settings::WidgetSettingVisibility labelSourceIsIdAndName() {
+    settings::WidgetSettingVisibility visibility;
+    visibility.all = {{"label_source", {"id_and_name"}}};
+    return visibility;
+  }
+
   // FocusHint labels the focused workspace only, so the occupied filter never bites there.
   settings::WidgetSettingVisibility occupiedFilterApplies() {
     settings::WidgetSettingVisibility visibility;
@@ -72,6 +78,11 @@ const noctalia::bar::WidgetDefinition<WorkspacesWidget::Options>& workspacesWidg
                               .configValue = "name",
                               .labelKey = "settings.widgets.options.name",
                           },
+                          {
+                              .value = WorkspacesLabelSource::IdAndName,
+                              .configValue = "id_and_name",
+                              .labelKey = "settings.widgets.options.id-and-name",
+                          },
                       },
                   .presentation =
                       settings::WidgetSettingPresentation{
@@ -79,6 +90,15 @@ const noctalia::bar::WidgetDefinition<WorkspacesWidget::Options>& workspacesWidg
                           .segmented = true,
                           .visibleWhen = labelsShown(),
                       },
+              }),
+              field<&Options::labelSeparator>({
+                .key = "label_separator",
+                .presentation =
+                    settings::WidgetSettingPresentation{
+                        .descriptionKey = "settings.widgets.settings.label-separator.description",
+                        .group = "workspaces.list",
+                        .visibleWhen = labelSourceIsIdAndName(),
+                    },
               }),
               field<&Options::labelsOnlyWhenOccupied>({
                   .key = "labels_only_when_occupied",


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This adds an "id_and_name" option to the label_source option on the workspaces widget, which displays both the numerical ID of the workspace and its name, if an explicit name is given. There is also a label_separator option which lets you configure what is placed in between the workspace ID and name (defaults to a single space).

## Motivation

This is useful if you use named workspaces (i.e. in Niri), but still want to be able to easily see what number to press to go to that exact workspace, simply by looking at the bar.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

<!--## Related Issue-->

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

1. In config, set `widget.workspaces.label_source` to `id_and_name`, and optionally set `label_separator` to whatever you want.
2. Rename some workspaces
3. Observe the named ones show both the index and name, while unnamed ones just show the index alone.

I have also checked the settings UI to confirm that the option shows up correctly and is configurable.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

Image demonstrates having `label_separator` set to `":"`.

<img width="578" height="59" alt="image" src="https://github.com/user-attachments/assets/6678d37e-25e6-43ab-86ac-593075e0811c" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] ~~I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.~~ I updated the docs directly in this PR after rebasing
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

~~I'm not quite sure how the config defaults are supposed to work. I want the `label_separator` to default to a single space, but it seems like it still is just defaulting to an empty string. Apart from that I don't see any issues.~~ Figured it out, I had accidentally forgotten to change it under the `Options` struct.