### PR TITLE
fix(radios): allow backend activation despite reported rfkill hard block

### DIFF
--- a/src/dbus/bluetooth/bluetooth_service.cpp
+++ b/src/dbus/bluetooth/bluetooth_service.cpp
@@ -577,10 +577,10 @@ void BluetoothService::setPowered(bool enabled) {
   if (enabled) {
     const RfkillSwitchResult rfkillResult = setRfkillSoftBlocked(RfkillDeviceType::Bluetooth, false);
     if (rfkillResult.hardBlocked) {
-      kLog.warn("setPowered: bluetooth rfkill hard block is active");
-      return;
-    }
-    if (!rfkillResult.success) {
+      // Platform rfkill state can be stale; let BlueZ attempt activation while
+      // the kernel continues to enforce genuine hardware blocks.
+      kLog.warn("setPowered: bluetooth rfkill hard block reported, trying BlueZ Powered anyway");
+    } else if (!rfkillResult.success) {
       kLog.warn("setPowered: rfkill unblock failed ({}), trying BlueZ Powered anyway", rfkillResult.detail);
     }
     const bool wasSoftBlocked = m_state.rfkillSoftBlocked;

--- a/src/dbus/bluetooth/bluetooth_service.cpp
+++ b/src/dbus/bluetooth/bluetooth_service.cpp
@@ -132,7 +132,6 @@ namespace {
 
   void applyRfkillState(BluetoothState& out) {
     out.rfkillSoftBlocked = isRfkillSoftBlocked(RfkillDeviceType::Bluetooth);
-    out.rfkillHardBlocked = isRfkillHardBlocked(RfkillDeviceType::Bluetooth);
   }
 
   void readAdapterProps(const InterfaceProps& props, BluetoothState& out) {
@@ -489,9 +488,6 @@ void BluetoothService::registerIpc(IpcService& ipc, StateFeedbackCallback stateF
     if (!state().adapterPresent) {
       return "error: bluetooth adapter unavailable\n";
     }
-    if (enabled && state().rfkillHardBlocked) {
-      return "error: bluetooth adapter is rfkill hard-blocked\n";
-    }
     if (state().powered == enabled) {
       return "ok\n";
     }
@@ -577,10 +573,9 @@ void BluetoothService::setPowered(bool enabled) {
   if (enabled) {
     const RfkillSwitchResult rfkillResult = setRfkillSoftBlocked(RfkillDeviceType::Bluetooth, false);
     if (rfkillResult.hardBlocked) {
-      // Platform rfkill state can be stale; let BlueZ attempt activation while
-      // the kernel continues to enforce genuine hardware blocks.
-      kLog.warn("setPowered: bluetooth rfkill hard block reported, trying BlueZ Powered anyway");
-    } else if (!rfkillResult.success) {
+      kLog.warn("setPowered: bluetooth rfkill reports a hard block");
+    }
+    if (!rfkillResult.success) {
       kLog.warn("setPowered: rfkill unblock failed ({}), trying BlueZ Powered anyway", rfkillResult.detail);
     }
     const bool wasSoftBlocked = m_state.rfkillSoftBlocked;
@@ -812,7 +807,7 @@ BluetoothStateChangeOrigin BluetoothService::consumePoweredChangeOrigin(bool pow
 }
 
 void BluetoothService::scheduleAutoReconnect() {
-  if (!m_state.powered || m_state.rfkillHardBlocked) {
+  if (!m_state.powered) {
     return;
   }
   m_autoReconnectAttempt = 0;
@@ -831,7 +826,7 @@ void BluetoothService::armAutoReconnect() {
 }
 
 void BluetoothService::runAutoReconnectPass() {
-  if (!m_state.powered || m_state.rfkillHardBlocked) {
+  if (!m_state.powered) {
     return;
   }
   std::vector<std::string> pending;

--- a/src/dbus/bluetooth/bluetooth_service.h
+++ b/src/dbus/bluetooth/bluetooth_service.h
@@ -58,7 +58,6 @@ struct BluetoothState {
   bool powered = false;
   /// rfkill soft block (e.g. GDM/GNOME login screen) prevents powering on until cleared.
   bool rfkillSoftBlocked = false;
-  bool rfkillHardBlocked = false;
   bool discoverable = false;
   bool pairable = false;
   bool discovering = false;

--- a/src/dbus/network/iwd_service.cpp
+++ b/src/dbus/network/iwd_service.cpp
@@ -343,7 +343,6 @@ bool IwdService::activateAccessPoint(const AccessPointInfo& ap, const std::strin
 void IwdService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete) {
   const bool softBlocked = !enabled;
   bool rfkillDone = false;
-  bool hardBlocked = false;
   for (const auto& [stationPath, ifname] : m_deviceNames) {
     (void)stationPath;
     if (ifname.empty()) {
@@ -351,10 +350,7 @@ void IwdService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onCo
     }
     const RfkillSwitchResult result = setRfkillSoftBlockedForNetInterface(ifname, softBlocked);
     if (result.hardBlocked) {
-      kLog.warn("setWirelessEnabled: rfkill hard block on {}", ifname);
-      hardBlocked = enabled;
-      rfkillDone = !enabled;
-      break;
+      kLog.warn("setWirelessEnabled: rfkill reports a hard block on {}", ifname);
     }
     if (result.success) {
       rfkillDone = true;
@@ -365,10 +361,9 @@ void IwdService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onCo
   if (!rfkillDone) {
     const RfkillSwitchResult fallback = setRfkillSoftBlocked(RfkillDeviceType::Wlan, softBlocked);
     if (fallback.hardBlocked) {
-      kLog.warn("setWirelessEnabled: wlan rfkill hard block is active");
-      hardBlocked = enabled;
-      rfkillDone = !enabled;
-    } else if (fallback.success) {
+      kLog.warn("setWirelessEnabled: wlan rfkill reports a hard block");
+    }
+    if (fallback.success) {
       rfkillDone = true;
     } else if (!fallback.detail.empty()) {
       kLog.debug("setWirelessEnabled: wlan rfkill fallback: {}", fallback.detail);
@@ -389,7 +384,7 @@ void IwdService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onCo
 
   refresh();
   if (onComplete) {
-    onComplete(!hardBlocked && (rfkillDone || poweredUpdated));
+    onComplete(rfkillDone || poweredUpdated);
   }
 }
 

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -810,13 +810,10 @@ void NetworkManagerService::setWirelessEnabled(bool enabled, WirelessEnabledComp
   if (enabled) {
     const RfkillSwitchResult rfkillResult = setRfkillSoftBlocked(RfkillDeviceType::Wlan, false);
     if (rfkillResult.hardBlocked) {
-      kLog.warn("setWirelessEnabled: wlan rfkill hard block is active");
-      if (onComplete) {
-        onComplete(false);
-      }
-      return;
-    }
-    if (!rfkillResult.success) {
+      // A vendor soft block can also appear as a PHY hard block. Let NM clear
+      // the platform switch; the kernel still enforces genuine hardware blocks.
+      kLog.warn("setWirelessEnabled: wlan rfkill hard block reported, trying NetworkManager anyway");
+    } else if (!rfkillResult.success) {
       kLog.warn("setWirelessEnabled: rfkill unblock failed ({}), trying NetworkManager anyway", rfkillResult.detail);
     }
   }

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -810,10 +810,9 @@ void NetworkManagerService::setWirelessEnabled(bool enabled, WirelessEnabledComp
   if (enabled) {
     const RfkillSwitchResult rfkillResult = setRfkillSoftBlocked(RfkillDeviceType::Wlan, false);
     if (rfkillResult.hardBlocked) {
-      // A vendor soft block can also appear as a PHY hard block. Let NM clear
-      // the platform switch; the kernel still enforces genuine hardware blocks.
-      kLog.warn("setWirelessEnabled: wlan rfkill hard block reported, trying NetworkManager anyway");
-    } else if (!rfkillResult.success) {
+      kLog.warn("setWirelessEnabled: wlan rfkill reports a hard block");
+    }
+    if (!rfkillResult.success) {
       kLog.warn("setWirelessEnabled: rfkill unblock failed ({}), trying NetworkManager anyway", rfkillResult.detail);
     }
   }

--- a/src/dbus/network/wpa_supplicant_service.cpp
+++ b/src/dbus/network/wpa_supplicant_service.cpp
@@ -305,7 +305,6 @@ void WpaSupplicantService::disconnect() {
 void WpaSupplicantService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete) {
   const bool softBlocked = !enabled;
   bool rfkillDone = false;
-  bool hardBlocked = false;
   for (const auto& [ifacePath, proxy] : m_interfaces) {
     (void)ifacePath;
     const auto ifname = getPropertyOr<std::string>(*proxy, kWpaIfaceInterface, "Ifname", "");
@@ -314,10 +313,7 @@ void WpaSupplicantService::setWirelessEnabled(bool enabled, WirelessEnabledCompl
     }
     const RfkillSwitchResult result = setRfkillSoftBlockedForNetInterface(ifname, softBlocked);
     if (result.hardBlocked) {
-      kLog.warn("setWirelessEnabled: rfkill hard block on {}", ifname);
-      hardBlocked = enabled;
-      rfkillDone = !enabled;
-      break;
+      kLog.warn("setWirelessEnabled: rfkill reports a hard block on {}", ifname);
     }
     if (result.success) {
       rfkillDone = true;
@@ -328,10 +324,9 @@ void WpaSupplicantService::setWirelessEnabled(bool enabled, WirelessEnabledCompl
   if (!rfkillDone) {
     const RfkillSwitchResult fallback = setRfkillSoftBlocked(RfkillDeviceType::Wlan, softBlocked);
     if (fallback.hardBlocked) {
-      kLog.warn("setWirelessEnabled: wlan rfkill hard block is active");
-      hardBlocked = enabled;
-      rfkillDone = !enabled;
-    } else if (fallback.success) {
+      kLog.warn("setWirelessEnabled: wlan rfkill reports a hard block");
+    }
+    if (fallback.success) {
       rfkillDone = true;
     } else if (!fallback.detail.empty()) {
       kLog.debug("setWirelessEnabled: wlan rfkill fallback: {}", fallback.detail);
@@ -355,7 +350,7 @@ void WpaSupplicantService::setWirelessEnabled(bool enabled, WirelessEnabledCompl
     }
   }
 
-  const bool success = !hardBlocked && (rfkillDone || fallbackCommandSucceeded);
+  const bool success = rfkillDone || fallbackCommandSucceeded;
   if (success) {
     m_wirelessEnabledOverride = enabled;
   }

--- a/src/system/rfkill_helper.cpp
+++ b/src/system/rfkill_helper.cpp
@@ -213,14 +213,15 @@ RfkillSwitchResult setRfkillSoftBlocked(RfkillDeviceType type, bool softBlocked)
     kLog.debug("setRfkillSoftBlocked: no rfkill entry for type {}", static_cast<unsigned>(type));
     return {.success = false, .detail = "no rfkill switch found"};
   }
-  if (std::ranges::any_of(entries, &RfkillEntry::hard)) {
-    return {.success = false, .hardBlocked = true, .detail = "rfkill hard block is active"};
-  }
+  // A hard block is reported, not obeyed: the kernel applies the soft-block change regardless and
+  // re-queries hardware state while doing so, which is what clears a stale vendor platform block.
+  const bool hardBlocked = std::ranges::any_of(entries, &RfkillEntry::hard);
   if (std::ranges::all_of(entries, [softBlocked](const RfkillEntry& entry) { return entry.soft == softBlocked; })) {
-    return {.success = true, .detail = {}};
+    return {.success = true, .hardBlocked = hardBlocked, .detail = {}};
   }
 
   RfkillSwitchResult result = setRfkillSoftBlockedByType(*typeId, softBlocked);
+  result.hardBlocked = hardBlocked;
   if (!result.success) {
     kLog.warn("setRfkillSoftBlocked: type {} failed: {}", static_cast<unsigned>(type), result.detail);
   }
@@ -239,13 +240,11 @@ RfkillSwitchResult setRfkillSoftBlockedForNetInterface(std::string_view ifname, 
       if (wantedType.has_value() && entry.type != *wantedType) {
         return {.success = false, .detail = "rfkill switch is not WLAN"};
       }
-      if (entry.hard) {
-        return {.success = false, .hardBlocked = true, .detail = "rfkill hard block is active"};
-      }
       if (entry.soft == softBlocked) {
-        return {.success = true, .detail = {}};
+        return {.success = true, .hardBlocked = entry.hard, .detail = {}};
       }
       RfkillSwitchResult result = setRfkillSoftBlockedByIndex(entry.index, softBlocked);
+      result.hardBlocked = entry.hard;
       if (!result.success) {
         kLog.warn("setRfkillSoftBlockedForNetInterface: index {} failed: {}", entry.index, result.detail);
       }
@@ -258,5 +257,3 @@ RfkillSwitchResult setRfkillSoftBlockedForNetInterface(std::string_view ifname, 
 
 // A radio is blocked when any of its switches blocks it.
 bool isRfkillSoftBlocked(RfkillDeviceType type) { return std::ranges::any_of(findEntries(type), &RfkillEntry::soft); }
-
-bool isRfkillHardBlocked(RfkillDeviceType type) { return std::ranges::any_of(findEntries(type), &RfkillEntry::hard); }

--- a/src/system/rfkill_helper.h
+++ b/src/system/rfkill_helper.h
@@ -11,6 +11,8 @@ enum class RfkillDeviceType : std::uint8_t {
 
 struct RfkillSwitchResult {
   bool success = false;
+  // Diagnostic only: a hard block was observed while writing. Vendor platform switches report stale
+  // hard blocks, so callers must not treat this as a reason to skip the radio operation.
   bool hardBlocked = false;
   std::string detail;
 };
@@ -23,6 +25,3 @@ struct RfkillSwitchResult {
 
 /// True when any switch of this type is soft-blocked.
 [[nodiscard]] bool isRfkillSoftBlocked(RfkillDeviceType type);
-
-/// True when any switch of this type is hard-blocked.
-[[nodiscard]] bool isRfkillHardBlocked(RfkillDeviceType type);


### PR DESCRIPTION
## Summary

Let NetworkManager and BlueZ attempt radio activation even when the preliminary rfkill check reports a hard block. Retain a diagnostic warning and all existing backend error handling.

## Motivation

On a Dell Latitude 5531 with Intel AX211/iwlwifi, disabling Wi-Fi in Noctalia produces:

```
dell-wifi: Soft blocked: yes; Hard blocked: no
phy0:      Soft blocked: yes; Hard blocked: yes
```

Re-enabling in Noctalia logs `setWirelessEnabled: wlan rfkill hard block is active` and returns without requesting activation from NetworkManager. `nmcli radio wifi on` alone clears both blocks and reconnects. The vendor platform soft block can manifest as a PHY hard block, so this initial observation must not prevent the backend from attempting activation.

The same early-return pattern exists in Bluetooth, and #3367 contains a report of a platform rfkill hard-block indication preventing an otherwise functional Bluetooth adapter from being enabled.

This is not an override of a real hardware switch: kernel enforcement remains unchanged. The patch only removes the client-side refusal to attempt the existing backend operation. Disable behavior and error handling are preserved.

## Type of Change

- [x] Bug fix

## Related Issue

Fixes #3367

## Testing

The two modified source files are byte-identical to the locally built and hardware-tested patch based on 29dab93fd. They were unchanged upstream when rebasing this submission onto main (4912b92d).

- Full release build of the patched shell on 29dab93fd: `meson setup build-radio --buildtype=release -Dtests=enabled -Db_ndebug=true` and `ninja -C build-radio -j 4 noctalia`.
- Existing `network_manager_security` test passed; rerun before submission. This is an existing smoke test, not a new regression test for rfkill.
- Patched-shell configuration validation passed with the same two pre-existing local configuration warnings as the installed shell.
- Wi-Fi: reproduced the failure before patching; after starting the patched shell, the user confirmed disabling and re-enabling through Noctalia works.
- Bluetooth: Noctalia IPC disable/enable returned off/on, and BlueZ `Powered` returned true. No connected Bluetooth devices were interrupted. The ThinkPad-specific hard-block scenario has not been reproduced on this Dell.
- `just format` with clang-format 22.1.8 and `git diff --check`.
- A full rebuild of the newer main revision was not repeated; the modified files match the tested build exactly. Full test suite and physical hardware-switch coverage were not run.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Environment: Arch Linux, Dell Latitude 5531, Intel AX211, NetworkManager. BIOS WLAN enabled and WLAN autosense disabled; user has write access to /dev/rfkill.

## Screenshots / Videos

Not applicable: no visual/layout changes.

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed CONTRIBUTING.md and the project ethos.
- [x] I ran just format with clang-format v22+.
- [x] I ran relevant build/test commands and described their coverage above.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors in the affected radio path.
- [x] No documentation changes are required: this restores the existing enable operation without changing configuration or IPC.
- [x] No new user-facing strings or translation changes.
- [x] Existing canonical config keys, IPC names, paths and identifiers are preserved.

## Additional Notes

Prepared with OpenAI Codex assistance, reviewed against the existing activation paths, and tested on the affected hardware. Bluetooth hard-block behavior on other hardware and genuine hardware-switch cases would benefit from additional testing.
