### PR TITLE
feat(weather): apparent temperature

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -122,6 +122,7 @@
         "off": "Weather off",
         "tooltip": {
           "condition": "Condition",
+          "feels-like": "Feels like",
           "high": "High",
           "humidity": "Humidity",
           "low": "Low",
@@ -423,10 +424,10 @@
       "data-unavailable": "Weather data unavailable",
       "details": {
         "elevation": "Elevation",
+        "feels-like": "Feels Like",
         "sunrise": "Sunrise",
         "sunset": "Sunset",
-        "temp-max": "Temperature Max",
-        "temp-min": "Temperature Min",
+        "temp-range": "Temperature Range",
         "timezone": "Timezone",
         "uv-index": "UV Index",
         "wind": "Wind"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -122,7 +122,7 @@
         "off": "Weather off",
         "tooltip": {
           "condition": "Condition",
-          "feels-like": "Feels like",
+          "feels-like": "Feels Like",
           "high": "High",
           "humidity": "Humidity",
           "low": "Low",
@@ -427,7 +427,8 @@
         "feels-like": "Feels Like",
         "sunrise": "Sunrise",
         "sunset": "Sunset",
-        "temp-range": "Temperature Range",
+        "temp-max": "Temperature Max",
+        "temp-min": "Temperature Min",
         "timezone": "Timezone",
         "uv-index": "UV Index",
         "wind": "Wind"

--- a/src/shell/bar/widgets/weather_widget.cpp
+++ b/src/shell/bar/widgets/weather_widget.cpp
@@ -169,8 +169,7 @@ void WeatherWidget::sync(Renderer& renderer) {
   const std::string windUnit = imperial ? "mph" : "km/h";
 
   const int currentTemp = static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.temperatureC)));
-  const int feelsLikeTemp =
-      static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.apparentTemperatureC)));
+  const auto& apparentTemp = snapshot.current.apparentTemperatureC;
   const double displayWind = imperial ? snapshot.current.windSpeedKmh * 0.621371 : snapshot.current.windSpeedKmh;
 
   std::vector<TooltipRow> rows;
@@ -179,7 +178,12 @@ void WeatherWidget::sync(Renderer& renderer) {
        WeatherService::shortDescriptionForCode(snapshot.current.weatherCode)}
   );
   rows.push_back({i18n::tr("bar.widgets.weather.tooltip.temperature"), std::format("{}{}", currentTemp, tempUnit)});
-  rows.push_back({i18n::tr("bar.widgets.weather.tooltip.feels-like"), std::format("{}{}", feelsLikeTemp, tempUnit)});
+  if (apparentTemp.has_value()) {
+    rows.push_back(
+        {i18n::tr("bar.widgets.weather.tooltip.feels-like"),
+         std::format("{}{}", static_cast<int>(std::lround(m_weather->displayTemperature(*apparentTemp))), tempUnit)}
+    );
+  }
 
   if (!snapshot.forecastDays.empty()) {
     const auto& today = snapshot.forecastDays.front();

--- a/src/shell/bar/widgets/weather_widget.cpp
+++ b/src/shell/bar/widgets/weather_widget.cpp
@@ -169,6 +169,8 @@ void WeatherWidget::sync(Renderer& renderer) {
   const std::string windUnit = imperial ? "mph" : "km/h";
 
   const int currentTemp = static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.temperatureC)));
+  const int feelsLikeTemp =
+      static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.apparentTemperatureC)));
   const double displayWind = imperial ? snapshot.current.windSpeedKmh * 0.621371 : snapshot.current.windSpeedKmh;
 
   std::vector<TooltipRow> rows;
@@ -177,6 +179,7 @@ void WeatherWidget::sync(Renderer& renderer) {
        WeatherService::shortDescriptionForCode(snapshot.current.weatherCode)}
   );
   rows.push_back({i18n::tr("bar.widgets.weather.tooltip.temperature"), std::format("{}{}", currentTemp, tempUnit)});
