### PR TITLE
fix(plugin_panel): save context on open plugin_panel

### DIFF
--- a/src/shell/panel/plugin_panel.cpp
+++ b/src/shell/panel/plugin_panel.cpp
@@ -230,6 +230,7 @@ void PluginPanel::startScript() {
 }
 
 void PluginPanel::onOpen(std::string_view context) {
+  m_context = std::string(context);
   closeContextMenu();
   ++m_openGeneration;
   m_open = true;

--- a/src/shell/panel/plugin_panel.h
+++ b/src/shell/panel/plugin_panel.h
@@ -61,6 +61,7 @@ public:
   void onClose() override;
   void onFrameTick(float deltaMs) override;
 
+  [[nodiscard]] bool isContextActive(std::string_view context) const override { return m_context == context; }
   [[nodiscard]] float preferredWidth() const override { return scaled(m_preferredWidth); }
   [[nodiscard]] float preferredHeight() const override { return scaled(m_preferredHeight); }
   [[nodiscard]] bool fillsWidth() const noexcept override { return m_widthFill; }
@@ -147,4 +148,5 @@ private:
   bool m_persistent = false;
   scripting::PluginPanelShellConfig m_shellConfig;
   std::shared_ptr<bool> m_alive = std::make_shared<bool>(true);
+  std::string m_context;
 };


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Compare the saved context in the isContextActive.
This allows to toggle panels opened with context.

<!-- What changed and why? -->

If a plugin panel is opened with context then `PanelManager::togglePanel` always reopen the panel because isContextActive returns false. In this this PR context is saved in the `PluginPanel::onOpen` and `PluginPanel::isContextActive` return true if context is the same as saved one.

## Motivation

Make Noctalia better

<!-- What problem does this solve? -->

Impossible to close panel opened with context by clicking the same widget.
Look #4157 for details

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #4157

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Just compiled and run fixed noctalia, checked with nvtop plugin because it uses panel with context. With fixes it it possible to click widget to open and close panel. Other panels are working without changes.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
