### PR TITLE
feat(osd): add configurable cooldown for media (now playing) popups

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2947,6 +2947,10 @@
           "description": "Show an OSD popup when Wi-Fi is toggled",
           "label": "Wi-Fi"
         },
+        "osd-media-cooldown": {
+          "description": "Minimum delay between media (now playing) popups; 0 disables the cooldown",
+          "label": "Media Cooldown"
+        },
         "osd-monitors": {
           "description": "Choose which monitors show OSD popups; leave empty to show on all monitors",
           "label": "Monitors"

--- a/example.toml
+++ b/example.toml
@@ -195,6 +195,7 @@ background_opacity = 0.97           # background opacity of OSD popups
 offset_x = 20                       # absolute horizontal margin from the screen edge
 offset_y = 8                        # absolute vertical margin from the screen edge
 # monitors = ["DP-1"]               # connector names; omit or leave empty for all monitors
+media_cooldown_ms = 0               # cooldown between media (now playing) popups in ms; 0 = no cooldown
 
 [osd.kinds]
 volume = true                       # master volume OSD toggle
@@ -209,7 +210,9 @@ nightlight = true                   # night light toggle
 dnd = true                          # Do Not Disturb toggle
 lock_keys = true                    # Caps/Num/Scroll Lock changes; disable to stop polling when no widget uses them
 keyboard_layout = true              # input keyboard layout changes
+media = true                        # now playing (track change) popups
 privacy = true                      # microphone/camera/screen-share capture changes
+keyboard_backlight = true           # keyboard backlight changes
 
 # ── Lock Screen ───────────────────────────────────────────────────────────────
 

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -804,6 +804,15 @@ void Application::initNotificationAndOsd() {
   m_keyboardLayoutOsd.bindOverlay(m_osdOverlay);
   m_keyboardLayoutOsd.prime(m_compositorPlatform);
   m_mediaOsd.bindOverlay(m_osdOverlay);
+  m_mediaOsd.configure(m_configService.config());
+  m_configService.addReloadCallback(
+      [this]() {
+        if (m_configService.lastChange().osd) {
+          m_mediaOsd.configure(m_configService.config());
+        }
+      },
+      "media-osd-cooldown"
+  );
   m_privacyOsd.bindOverlay(m_osdOverlay);
   m_privacyOsd.configure(m_configService.config());
   m_configService.addReloadCallback(

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -735,6 +735,8 @@ struct OsdConfig {
   int offsetX = 20;
   int offsetY = 8;
   std::vector<std::string> monitors;
+  // Cooldown between media (now playing) popups, in milliseconds; 0 = disabled.
+  std::int32_t mediaCooldownMs = 0;
   OsdKindsConfig kinds;
 
   bool operator==(const OsdConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -73,6 +73,7 @@ namespace noctalia::config::schema {
         field(&OsdConfig::offsetX, "offset_x", Range<std::int64_t>{0, std::nullopt}),
         field(&OsdConfig::offsetY, "offset_y", Range<std::int64_t>{0, std::nullopt}),
         field(&OsdConfig::monitors, "monitors"),
+        field(&OsdConfig::mediaCooldownMs, "media_cooldown_ms", Range<std::int64_t>{0, std::nullopt}),
         subTable(&OsdConfig::kinds, "kinds", osdKindsSchema()),
     };
     return s;

--- a/src/shell/osd/media_osd.cpp
+++ b/src/shell/osd/media_osd.cpp
@@ -1,10 +1,11 @@
 #include "shell/osd/media_osd.h"
 
+#include "config/config_types.h"
 #include "dbus/mpris/mpris_service.h"
-#include "shell/osd/osd_overlay.h"
 
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 namespace {
 
@@ -37,6 +38,63 @@ namespace {
 
 void MediaOsd::bindOverlay(OsdOverlay& overlay) { m_overlay = &overlay; }
 
+void MediaOsd::configure(const Config& config) {
+  m_cooldown = std::chrono::milliseconds(std::max<std::int64_t>(0, config.osd.mediaCooldownMs));
+
+  // A reload may have shortened the cooldown below what the pending flush is
+  // waiting on; release anything that is no longer suppressed.
+  if (m_pendingContent.has_value() && !inCooldown(std::chrono::steady_clock::now())) {
+    flushPending();
+  }
+}
+
+bool MediaOsd::inCooldown(std::chrono::steady_clock::time_point now) const noexcept {
+  return m_cooldown.count() > 0 && now < m_cooldownUntil;
+}
+
+void MediaOsd::pushTrackContent(const OsdContent& content) {
+  if (m_overlay == nullptr) {
+    return;
+  }
+  const auto now = std::chrono::steady_clock::now();
+  if (inCooldown(now)) {
+    // Keep only the most recent trigger; it re-appears once the cooldown ends.
+    m_pendingContent = content;
+    if (m_pendingFlushTimer == 0) {
+      schedulePendingFlush(m_cooldownUntil);
+    }
+    return;
+  }
+  m_overlay->show(content);
+  m_cooldownUntil = now + m_cooldown;
+}
+
+void MediaOsd::schedulePendingFlush(std::chrono::steady_clock::time_point when) {
+  const auto delay = std::chrono::duration_cast<std::chrono::milliseconds>(when - std::chrono::steady_clock::now());
+  const std::weak_ptr<void> aliveGuard = m_aliveGuard;
+  m_pendingFlushTimer = TimerManager::instance().start(m_pendingFlushTimer, delay, [this, aliveGuard]() {
+    if (aliveGuard.expired()) {
+      return;
+    }
+    m_pendingFlushTimer = 0;
+    flushPending();
+  });
+}
+
+void MediaOsd::flushPending() {
+  if (!m_pendingContent.has_value()) {
+    return;
+  }
+  const auto now = std::chrono::steady_clock::now();
+  if (inCooldown(now)) {
+    schedulePendingFlush(m_cooldownUntil);
+    return;
+  }
+  OsdContent content = std::move(*m_pendingContent);
+  m_pendingContent.reset();
+  pushTrackContent(content);
+}
+
 void MediaOsd::onMprisChanged(const MprisService& service) {
   const auto activePlayerOpt = service.activePlayer();
   if (activePlayerOpt.has_value()) {
@@ -49,9 +107,7 @@ void MediaOsd::onMprisChanged(const MprisService& service) {
       m_hasData = true;
     } else if (activePlayer.playbackStatus == "Playing" && osdData != m_lastData) {
       m_lastData = osdData;
-      if (m_overlay != nullptr) {
-        m_overlay->show(makeMprisContent(osdData));
-      }
+      pushTrackContent(makeMprisContent(osdData));
     }
   }
 

--- a/src/shell/osd/media_osd.h
+++ b/src/shell/osd/media_osd.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include "core/timer_manager.h"
+#include "shell/osd/osd_overlay.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
+
 class MprisService;
-class OsdOverlay;
+struct Config;
 
 struct MediaOsdData {
   std::string title;
@@ -15,11 +23,23 @@ struct MediaOsdData {
 class MediaOsd {
 public:
   void bindOverlay(OsdOverlay& overlay);
+  void configure(const Config& config);
   void onMprisChanged(const MprisService& service);
 
 private:
+  [[nodiscard]] bool inCooldown(std::chrono::steady_clock::time_point now) const noexcept;
+  void pushTrackContent(const OsdContent& content);
+  void schedulePendingFlush(std::chrono::steady_clock::time_point when);
+  void flushPending();
+
   OsdOverlay* m_overlay = nullptr;
   MediaOsdData m_lastData;
   std::unordered_map<std::string, double> m_lastVolumes;
+  std::chrono::milliseconds m_cooldown{0};
+  std::chrono::steady_clock::time_point m_cooldownUntil;
+  std::optional<OsdContent> m_pendingContent;
+  TimerManager::TimerId m_pendingFlushTimer = 0;
   bool m_hasData = false;
+  // Keeps TimerManager callbacks from touching a destroyed MediaOsd.
+  std::shared_ptr<void> m_aliveGuard = std::make_shared<int>(0);
 };

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2015,6 +2015,18 @@ namespace settings {
         "monitor output display screen hud overlay"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Osd, "osd", tr("settings.schema.shell.osd-media-cooldown.label"),
+        tr("settings.schema.shell.osd-media-cooldown.description"), {"osd", "media_cooldown_ms"},
+        StepperSetting{
+            .value = cfg.osd.mediaCooldownMs,
+            .minValue = 0,
+            .maxValue = 10000,
+            .step = 250,
+            .valueSuffix = "ms",
+        },
+        "hud overlay media now playing cooldown debounce"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Osd, "kinds", tr("settings.schema.shell.osd-kinds-volume.label"),
         tr("settings.schema.shell.osd-kinds-volume.description"), {"osd", "kinds", "volume"},
         ToggleSetting{cfg.osd.kinds.volume}, "hud overlay audio output input microphone"

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -342,6 +342,7 @@ location = "https://example.invalid/bad"
     c.osd.offsetX = 33;
     c.osd.offsetY = 11;
     c.osd.monitors = {"DP-1", "HDMI-A-1"};
+    c.osd.mediaCooldownMs = 1500;
     c.osd.kinds.lockKeys = false;
     c.osd.kinds.keyboardLayout = false;
     c.backdrop = BackdropConfig{true, 0.8f, 0.2f};


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add a configurable cooldown time to the media (now playing) OSD.
<!-- What changed and why? -->

## Motivation

As mentioned by users in #4070, due to some player implementation issues, OSD messages repeatedly appear when fast-forwarding. Adding a cooldown reduces unnecessary popups.
<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4070
<!-- Example: Closes #123 -->

## Testing

Since I couldn't find a similar player, I quickly switched songs to test and observe, and the cooldown was correct.
<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
> I am not a native English speaker and used LLM-assisted translation