+  rows.push_back({i18n::tr("bar.widgets.weather.tooltip.feels-like"), std::format("{}{}", feelsLikeTemp, tempUnit)});
 
   if (!snapshot.forecastDays.empty()) {
     const auto& today = snapshot.forecastDays.front();

--- a/src/shell/control_center/tabs/weather_tab.cpp
+++ b/src/shell/control_center/tabs/weather_tab.cpp
@@ -254,8 +254,8 @@ std::unique_ptr<Flex> WeatherTab::create() {
     return rowPtr;
   };
 
-  addDetailRow("temperature", i18n::tr("control-center.weather.details.temp-min"), m_tempMinLabel);
-  addDetailRow("temperature-sun", i18n::tr("control-center.weather.details.temp-max"), m_tempMaxLabel);
+  addDetailRow("temperature", i18n::tr("control-center.weather.details.temp-range"), m_tempRangeLabel);
+  addDetailRow("thermometer", i18n::tr("control-center.weather.details.feels-like"), m_feelsLikeLabel);
   addDetailRow("wind", i18n::tr("control-center.weather.details.wind"), m_windLabel);
   addDetailRow("weather-sunrise", i18n::tr("control-center.weather.details.sunrise"), m_sunriseLabel);
   addDetailRow("weather-sunset", i18n::tr("control-center.weather.details.sunset"), m_sunsetLabel);
@@ -523,8 +523,8 @@ void WeatherTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeig
     m_statusLabel->setMaxWidth(leftColumnWidth);
   }
   for (auto* label :
-       {m_windLabel, m_sunriseLabel, m_sunsetLabel, m_tempMinLabel, m_tempMaxLabel, m_elevationLabel, m_uvIndexLabel,
-        m_timeZoneLabel}) {
+       {m_windLabel, m_sunriseLabel, m_sunsetLabel, m_tempRangeLabel, m_feelsLikeLabel, m_elevationLabel,
+        m_uvIndexLabel, m_timeZoneLabel}) {
     if (label != nullptr) {
       label->setMaxWidth(leftColumnWidth);
     }
@@ -726,8 +726,8 @@ void WeatherTab::onClose() {
   m_windLabel = nullptr;
   m_sunriseLabel = nullptr;
   m_sunsetLabel = nullptr;
-  m_tempMaxLabel = nullptr;
-  m_tempMinLabel = nullptr;
+  m_tempRangeLabel = nullptr;
+  m_feelsLikeLabel = nullptr;
   m_elevationLabel = nullptr;
   m_uvIndexLabel = nullptr;
   m_timeZoneLabel = nullptr;
@@ -785,11 +785,11 @@ void WeatherTab::sync(Renderer& renderer) {
     if (m_sunsetLabel != nullptr) {
       m_sunsetLabel->setText("--");
     }
-    if (m_tempMaxLabel != nullptr) {
-      m_tempMaxLabel->setText("--");
+    if (m_tempRangeLabel != nullptr) {
+      m_tempRangeLabel->setText("--");
     }
-    if (m_tempMinLabel != nullptr) {
-      m_tempMinLabel->setText("--");
+    if (m_feelsLikeLabel != nullptr) {
+      m_feelsLikeLabel->setText("--");
     }
     if (m_elevationLabel != nullptr) {
       m_elevationLabel->setText("--");
@@ -816,11 +816,11 @@ void WeatherTab::sync(Renderer& renderer) {
     if (m_sunsetLabel != nullptr) {
       m_sunsetLabel->setText("--");
     }
-    if (m_tempMaxLabel != nullptr) {
-      m_tempMaxLabel->setText("--");
+    if (m_tempRangeLabel != nullptr) {
+      m_tempRangeLabel->setText("--");
     }
-    if (m_tempMinLabel != nullptr) {
-      m_tempMinLabel->setText("--");
+    if (m_feelsLikeLabel != nullptr) {
+      m_feelsLikeLabel->setText("--");
     }
     if (m_elevationLabel != nullptr) {
       m_elevationLabel->setText("--");
@@ -862,11 +862,11 @@ void WeatherTab::sync(Renderer& renderer) {
     if (m_sunsetLabel != nullptr) {
       m_sunsetLabel->setText("--");
     }
-    if (m_tempMaxLabel != nullptr) {
-      m_tempMaxLabel->setText("--");
+    if (m_tempRangeLabel != nullptr) {
+      m_tempRangeLabel->setText("--");
     }
-    if (m_tempMinLabel != nullptr) {
-      m_tempMinLabel->setText("--");
+    if (m_feelsLikeLabel != nullptr) {
+      m_feelsLikeLabel->setText("--");
     }
     if (m_elevationLabel != nullptr) {
       m_elevationLabel->setText("--");
@@ -947,23 +947,23 @@ void WeatherTab::sync(Renderer& renderer) {
     );
   }
   auto unit = m_weather->displayTemperatureUnit();
-  if (m_tempMaxLabel != nullptr) {
+  if (m_tempRangeLabel != nullptr) {
     if (!snapshot.forecastDays.empty()) {
-      const int temp =
-          static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.forecastDays.front().temperatureMaxC)));
-      m_tempMaxLabel->setText(std::format("{}{}", temp, unit));
+      const auto& today = snapshot.forecastDays.front();
+      const int tempMin = static_cast<int>(std::lround(m_weather->displayTemperature(today.temperatureMinC)));
+      const int tempMax = static_cast<int>(std::lround(m_weather->displayTemperature(today.temperatureMaxC)));
+      m_tempRangeLabel->setText(std::format("{}{} / {}{}", tempMin, unit, tempMax, unit));
     } else {
-      m_tempMaxLabel->setText("--");
+      m_tempRangeLabel->setText("--");
     }
   }
-  if (m_tempMinLabel != nullptr) {
-    if (!snapshot.forecastDays.empty()) {
-      const int temp =
-          static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.forecastDays.front().temperatureMinC)));
-      m_tempMinLabel->setText(std::format("{}{}", temp, unit));
-    } else {
-      m_tempMinLabel->setText("--");
-    }
+  if (m_feelsLikeLabel != nullptr) {
+    m_feelsLikeLabel->setText(
+        std::format(
+            "{}{}", static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.apparentTemperatureC))),
+            unit
+        )
+    );
   }
   if (m_elevationLabel != nullptr) {
     const bool imperial = m_weather->useImperial();

--- a/src/shell/control_center/tabs/weather_tab.cpp
+++ b/src/shell/control_center/tabs/weather_tab.cpp
@@ -38,7 +38,6 @@ namespace {
 } // namespace
 
 WeatherTab::WeatherTab(WeatherService* weather, ConfigService* config) : m_weather(weather), m_config(config) {
-  m_detailRows.fill(nullptr);
   m_forecastRows.fill(nullptr);
   m_forecastSeparators.fill(nullptr);
   m_forecastIconSlots.fill(nullptr);
@@ -204,26 +203,23 @@ std::unique_ptr<Flex> WeatherTab::create() {
       .gap = 0.0F,
       .configure = [scale, opacity = panelCardOpacity()](Flex& card) {
         applySectionCardStyle(card, scale, opacity);
-        card.setPadding(Style::spaceMd * scale, Style::spaceMd * scale, Style::spaceLg * scale, Style::spaceMd * scale);
+        card.setPadding(Style::spaceMd * scale);
         card.setGap(0.0F);
       },
   });
   const float detailKeyWidth = Style::controlHeightLg * 2.0F * scale;
+  // Detail rows are label/value pairs, not touch targets: they size to the text plus a small
+  // margin around the row glyph, not to a control height.
+  const float detailRowHeight = (Style::fontSizeBody + Style::spaceMd) * scale;
 
-  std::size_t detailRowIndex = 0;
   auto addDetailRow = [&](std::string_view iconName, std::string_view key, Label*& valueOut) -> Flex* {
     auto row = ui::row({
         .align = FlexAlign::Center,
         .gap = (Style::spaceSm + Style::spaceXs) * scale,
-        .minHeight = Style::controlHeightSm * scale,
+        .minHeight = detailRowHeight,
         .flexGrow = 0.0F,
     });
     Flex* rowPtr = row.get();
-    if (detailRowIndex < kDetailRowCount) {
-      m_detailRows[detailRowIndex] = rowPtr;
-    }
-    ++detailRowIndex;
-
     row->addChild(
         ui::glyph({
             .glyph = std::string(iconName),
@@ -254,8 +250,9 @@ std::unique_ptr<Flex> WeatherTab::create() {
     return rowPtr;
   };
 
-  addDetailRow("temperature", i18n::tr("control-center.weather.details.temp-range"), m_tempRangeLabel);
   addDetailRow("thermometer", i18n::tr("control-center.weather.details.feels-like"), m_feelsLikeLabel);
+  addDetailRow("temperature", i18n::tr("control-center.weather.details.temp-min"), m_tempMinLabel);
+  addDetailRow("temperature-sun", i18n::tr("control-center.weather.details.temp-max"), m_tempMaxLabel);
   addDetailRow("wind", i18n::tr("control-center.weather.details.wind"), m_windLabel);
   addDetailRow("weather-sunrise", i18n::tr("control-center.weather.details.sunrise"), m_sunriseLabel);
   addDetailRow("weather-sunset", i18n::tr("control-center.weather.details.sunset"), m_sunsetLabel);
@@ -523,7 +520,7 @@ void WeatherTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeig
     m_statusLabel->setMaxWidth(leftColumnWidth);
   }
   for (auto* label :
-       {m_windLabel, m_sunriseLabel, m_sunsetLabel, m_tempRangeLabel, m_feelsLikeLabel, m_elevationLabel,
+       {m_feelsLikeLabel, m_tempMinLabel, m_tempMaxLabel, m_windLabel, m_sunriseLabel, m_sunsetLabel, m_elevationLabel,
         m_uvIndexLabel, m_timeZoneLabel}) {
     if (label != nullptr) {
       label->setMaxWidth(leftColumnWidth);
@@ -544,16 +541,6 @@ void WeatherTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeig
     const float desiredGlyph =
         std::max(Style::controlHeightLg * 1.8F * scale, std::min(kCurrentGlyphSize * scale, cardInnerHeight * 0.8F));
     m_currentGlyph->setGlyphSize(desiredGlyph);
-  }
-
-  if (m_detailsCard != nullptr) {
-    const float rowMinHeight = Style::controlHeightSm * scale;
-    for (auto* row : m_detailRows) {
-      if (row != nullptr) {
-        row->setMinHeight(row->visible() ? rowMinHeight : 0.0F);
-        row->setFlexGrow(0.0F);
-      }
-    }
   }
 
   std::size_t visibleForecastDays = 0;
@@ -726,13 +713,13 @@ void WeatherTab::onClose() {
   m_windLabel = nullptr;
   m_sunriseLabel = nullptr;
   m_sunsetLabel = nullptr;
-  m_tempRangeLabel = nullptr;
+  m_tempMaxLabel = nullptr;
+  m_tempMinLabel = nullptr;
   m_feelsLikeLabel = nullptr;
   m_elevationLabel = nullptr;
   m_uvIndexLabel = nullptr;
   m_timeZoneLabel = nullptr;
   m_timeZoneRow = nullptr;
-  m_detailRows.fill(nullptr);
   m_forecastRows.fill(nullptr);
   m_forecastSeparators.fill(nullptr);
   m_forecastIconSlots.fill(nullptr);
@@ -785,8 +772,11 @@ void WeatherTab::sync(Renderer& renderer) {
     if (m_sunsetLabel != nullptr) {
       m_sunsetLabel->setText("--");
     }
-    if (m_tempRangeLabel != nullptr) {
-      m_tempRangeLabel->setText("--");
+    if (m_tempMaxLabel != nullptr) {
+      m_tempMaxLabel->setText("--");
+    }
+    if (m_tempMinLabel != nullptr) {
+      m_tempMinLabel->setText("--");
     }
     if (m_feelsLikeLabel != nullptr) {
       m_feelsLikeLabel->setText("--");
@@ -816,8 +806,11 @@ void WeatherTab::sync(Renderer& renderer) {
     if (m_sunsetLabel != nullptr) {
       m_sunsetLabel->setText("--");
     }
-    if (m_tempRangeLabel != nullptr) {
-      m_tempRangeLabel->setText("--");
+    if (m_tempMaxLabel != nullptr) {
+      m_tempMaxLabel->setText("--");
+    }
+    if (m_tempMinLabel != nullptr) {
+      m_tempMinLabel->setText("--");
     }
     if (m_feelsLikeLabel != nullptr) {
       m_feelsLikeLabel->setText("--");
@@ -862,8 +855,11 @@ void WeatherTab::sync(Renderer& renderer) {
     if (m_sunsetLabel != nullptr) {
       m_sunsetLabel->setText("--");
     }
-    if (m_tempRangeLabel != nullptr) {
-      m_tempRangeLabel->setText("--");
+    if (m_tempMaxLabel != nullptr) {
+      m_tempMaxLabel->setText("--");
+    }
+    if (m_tempMinLabel != nullptr) {
+      m_tempMinLabel->setText("--");
     }
     if (m_feelsLikeLabel != nullptr) {
       m_feelsLikeLabel->setText("--");
@@ -947,23 +943,31 @@ void WeatherTab::sync(Renderer& renderer) {
     );
   }
   auto unit = m_weather->displayTemperatureUnit();
-  if (m_tempRangeLabel != nullptr) {
+  if (m_feelsLikeLabel != nullptr) {
+    const auto& apparent = snapshot.current.apparentTemperatureC;
+    m_feelsLikeLabel->setText(
+        apparent.has_value()
+            ? std::format("{}{}", static_cast<int>(std::lround(m_weather->displayTemperature(*apparent))), unit)
+            : std::string("--")
+    );
+  }
+  if (m_tempMinLabel != nullptr) {
     if (!snapshot.forecastDays.empty()) {
-      const auto& today = snapshot.forecastDays.front();
-      const int tempMin = static_cast<int>(std::lround(m_weather->displayTemperature(today.temperatureMinC)));
-      const int tempMax = static_cast<int>(std::lround(m_weather->displayTemperature(today.temperatureMaxC)));
-      m_tempRangeLabel->setText(std::format("{}{} / {}{}", tempMin, unit, tempMax, unit));
+      const int temp =
+          static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.forecastDays.front().temperatureMinC)));
+      m_tempMinLabel->setText(std::format("{}{}", temp, unit));
     } else {
-      m_tempRangeLabel->setText("--");
+      m_tempMinLabel->setText("--");
     }
   }
-  if (m_feelsLikeLabel != nullptr) {
-    m_feelsLikeLabel->setText(
-        std::format(
-            "{}{}", static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.apparentTemperatureC))),
-            unit
-        )
-    );
+  if (m_tempMaxLabel != nullptr) {
+    if (!snapshot.forecastDays.empty()) {
+      const int temp =
+          static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.forecastDays.front().temperatureMaxC)));
+      m_tempMaxLabel->setText(std::format("{}{}", temp, unit));
+    } else {
+      m_tempMaxLabel->setText("--");
+    }
   }
   if (m_elevationLabel != nullptr) {
     const bool imperial = m_weather->useImperial();

--- a/src/shell/control_center/tabs/weather_tab.h
+++ b/src/shell/control_center/tabs/weather_tab.h
@@ -50,7 +50,7 @@ private:
   [[nodiscard]] static EffectType effectForWeatherCode(std::int32_t code, bool isDay);
 
   static constexpr std::size_t kForecastRowCount = 7;
-  static constexpr std::size_t kDetailRowCount = 7;
+  static constexpr std::size_t kDetailRowCount = 8;
 
   WeatherService* m_weather = nullptr;
   ConfigService* m_config = nullptr;
@@ -75,8 +75,8 @@ private:
   Label* m_windLabel = nullptr;
   Label* m_sunriseLabel = nullptr;
   Label* m_sunsetLabel = nullptr;
-  Label* m_tempMaxLabel = nullptr;
-  Label* m_tempMinLabel = nullptr;
+  Label* m_tempRangeLabel = nullptr;
+  Label* m_feelsLikeLabel = nullptr;
   Label* m_elevationLabel = nullptr;
   Label* m_timeZoneLabel = nullptr;
   Flex* m_timeZoneRow = nullptr;

--- a/src/shell/control_center/tabs/weather_tab.h
+++ b/src/shell/control_center/tabs/weather_tab.h
@@ -50,7 +50,6 @@ private:
   [[nodiscard]] static EffectType effectForWeatherCode(std::int32_t code, bool isDay);
 
   static constexpr std::size_t kForecastRowCount = 7;
-  static constexpr std::size_t kDetailRowCount = 8;
 
   WeatherService* m_weather = nullptr;
   ConfigService* m_config = nullptr;
@@ -75,13 +74,13 @@ private:
   Label* m_windLabel = nullptr;
   Label* m_sunriseLabel = nullptr;
   Label* m_sunsetLabel = nullptr;
-  Label* m_tempRangeLabel = nullptr;
+  Label* m_tempMaxLabel = nullptr;
+  Label* m_tempMinLabel = nullptr;
   Label* m_feelsLikeLabel = nullptr;
   Label* m_elevationLabel = nullptr;
   Label* m_timeZoneLabel = nullptr;
   Flex* m_timeZoneRow = nullptr;
   Label* m_uvIndexLabel = nullptr;
-  std::array<Flex*, kDetailRowCount> m_detailRows{};
   std::array<Flex*, kForecastRowCount> m_forecastRows{};
   std::array<Separator*, kForecastRowCount - 1> m_forecastSeparators{};
   std::array<Flex*, kForecastRowCount> m_forecastIconSlots{};

--- a/src/system/weather_service.cpp
+++ b/src/system/weather_service.cpp
@@ -500,7 +500,8 @@ void WeatherService::startWeatherFetch() {
   const auto path = transportCacheDir() / "forecast.json";
   const std::string url = std::format(
       "https://api.open-meteo.com/v1/forecast?latitude={}&longitude={}"
-      "&current=temperature_2m,wind_speed_10m,wind_direction_10m,weather_code,is_day,uv_index,relative_humidity_2m"
+      "&current=temperature_2m,apparent_temperature,wind_speed_10m,wind_direction_10m,weather_code,is_day,uv_index,"
+      "relative_humidity_2m"
       "&hourly=temperature_2m,relative_humidity_2m,precipitation_probability,weather_code,is_day,wind_speed_10m"
       "&daily=temperature_2m_max,temperature_2m_min,weather_code,sunrise,sunset"
       "&forecast_days={}&forecast_hours={}&timezone=auto",
@@ -593,6 +594,7 @@ void WeatherService::handleWeatherResponse(const std::filesystem::path& path, bo
     next.current.timeIso = readString(current, "time");
     next.current.intervalSeconds = readOptionalInt(current, "interval");
     next.current.temperatureC = readNumber(current, "temperature_2m");
+    next.current.apparentTemperatureC = readOptionalNumber(current, "apparent_temperature");
     next.current.windSpeedKmh = readOptionalNumber(current, "wind_speed_10m");
     next.current.windDirectionDeg = readOptionalInt(current, "wind_direction_10m");
     next.current.isDay = readBool(current, "is_day", true);
@@ -734,6 +736,7 @@ void WeatherService::loadCache() {
       m_snapshot.current.timeIso = readString(*it, "time_iso");
       m_snapshot.current.intervalSeconds = readOptionalInt(*it, "interval_seconds");
       m_snapshot.current.temperatureC = readOptionalNumber(*it, "temperature_c");
+      m_snapshot.current.apparentTemperatureC = readOptionalNumber(*it, "apparent_temperature_c");
       m_snapshot.current.windSpeedKmh = readOptionalNumber(*it, "wind_speed_kmh");
       m_snapshot.current.windDirectionDeg = readOptionalInt(*it, "wind_direction_deg");
       m_snapshot.current.isDay = readBool(*it, "is_day", true);
@@ -825,6 +828,7 @@ void WeatherService::saveCache() const {
                 {"time_iso", m_snapshot.current.timeIso},
                 {"interval_seconds", m_snapshot.current.intervalSeconds},
                 {"temperature_c", m_snapshot.current.temperatureC},
+                {"apparent_temperature_c", m_snapshot.current.apparentTemperatureC},
                 {"wind_speed_kmh", m_snapshot.current.windSpeedKmh},
                 {"wind_direction_deg", m_snapshot.current.windDirectionDeg},
                 {"is_day", m_snapshot.current.isDay},

--- a/src/system/weather_service.cpp
+++ b/src/system/weather_service.cpp
@@ -130,6 +130,14 @@ namespace {
     return it->get<double>();
   }
 
+  std::optional<double> findNumber(const nlohmann::json& json, const char* key) {
+    const auto it = json.find(key);
+    if (it == json.end() || !it->is_number()) {
+      return std::nullopt;
+    }
+    return it->get<double>();
+  }
+
   std::int32_t readInt(const nlohmann::json& json, const char* key) {
     const auto it = json.find(key);
     if (it == json.end() || !it->is_number_integer()) {
@@ -594,7 +602,7 @@ void WeatherService::handleWeatherResponse(const std::filesystem::path& path, bo
     next.current.timeIso = readString(current, "time");
     next.current.intervalSeconds = readOptionalInt(current, "interval");
     next.current.temperatureC = readNumber(current, "temperature_2m");
-    next.current.apparentTemperatureC = readOptionalNumber(current, "apparent_temperature");
+    next.current.apparentTemperatureC = findNumber(current, "apparent_temperature");
     next.current.windSpeedKmh = readOptionalNumber(current, "wind_speed_10m");
     next.current.windDirectionDeg = readOptionalInt(current, "wind_direction_10m");
     next.current.isDay = readBool(current, "is_day", true);
@@ -736,7 +744,7 @@ void WeatherService::loadCache() {
       m_snapshot.current.timeIso = readString(*it, "time_iso");
       m_snapshot.current.intervalSeconds = readOptionalInt(*it, "interval_seconds");
       m_snapshot.current.temperatureC = readOptionalNumber(*it, "temperature_c");
-      m_snapshot.current.apparentTemperatureC = readOptionalNumber(*it, "apparent_temperature_c");
+      m_snapshot.current.apparentTemperatureC = findNumber(*it, "apparent_temperature_c");
       m_snapshot.current.windSpeedKmh = readOptionalNumber(*it, "wind_speed_kmh");
       m_snapshot.current.windDirectionDeg = readOptionalInt(*it, "wind_direction_deg");
       m_snapshot.current.isDay = readBool(*it, "is_day", true);
@@ -828,7 +836,10 @@ void WeatherService::saveCache() const {
                 {"time_iso", m_snapshot.current.timeIso},
                 {"interval_seconds", m_snapshot.current.intervalSeconds},
                 {"temperature_c", m_snapshot.current.temperatureC},
-                {"apparent_temperature_c", m_snapshot.current.apparentTemperatureC},
+                {"apparent_temperature_c",
+                 m_snapshot.current.apparentTemperatureC.has_value()
+                     ? nlohmann::json(*m_snapshot.current.apparentTemperatureC)
+                     : nlohmann::json()},
                 {"wind_speed_kmh", m_snapshot.current.windSpeedKmh},
                 {"wind_direction_deg", m_snapshot.current.windDirectionDeg},
                 {"is_day", m_snapshot.current.isDay},

--- a/src/system/weather_service.h
+++ b/src/system/weather_service.h
@@ -48,7 +48,7 @@ struct WeatherCurrentConditions {
   std::string timeIso;
   std::int32_t intervalSeconds = 0;
   double temperatureC = 0.0;
-  double apparentTemperatureC = 0.0;
+  std::optional<double> apparentTemperatureC;
   double windSpeedKmh = 0.0;
   std::int32_t windDirectionDeg = 0;
   bool isDay = true;

--- a/src/system/weather_service.h
+++ b/src/system/weather_service.h
@@ -48,6 +48,7 @@ struct WeatherCurrentConditions {
   std::string timeIso;
   std::int32_t intervalSeconds = 0;
   double temperatureC = 0.0;
+  double apparentTemperatureC = 0.0;
   double windSpeedKmh = 0.0;
   std::int32_t windDirectionDeg = 0;
   bool isDay = true;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

I added the apparent (aka feels like) temperature to the weather panel.

I also collapsed `Min temperature` and `Max temperature` to a `Temperature range` so that we take up the same amount of space in the layout.

## Motivation

I wanted to have a feels like temperature on the weather panel. It helps me decide which one of my 2 t-shirts to wear for the day.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

I've tested using `just run` and then checked both the tool tip and the weather panel. I felt my eyes tear up as I glanced over the Feels Like temperature field. Why, do you ask? Because it's so darn hot.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="584" height="507" alt="image" src="https://github.com/user-attachments/assets/c255a9b4-c18c-48fb-bfd9-7e70869d9cfc" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
