### PR TITLE
feat(switcher): add MRU order option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3060,10 +3060,6 @@
           "description": "Copy the current wallpaper and colors to Noctalia Greeter (requires administrator approval)",
           "label": "Noctalia Greeter"
         },
-        "window-switcher-mru": {
-          "description": "Order windows in the switcher by most recently used rather than workspace and screen layout",
-          "label": "Use MRU Order"
-        },
         "telemetry": {
           "description": "Sends a small anonymous startup ping with version, OS, compositor, monitor resolutions, RAM, and UI scale",
           "label": "Anonymous Startup Ping"
@@ -3071,6 +3067,10 @@
         "time-format": {
           "description": "Default time format for shell UI without its own setting",
           "label": "Time Format"
+        },
+        "window-switcher-mru": {
+          "description": "Order windows in the switcher by most recently used rather than workspace and screen layout",
+          "label": "Most Recently Used Order"
         }
       },
       "system": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1257,7 +1257,8 @@
         "wallpaper": "Wallpaper",
         "weather": "Weather",
         "widget-list": "Widget List",
-        "widgets": "Widgets"
+        "widgets": "Widgets",
+        "window-switcher": "Window Switcher"
       },
       "sections": {
         "accessibility": "Accessibility",
@@ -3058,6 +3059,10 @@
           "button": "Sync Now",
           "description": "Copy the current wallpaper and colors to Noctalia Greeter (requires administrator approval)",
           "label": "Noctalia Greeter"
+        },
+        "window-switcher-mru": {
+          "description": "Order windows in the switcher by most recently used rather than workspace and screen layout",
+          "label": "Use MRU Order"
         },
         "telemetry": {
           "description": "Sends a small anonymous startup ping with version, OS, compositor, monitor resolutions, RAM, and UI scale",

--- a/docs/user/configuration/shell.mdx
+++ b/docs/user/configuration/shell.mdx
@@ -161,6 +161,9 @@ command = "swaylock -f"
 [shell.mpris]
 blacklist = []           # optional list of players to hide from media widgets/control-center
 
+[shell.window_switcher]
+mru = false              # order windows by most recently used (Alt+Tab toggle) instead of workspace layout
+
 [shell.privacy]
 mic_filter_regex    = "" # ignore matching microphone application names
 cam_filter_regex    = "" # ignore matching camera process names

--- a/docs/user/configuration/shell.mdx
+++ b/docs/user/configuration/shell.mdx
@@ -162,7 +162,7 @@ command = "swaylock -f"
 blacklist = []           # optional list of players to hide from media widgets/control-center
 
 [shell.window_switcher]
-mru = false              # order windows by most recently used (Alt+Tab toggle) instead of workspace layout
+mru = false              # order windows by most recently used (Alt+Tab) instead of workspace layout
 
 [shell.privacy]
 mic_filter_regex    = "" # ignore matching microphone application names

--- a/example.toml
+++ b/example.toml
@@ -104,6 +104,10 @@ prefix = "win"
 [shell.mpris]
 blacklist = []                      # ignore MPRIS players by bus/identity/desktop entry token
 
+
+[shell.window_switcher]
+mru = false                           # order windows by most recently used (Alt+Tab toggle) instead of workspace layout
+
 # ── Wallpaper ─────────────────────────────────────────────────────────────────
 
 [wallpaper]

--- a/example.toml
+++ b/example.toml
@@ -104,9 +104,8 @@ prefix = "win"
 [shell.mpris]
 blacklist = []                      # ignore MPRIS players by bus/identity/desktop entry token
 
-
 [shell.window_switcher]
-mru = false                           # order windows by most recently used (Alt+Tab toggle) instead of workspace layout
+mru = false                         # order windows by most recently used (Alt+Tab) instead of workspace layout
 
 # ── Wallpaper ─────────────────────────────────────────────────────────────────
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1061,6 +1061,12 @@ struct ShellConfig {
     bool operator==(const PrivacyConfig&) const = default;
   };
 
+  struct WindowSwitcherConfig {
+    bool mru = false;
+
+    bool operator==(const WindowSwitcherConfig&) const = default;
+  };
+
   float cornerRadiusScale = 1.0F;
   bool buttonBorders = true;
   bool inputBorders = true;
@@ -1109,6 +1115,7 @@ struct ShellConfig {
   ShadowConfig shadow;
   PanelConfig panel;
   LauncherConfig launcher;
+  WindowSwitcherConfig windowSwitcher;
   KeyboardLayoutConfig keyboardLayout;
   ScreenCornersConfig screenCorners;
   MprisConfig mpris;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1373,6 +1373,13 @@ namespace noctalia::config::schema {
       return s;
     }
 
+    const Schema<ShellConfig::WindowSwitcherConfig>& shellWindowSwitcherSchema() {
+      static const Schema<ShellConfig::WindowSwitcherConfig> s = {
+          field(&ShellConfig::WindowSwitcherConfig::mru, "mru"),
+      };
+      return s;
+    }
+
     const Schema<ShellConfig::ScreenCornersConfig>& shellScreenCornersSchema() {
       static const Schema<ShellConfig::ScreenCornersConfig> s = {
           field(&ShellConfig::ScreenCornersConfig::enabled, "enabled"),
@@ -1562,6 +1569,7 @@ namespace noctalia::config::schema {
         subTable(&ShellConfig::panel, "panel", shellPanelSchema()),
         subTable(&ShellConfig::launcher, "launcher", shellLauncherSchema()),
         subTable(&ShellConfig::keyboardLayout, "keyboard_layout", shellKeyboardLayoutSchema()),
+        subTable(&ShellConfig::windowSwitcher, "window_switcher", shellWindowSwitcherSchema()),
         subTable(&ShellConfig::screenCorners, "screen_corners", shellScreenCornersSchema()),
         subTable(&ShellConfig::mpris, "mpris", shellMprisSchema()),
         subTable(&ShellConfig::screenshot, "screenshot", shellScreenshotSchema()),

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1917,6 +1917,11 @@ namespace settings {
         tr("settings.schema.shell.screenshot-pipe-to-command.description"), {"shell", "screenshot", "pipe_to_command"},
         ToggleSetting{cfg.shell.screenshot.pipeToCommand}, "screenshot capture pipe command stdin"
     ));
+    entries.push_back(makeEntry(
+        SettingsSection::Shell, "window-switcher", tr("settings.schema.shell.window-switcher-mru.label"),
+        tr("settings.schema.shell.window-switcher-mru.description"), {"shell", "window_switcher", "mru"},
+        ToggleSetting{cfg.shell.windowSwitcher.mru}, "window switcher alt tab mru most recently used"
+    ));
     {
       auto e = makeEntry(
           SettingsSection::Shell, "screenshot", tr("settings.schema.shell.screenshot-pipe-command.label"),

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1917,11 +1917,6 @@ namespace settings {
         tr("settings.schema.shell.screenshot-pipe-to-command.description"), {"shell", "screenshot", "pipe_to_command"},
         ToggleSetting{cfg.shell.screenshot.pipeToCommand}, "screenshot capture pipe command stdin"
     ));
-    entries.push_back(makeEntry(
-        SettingsSection::Shell, "window-switcher", tr("settings.schema.shell.window-switcher-mru.label"),
-        tr("settings.schema.shell.window-switcher-mru.description"), {"shell", "window_switcher", "mru"},
-        ToggleSetting{cfg.shell.windowSwitcher.mru}, "window switcher alt tab mru most recently used"
-    ));
     {
       auto e = makeEntry(
           SettingsSection::Shell, "screenshot", tr("settings.schema.shell.screenshot-pipe-command.label"),
@@ -1937,6 +1932,11 @@ namespace settings {
       e.visibleWhen = [](const Config& c) { return c.shell.screenshot.pipeToCommand; };
       entries.push_back(std::move(e));
     }
+    entries.push_back(makeEntry(
+        SettingsSection::Shell, "window-switcher", tr("settings.schema.shell.window-switcher-mru.label"),
+        tr("settings.schema.shell.window-switcher-mru.description"), {"shell", "window_switcher", "mru"},
+        ToggleSetting{cfg.shell.windowSwitcher.mru}, "window switcher alt tab mru most recently used"
+    ));
     entries.push_back(makeEntry(
         SettingsSection::Osd, "osd", tr("settings.schema.shell.osd-enabled.label"),
         tr("settings.schema.shell.osd-enabled.description"), {"osd", "enabled"}, ToggleSetting{cfg.osd.enabled},

--- a/src/shell/switcher/window_switcher.cpp
+++ b/src/shell/switcher/window_switcher.cpp
@@ -34,6 +34,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <deque>
+#include <limits>
 #include <linux/input-event-codes.h>
 #include <memory>
 #include <unordered_map>
@@ -225,13 +227,11 @@ namespace {
   }
 
   [[nodiscard]] std::string currentFocusedWindowKey(const CompositorPlatform& platform) {
-    if (const auto focusedId = platform.focusedCompositorWindowId(); focusedId.has_value() && !focusedId->empty()) {
-      return canonicalWindowId(*focusedId);
+    const auto focusedId = platform.focusedCompositorWindowId();
+    if (!focusedId.has_value()) {
+      return {};
     }
-    if (const auto active = platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
-      return "handle:" + std::to_string(reinterpret_cast<std::uintptr_t>(active->handle));
-    }
-    return {};
+    return canonicalWindowId(*focusedId);
   }
 
   [[nodiscard]] std::uintptr_t resolveCloseHandle(
@@ -284,7 +284,7 @@ namespace {
     std::int32_t sortX = 0;
     std::int32_t sortY = 0;
     std::uint64_t toplevelOrder = 0;
-    // Initialize to max so non-MRU items gracefully fall to the back
+    // Windows with no MRU rank sort after every ranked window.
     std::size_t mruIndex = std::numeric_limits<std::size_t>::max();
   };
 
@@ -339,10 +339,29 @@ namespace {
     }
   }
 
+  // Identity keys of every window the switcher can list right now. Compositors reuse
+  // window ids (Hyprland reuses addresses), so MRU ranks must expire with the window.
+  [[nodiscard]] std::unordered_set<std::string> liveWindowKeys(const CompositorPlatform& platform) {
+    std::unordered_set<std::string> keys;
+    keys.reserve(32);
+    for (const auto& assignment : platform.workspaceWindowAssignments()) {
+      if (std::string key = canonicalWindowId(assignment.windowId); !key.empty()) {
+        keys.insert(std::move(key));
+      }
+    }
+
+    std::unordered_map<std::string, ToplevelInfo> liveToplevelById;
+    indexLiveToplevelsByWindowId(platform, liveToplevelById);
+    for (const auto& live : liveToplevelById) {
+      keys.insert(live.first);
+    }
+    return keys;
+  }
+
   void buildWindowEntries(
       const CompositorPlatform& platform, IconResolver& iconResolver, int iconSize,
-      std::vector<WindowSwitcherEntry>& out, const std::optional<std::string>& focusedId, bool useMru = false,
-      const std::deque<std::string>& mruKeys = {}
+      std::vector<WindowSwitcherEntry>& out, const std::optional<std::string>& focusedId,
+      const std::deque<std::string>* mruKeys
   ) {
     std::unordered_map<std::string, WorkspaceWindowAssignment> assignmentById;
     assignmentById.reserve(32);
@@ -364,11 +383,12 @@ namespace {
     std::vector<WindowSwitcherCandidate> candidates;
     candidates.reserve(assignmentById.size() + liveToplevelById.size());
 
+    // Empty while MRU ordering is off, which leaves every candidate at rank max.
     std::unordered_map<std::string_view, std::size_t> mruRanks;
-    if (useMru) {
-      mruRanks.reserve(mruKeys.size());
-      for (std::size_t i = 0; i < mruKeys.size(); ++i) {
-        mruRanks.try_emplace(mruKeys[i], i);
+    if (mruKeys != nullptr) {
+      mruRanks.reserve(mruKeys->size());
+      for (std::size_t i = 0; i < mruKeys->size(); ++i) {
+        mruRanks.try_emplace((*mruKeys)[i], i);
       }
     }
 
@@ -377,12 +397,8 @@ namespace {
         return;
       }
       seenKeys.insert(key);
-
-      if (useMru) {
-        const std::string idKey = identityKeyForEntry(candidate.entry);
-        if (auto it = mruRanks.find(idKey); it != mruRanks.end()) {
-          candidate.mruIndex = it->second;
-        }
+      if (const auto rank = mruRanks.find(key); rank != mruRanks.end()) {
+        candidate.mruIndex = rank->second;
       }
       candidates.push_back(std::move(candidate));
     };
@@ -419,19 +435,6 @@ namespace {
       addCandidate(std::move(candidate), key);
     }
 
-    std::optional<std::string> focusedKey;
-    if (focusedId.has_value()) {
-      focusedKey = canonicalWindowId(*focusedId);
-      if (focusedKey->empty()) {
-        focusedKey = *focusedId;
-      }
-    }
-    if (!focusedKey.has_value()) {
-      if (const auto active = platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
-        focusedKey = "handle:" + std::to_string(reinterpret_cast<std::uintptr_t>(active->handle));
-      }
-    }
-
     std::ranges::stable_sort(candidates, [](const WindowSwitcherCandidate& a, const WindowSwitcherCandidate& b) {
       if (a.mruIndex != b.mruIndex) {
         return a.mruIndex < b.mruIndex;
@@ -455,6 +458,14 @@ namespace {
 
     out.clear();
     out.reserve(candidates.size());
+
+    std::optional<std::string> focusedKey;
+    if (focusedId.has_value()) {
+      focusedKey = canonicalWindowId(*focusedId);
+      if (focusedKey->empty()) {
+        focusedKey = *focusedId;
+      }
+    }
 
     if (focusedKey.has_value()) {
       for (auto it = candidates.begin(); it != candidates.end(); ++it) {
@@ -613,27 +624,30 @@ void WindowSwitcher::onOutputChange() {
   }
 }
 
+bool WindowSwitcher::mruEnabled() const { return m_config != nullptr && m_config->config().shell.windowSwitcher.mru; }
+
 void WindowSwitcher::recordFocusedWindow() {
-  if (m_platform == nullptr) {
+  if (m_platform == nullptr || !mruEnabled()) {
     return;
   }
-  const bool useMru = (m_config != nullptr) ? m_config->config().shell.windowSwitcher.mru : false;
-  if (useMru) {
-    promoteMruKey(currentFocusedWindowKey(*m_platform));
-  }
+  promoteMruKey(currentFocusedWindowKey(*m_platform));
 }
 
 void WindowSwitcher::promoteMruKey(const std::string& key) {
-  if (key.empty()) {
+  if (key.empty() || m_platform == nullptr) {
     return;
   }
+
+  const std::unordered_set<std::string> live = liveWindowKeys(*m_platform);
+  std::erase_if(m_mruKeys, [&](const std::string& existing) { return existing != key && !live.contains(existing); });
+
   auto it = std::ranges::find(m_mruKeys, key);
-  if (it != m_mruKeys.end()) {
-    if (it != m_mruKeys.begin()) {
-      std::rotate(m_mruKeys.begin(), it, it + 1);
-    }
-  } else {
+  if (it == m_mruKeys.end()) {
     m_mruKeys.insert(m_mruKeys.begin(), key);
+    return;
+  }
+  if (it != m_mruKeys.begin()) {
+    std::rotate(m_mruKeys.begin(), it, it + 1);
   }
 }
 
@@ -704,25 +718,12 @@ void WindowSwitcher::refreshWindows() {
     }
   }
 
-  const bool useMru = (m_config != nullptr) ? m_config->config().shell.windowSwitcher.mru : false;
-
   IconResolver iconResolver;
   const int iconSize = 96;
   buildWindowEntries(
-      *m_platform, iconResolver, iconSize, m_windows, m_platform->focusedCompositorWindowId(), useMru, m_mruKeys
+      *m_platform, iconResolver, iconSize, m_windows, m_platform->focusedCompositorWindowId(),
+      mruEnabled() ? &m_mruKeys : nullptr
   );
-
-  if (useMru) {
-    std::unordered_set<std::string> currentKeys;
-    currentKeys.reserve(m_windows.size());
-    for (const auto& entry : m_windows) {
-      const std::string k = identityKeyForEntry(entry);
-      if (!k.empty()) {
-        currentKeys.insert(k);
-      }
-    }
-    std::erase_if(m_mruKeys, [&](const std::string& k) { return !currentKeys.contains(k); });
-  }
 
   if (selectedKey.has_value()) {
     for (std::size_t i = 0; i < m_windows.size(); ++i) {
@@ -785,7 +786,9 @@ void WindowSwitcher::activateSelected() {
     return;
   }
   const WindowSwitcherEntry entry = m_windows[m_selectedIndex];
-  promoteMruKey(identityKeyForEntry(entry));
+  if (mruEnabled()) {
+    promoteMruKey(identityKeyForEntry(entry));
+  }
   // Hyprland ignores zwlr_foreign_toplevel_handle_v1.activate while an exclusive
   // keyboard layer-shell surface is mapped (hyprwm/Hyprland#4829). Snapshot the
   // selection, tear the overlay down, then activate on the next loop tick.

--- a/src/shell/switcher/window_switcher.cpp
+++ b/src/shell/switcher/window_switcher.cpp
@@ -224,6 +224,16 @@ namespace {
     return {};
   }
 
+  [[nodiscard]] std::string currentFocusedWindowKey(const CompositorPlatform& platform) {
+    if (const auto focusedId = platform.focusedCompositorWindowId(); focusedId.has_value() && !focusedId->empty()) {
+      return canonicalWindowId(*focusedId);
+    }
+    if (const auto active = platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
+      return "handle:" + std::to_string(reinterpret_cast<std::uintptr_t>(active->handle));
+    }
+    return {};
+  }
+
   [[nodiscard]] std::uintptr_t resolveCloseHandle(
       const CompositorPlatform& platform, std::string_view windowId, std::string_view appId, std::string_view title
   ) {
@@ -274,6 +284,8 @@ namespace {
     std::int32_t sortX = 0;
     std::int32_t sortY = 0;
     std::uint64_t toplevelOrder = 0;
+    // Initialize to max so non-MRU items gracefully fall to the back
+    std::size_t mruIndex = std::numeric_limits<std::size_t>::max();
   };
 
   [[nodiscard]] WindowSwitcherEntry makeEntryFromAssignment(
@@ -329,7 +341,8 @@ namespace {
 
   void buildWindowEntries(
       const CompositorPlatform& platform, IconResolver& iconResolver, int iconSize,
-      std::vector<WindowSwitcherEntry>& out, const std::optional<std::string>& focusedId
+      std::vector<WindowSwitcherEntry>& out, const std::optional<std::string>& focusedId, bool useMru = false,
+      const std::deque<std::string>& mruKeys = {}
   ) {
     std::unordered_map<std::string, WorkspaceWindowAssignment> assignmentById;
     assignmentById.reserve(32);
@@ -351,11 +364,26 @@ namespace {
     std::vector<WindowSwitcherCandidate> candidates;
     candidates.reserve(assignmentById.size() + liveToplevelById.size());
 
+    std::unordered_map<std::string_view, std::size_t> mruRanks;
+    if (useMru) {
+      mruRanks.reserve(mruKeys.size());
+      for (std::size_t i = 0; i < mruKeys.size(); ++i) {
+        mruRanks.try_emplace(mruKeys[i], i);
+      }
+    }
+
     auto addCandidate = [&](WindowSwitcherCandidate candidate, const std::string& key) {
       if (key.empty() || seenKeys.contains(key)) {
         return;
       }
       seenKeys.insert(key);
+
+      if (useMru) {
+        const std::string idKey = identityKeyForEntry(candidate.entry);
+        if (auto it = mruRanks.find(idKey); it != mruRanks.end()) {
+          candidate.mruIndex = it->second;
+        }
+      }
       candidates.push_back(std::move(candidate));
     };
 
@@ -391,7 +419,23 @@ namespace {
       addCandidate(std::move(candidate), key);
     }
 
+    std::optional<std::string> focusedKey;
+    if (focusedId.has_value()) {
+      focusedKey = canonicalWindowId(*focusedId);
+      if (focusedKey->empty()) {
+        focusedKey = *focusedId;
+      }
+    }
+    if (!focusedKey.has_value()) {
+      if (const auto active = platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
+        focusedKey = "handle:" + std::to_string(reinterpret_cast<std::uintptr_t>(active->handle));
+      }
+    }
+
     std::ranges::stable_sort(candidates, [](const WindowSwitcherCandidate& a, const WindowSwitcherCandidate& b) {
+      if (a.mruIndex != b.mruIndex) {
+        return a.mruIndex < b.mruIndex;
+      }
       if (a.workspaceKey != b.workspaceKey) {
         return a.workspaceKey < b.workspaceKey;
       }
@@ -411,14 +455,6 @@ namespace {
 
     out.clear();
     out.reserve(candidates.size());
-
-    std::optional<std::string> focusedKey;
-    if (focusedId.has_value()) {
-      focusedKey = canonicalWindowId(*focusedId);
-      if (focusedKey->empty()) {
-        focusedKey = *focusedId;
-      }
-    }
 
     if (focusedKey.has_value()) {
       for (auto it = candidates.begin(); it != candidates.end(); ++it) {
@@ -577,8 +613,33 @@ void WindowSwitcher::onOutputChange() {
   }
 }
 
+void WindowSwitcher::recordFocusedWindow() {
+  if (m_platform == nullptr) {
+    return;
+  }
+  const bool useMru = (m_config != nullptr) ? m_config->config().shell.windowSwitcher.mru : false;
+  if (useMru) {
+    promoteMruKey(currentFocusedWindowKey(*m_platform));
+  }
+}
+
+void WindowSwitcher::promoteMruKey(const std::string& key) {
+  if (key.empty()) {
+    return;
+  }
+  auto it = std::ranges::find(m_mruKeys, key);
+  if (it != m_mruKeys.end()) {
+    if (it != m_mruKeys.begin()) {
+      std::rotate(m_mruKeys.begin(), it, it + 1);
+    }
+  } else {
+    m_mruKeys.insert(m_mruKeys.begin(), key);
+  }
+}
+
 void WindowSwitcher::onToplevelChange() {
   if (!m_active) {
+    recordFocusedWindow();
     return;
   }
   const std::size_t previousCount = m_windows.size();
@@ -595,6 +656,9 @@ void WindowSwitcher::show(wl_output* output) {
   }
 
   const bool wasActive = m_active;
+  if (!wasActive) {
+    recordFocusedWindow();
+  }
   refreshWindows();
 
   m_output = output;
@@ -640,9 +704,25 @@ void WindowSwitcher::refreshWindows() {
     }
   }
 
+  const bool useMru = (m_config != nullptr) ? m_config->config().shell.windowSwitcher.mru : false;
+
   IconResolver iconResolver;
   const int iconSize = 96;
-  buildWindowEntries(*m_platform, iconResolver, iconSize, m_windows, m_platform->focusedCompositorWindowId());
+  buildWindowEntries(
+      *m_platform, iconResolver, iconSize, m_windows, m_platform->focusedCompositorWindowId(), useMru, m_mruKeys
+  );
+
+  if (useMru) {
+    std::unordered_set<std::string> currentKeys;
+    currentKeys.reserve(m_windows.size());
+    for (const auto& entry : m_windows) {
+      const std::string k = identityKeyForEntry(entry);
+      if (!k.empty()) {
+        currentKeys.insert(k);
+      }
+    }
+    std::erase_if(m_mruKeys, [&](const std::string& k) { return !currentKeys.contains(k); });
+  }
 
   if (selectedKey.has_value()) {
     for (std::size_t i = 0; i < m_windows.size(); ++i) {
@@ -704,10 +784,11 @@ void WindowSwitcher::activateSelected() {
   if (m_platform == nullptr || m_windows.empty() || m_selectedIndex >= m_windows.size()) {
     return;
   }
+  const WindowSwitcherEntry entry = m_windows[m_selectedIndex];
+  promoteMruKey(identityKeyForEntry(entry));
   // Hyprland ignores zwlr_foreign_toplevel_handle_v1.activate while an exclusive
   // keyboard layer-shell surface is mapped (hyprwm/Hyprland#4829). Snapshot the
   // selection, tear the overlay down, then activate on the next loop tick.
-  const WindowSwitcherEntry entry = m_windows[m_selectedIndex];
   CompositorPlatform* platform = m_platform;
   hide();
   DeferredCall::callLater([platform, entry]() { activateWindowSwitcherEntry(*platform, entry); });

--- a/src/shell/switcher/window_switcher.h
+++ b/src/shell/switcher/window_switcher.h
@@ -56,6 +56,7 @@ private:
   void buildScene(Instance& instance, std::uint32_t width, std::uint32_t height);
   void positionGrid(Instance& instance, float screenW, float screenH);
   void syncGridSelection();
+  [[nodiscard]] bool mruEnabled() const;
   void recordFocusedWindow();
   void promoteMruKey(const std::string& key);
 

--- a/src/shell/switcher/window_switcher.h
+++ b/src/shell/switcher/window_switcher.h
@@ -4,6 +4,7 @@
 #include "wayland/wayland_seat.h"
 
 #include <cstddef>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <string>
@@ -55,6 +56,8 @@ private:
   void buildScene(Instance& instance, std::uint32_t width, std::uint32_t height);
   void positionGrid(Instance& instance, float screenW, float screenH);
   void syncGridSelection();
+  void recordFocusedWindow();
+  void promoteMruKey(const std::string& key);
 
   WaylandConnection* m_wayland = nullptr;
   RenderContext* m_renderContext = nullptr;
@@ -64,6 +67,7 @@ private:
 
   Instance* m_instance = nullptr;
   std::vector<WindowSwitcherEntry> m_windows;
+  std::deque<std::string> m_mruKeys;
   std::size_t m_selectedIndex = 0;
   std::size_t m_gridColumns = 5;
   wl_output* m_output = nullptr;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added Most Recently Used (MRU) window sorting support to `WindowSwitcher` when `shell.windowSwitcher.mru` is enabled.

<!-- What changed and why? -->

## Motivation

<!-- What problem does this solve? -->
Previously, `WindowSwitcher` sorted windows strictly by workspace position, layout coordinates, and window title. When working across multiple windows or workspaces, users commonly expect standard MRU behavior where pressing Alt+Tab quickly alternates between the current and most recently used window.

In my vision, MRU based algorithm for window switcher makes more sense given the workflow I'm used to on Windows and macOS.

_tldr_: This change introduces optional MRU cycling while keeping the switcher responsive and performant.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #4103 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Unit tests were run, with all passing. `just format` command was run before commits too.
For manual verification, I toggled the option inside shell->window switcher->MRU configuration and tried messing with ALT+TAB and both new MRU and old algorithm worked as expected.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
Besides tests only occurred on Hyprland, the code added was meant to be compositor agnostic, creating an MRU list in 'window_switcher.cpp`, so I think it will not be a problem for the other ones
