### PR TITLE
feat(widgets/bluetooth): Add option to hide widget when adapter is off

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3547,7 +3547,7 @@
         },
         "hide-when-adapter-off": {
           "description": "Hide the Bluetooth widget when adapter is powered off",
-          "label": "Hide When Off"
+          "label": "Hide When Adapter Off"
         },
         "hide-when-empty": {
           "description": "Hide workspace pills when there are no open windows",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3545,6 +3545,10 @@
           "description": "Hide tray items whose StatusNotifierItem status is Passive",
           "label": "Hide Passive Items"
         },
+        "hide-when-adapter-off": {
+          "description": "Hide the Bluetooth widget when adapter is powered off",
+          "label": "Hide When Off"
+        },
         "hide-when-empty": {
           "description": "Hide workspace pills when there are no open windows",
           "label": "Hide When Empty",

--- a/docs/user/bar/widgets/bluetooth.mdx
+++ b/docs/user/bar/widgets/bluetooth.mdx
@@ -10,6 +10,7 @@ Shows the Bluetooth adapter state and connected device. Left-click opens the Blu
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `show_label` | bool | `false` | Show the connected device name next to the icon |
+| `hide_when_adapter_off` | bool | `false` | Hide the widget when Bluetooth is disabled |
 | `hide_when_no_connected_device` | bool | `false` | Hide the widget when no Bluetooth device is connected. |
 
 ```toml

--- a/docs/user/bar/widgets/bluetooth.mdx
+++ b/docs/user/bar/widgets/bluetooth.mdx
@@ -10,7 +10,7 @@ Shows the Bluetooth adapter state and connected device. Left-click opens the Blu
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `show_label` | bool | `false` | Show the connected device name next to the icon |
-| `hide_when_adapter_off` | bool | `false` | Hide the widget when Bluetooth is disabled |
+| `hide_when_adapter_off` | bool | `false` | Hide the widget when the adapter is powered off. While hidden, the widget's right-click power toggle is unavailable; re-enable Bluetooth from the control center. |
 | `hide_when_no_connected_device` | bool | `false` | Hide the widget when no Bluetooth device is connected. |
 
 ```toml

--- a/src/shell/bar/widgets/bluetooth_widget.cpp
+++ b/src/shell/bar/widgets/bluetooth_widget.cpp
@@ -45,7 +45,7 @@ namespace {
 } // namespace
 
 BluetoothWidget::BluetoothWidget(BluetoothService* bluetooth, wl_output* /*output*/, Options options)
-    : m_bluetooth(bluetooth), m_showLabel(options.showLabel),
+    : m_bluetooth(bluetooth), m_showLabel(options.showLabel), m_hideWhenAdapterOff(options.hideWhenAdapterOff),
       m_hideWhenNoConnectedDevice(options.hideWhenNoConnectedDevice) {}
 
 void BluetoothWidget::create() {
@@ -128,7 +128,8 @@ void BluetoothWidget::syncState(Renderer& renderer) {
   m_lastConnectedAlias = alias;
 
   const bool hasConnectedDevice = numConnected > 0;
-  const bool showWidget = s.adapterPresent && (!m_hideWhenNoConnectedDevice || hasConnectedDevice);
+  const bool showWidget =
+      s.adapterPresent && (!m_hideWhenAdapterOff || s.powered) && (!m_hideWhenNoConnectedDevice || hasConnectedDevice);
   syncWidgetVisibility(showWidget);
   if (!showWidget) {
     if (Node* rootNode = root(); rootNode != nullptr) {

--- a/src/shell/bar/widgets/bluetooth_widget.h
+++ b/src/shell/bar/widgets/bluetooth_widget.h
@@ -13,6 +13,7 @@ class BluetoothWidget : public Widget {
 public:
   struct Options {
     bool showLabel = false;
+    bool hideWhenAdapterOff = false;
     bool hideWhenNoConnectedDevice = false;
   };
 
@@ -28,6 +29,7 @@ private:
 
   BluetoothService* m_bluetooth = nullptr;
   bool m_showLabel = false;
+  bool m_hideWhenAdapterOff = false;
   bool m_hideWhenNoConnectedDevice = false;
   Glyph* m_glyph = nullptr;
   Label* m_label = nullptr;

--- a/src/shell/bar/widgets/bluetooth_widget_definition.cpp
+++ b/src/shell/bar/widgets/bluetooth_widget_definition.cpp
@@ -1,5 +1,17 @@
 #include "shell/bar/widgets/bluetooth_widget_definition.h"
 
+namespace {
+
+  // A powered-off adapter has no connected device, so hiding on "no connected device"
+  // already covers the adapter-off case and makes this toggle inert.
+  settings::WidgetSettingVisibility connectedDeviceFilterOff() {
+    settings::WidgetSettingVisibility visibility;
+    visibility.all = {{"hide_when_no_connected_device", {"false"}}};
+    return visibility;
+  }
+
+} // namespace
+
 const noctalia::bar::WidgetDefinition<BluetoothWidget::Options>& bluetoothWidgetDefinition() {
   using noctalia::bar::field;
   using Options = BluetoothWidget::Options;
@@ -12,6 +24,10 @@ const noctalia::bar::WidgetDefinition<BluetoothWidget::Options>& bluetoothWidget
           }),
           field<&Options::hideWhenAdapterOff>({
               .key = "hide_when_adapter_off",
+              .presentation =
+                  settings::WidgetSettingPresentation{
+                      .visibleWhen = connectedDeviceFilterOff(),
+                  },
           }),
           field<&Options::hideWhenNoConnectedDevice>({
               .key = "hide_when_no_connected_device",

--- a/src/shell/bar/widgets/bluetooth_widget_definition.cpp
+++ b/src/shell/bar/widgets/bluetooth_widget_definition.cpp
@@ -10,6 +10,9 @@ const noctalia::bar::WidgetDefinition<BluetoothWidget::Options>& bluetoothWidget
           field<&Options::showLabel>({
               .key = "show_label",
           }),
+          field<&Options::hideWhenAdapterOff>({
+              .key = "hide_when_adapter_off",
+          }),
           field<&Options::hideWhenNoConnectedDevice>({
               .key = "hide_when_no_connected_device",
           }),


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This adds a new `hide_when_adapter_off` option to the Bluetooth widget, which hides the Bluetooth widget when the adapter is powered off.

## Motivation

I almost always have Bluetooth disabled, so the bluetooth widget is usually just dead space on my bar. The existing `hide_when_no_connected_device` option is good, but I also want to see the widget if the bluetooth adapter was left powered on, whether or not any device is connected. This helps me remember to disable it when not used anymore, saving on battery.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

<!--## Related Issue-->

<!-- Example: Closes #123 -->

## Testing

I added to my config:

```toml
[widget.bluetooth]
hide_when_adapter_off = true
```

Then test by going to control center and toggling bluetooth on and off: I can observe that the bluetooth widget disappears when off, and reappears when turned back on.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

<img width="795" height="672" alt="image" src="https://github.com/user-attachments/assets/7eacd702-c7ad-427b-83c4-8c421ce97db3" />

<img width="795" height="672" alt="image" src="https://github.com/user-attachments/assets/11600903-f09f-4aad-b14d-12ac297f62c7" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

<!--## Additional Notes-->

<!-- Add follow-up notes, reviewer context, or known limitations. -->
