### PR TITLE
fix(battery): clamp health in the bar tooltip to 100%

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1127,6 +1127,7 @@ if build_tests
     'app_identity',
     'audio_glyphs',
     'audio_route_selection',
+    'battery_health',
     'battery_hook_state',
     'button_layout',
     'cairo_text_renderer',

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -254,6 +254,13 @@ namespace {
 
 } // namespace
 
+double UPowerDeviceInfo::healthPercent() const {
+  if (!hasHealth()) {
+    return 0.0;
+  }
+  return std::clamp(energyFull / energyFullDesign * 100.0, 0.0, 100.0);
+}
+
 bool UPowerDeviceInfo::sameCatalogEntry(const UPowerDeviceInfo& other) const {
   return path == other.path
       && nativePath == other.nativePath

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -254,9 +254,9 @@ namespace {
 
 } // namespace
 
-double UPowerDeviceInfo::healthPercent() const {
-  if (!hasHealth()) {
-    return 0.0;
+std::optional<double> UPowerDeviceInfo::healthPercent() const {
+  if (energyFullDesign <= 0.0 || energyFull <= 0.0) {
+    return std::nullopt;
   }
   return std::clamp(energyFull / energyFullDesign * 100.0, 0.0, 100.0);
 }

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -120,8 +120,9 @@ struct UPowerDeviceInfo {
   bool operator==(const UPowerDeviceInfo&) const = default;
 
   [[nodiscard]] bool isLaptopBattery() const { return type == UPowerDeviceType::Battery && powerSupply; }
-  [[nodiscard]] bool hasHealth() const { return energyFullDesign > 0.0 && energyFull > 0.0; }
-  [[nodiscard]] double healthPercent() const;
+  // Percent of design capacity, clamped to [0, 100]: a re-learned EnergyFull can exceed the
+  // vendor design value. Empty when the device reports no usable capacity pair.
+  [[nodiscard]] std::optional<double> healthPercent() const;
   [[nodiscard]] bool sameCatalogEntry(const UPowerDeviceInfo& other) const;
 };
 

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -120,6 +120,8 @@ struct UPowerDeviceInfo {
   bool operator==(const UPowerDeviceInfo&) const = default;
 
   [[nodiscard]] bool isLaptopBattery() const { return type == UPowerDeviceType::Battery && powerSupply; }
+  [[nodiscard]] bool hasHealth() const { return energyFullDesign > 0.0 && energyFull > 0.0; }
+  [[nodiscard]] double healthPercent() const;
   [[nodiscard]] bool sameCatalogEntry(const UPowerDeviceInfo& other) const;
 };
 

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <cmath>
 #include <format>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -538,8 +539,8 @@ void BatteryWidget::syncState(Renderer& renderer) {
           rows.push_back({i18n::tr("power.battery.tooltip.rate"), oss.str()});
         }
 
-        if (dev.hasHealth()) {
-          rows.push_back({i18n::tr("power.battery.tooltip.health"), std::format("{:.0F}%", dev.healthPercent())});
+        if (const std::optional<double> health = dev.healthPercent()) {
+          rows.push_back({i18n::tr("power.battery.tooltip.health"), std::format("{:.0F}%", *health)});
         }
       }
     }

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -538,9 +538,8 @@ void BatteryWidget::syncState(Renderer& renderer) {
           rows.push_back({i18n::tr("power.battery.tooltip.rate"), oss.str()});
         }
 
-        if (dev.energyFullDesign > 0.0) {
-          int health = static_cast<int>(std::round(dev.energyFull / dev.energyFullDesign * 100.0));
-          rows.push_back({i18n::tr("power.battery.tooltip.health"), std::to_string(health) + "%"});
+        if (dev.hasHealth()) {
+          rows.push_back({i18n::tr("power.battery.tooltip.health"), std::format("{:.0F}%", dev.healthPercent())});
         }
       }
     }

--- a/src/shell/control_center/tabs/power_tab.cpp
+++ b/src/shell/control_center/tabs/power_tab.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <format>
 #include <memory>
+#include <optional>
 #include <string>
 
 using namespace control_center;
@@ -710,19 +711,18 @@ void PowerTab::syncBatteryHealth() {
   }
 
   const UPowerDeviceInfo* battery = m_upower->defaultSystemBattery();
-  const bool hasHealth = battery != nullptr && battery->hasHealth();
-  m_healthCard->setVisible(hasHealth);
-  if (!hasHealth) {
+  const std::optional<double> health = battery != nullptr ? battery->healthPercent() : std::nullopt;
+  m_healthCard->setVisible(health.has_value());
+  if (!health) {
     return;
   }
 
-  const double health = battery->healthPercent();
   if (m_healthLabel != nullptr) {
-    m_healthLabel->setText(std::format("{:.0F}%", health));
+    m_healthLabel->setText(std::format("{:.0F}%", *health));
   }
   if (m_healthBar != nullptr) {
-    m_healthBar->setProgress(static_cast<float>(health / 100.0));
-    m_healthBar->setFill(colorSpecFromRole(healthRole(health)));
+    m_healthBar->setProgress(static_cast<float>(*health / 100.0));
+    m_healthBar->setFill(colorSpecFromRole(healthRole(*health)));
   }
 }
 

--- a/src/shell/control_center/tabs/power_tab.cpp
+++ b/src/shell/control_center/tabs/power_tab.cpp
@@ -710,13 +710,13 @@ void PowerTab::syncBatteryHealth() {
   }
 
   const UPowerDeviceInfo* battery = m_upower->defaultSystemBattery();
-  const bool hasHealth = battery != nullptr && battery->energyFullDesign > 0.0 && battery->energyFull > 0.0;
+  const bool hasHealth = battery != nullptr && battery->hasHealth();
   m_healthCard->setVisible(hasHealth);
   if (!hasHealth) {
     return;
   }
 
-  const double health = std::clamp(battery->energyFull / battery->energyFullDesign * 100.0, 0.0, 100.0);
+  const double health = battery->healthPercent();
   if (m_healthLabel != nullptr) {
     m_healthLabel->setText(std::format("{:.0F}%", health));
   }

--- a/tests/battery_health_test.cpp
+++ b/tests/battery_health_test.cpp
@@ -2,14 +2,12 @@
 #include "tests/test_check.h"
 
 #include <cmath>
+#include <optional>
 
 namespace {
 
   UPowerDeviceInfo battery(double energyFull, double energyFullDesign) {
     UPowerDeviceInfo info;
-    info.type = UPowerDeviceType::Battery;
-    info.powerSupply = true;
-    info.isPresent = true;
     info.energyFull = energyFull;
     info.energyFullDesign = energyFullDesign;
     return info;
@@ -20,19 +18,19 @@ namespace {
 } // namespace
 
 int main() {
-  const UPowerDeviceInfo worn = battery(50.0, 100.0);
-  TEST_CHECK(worn.hasHealth());
-  TEST_CHECK(nearlyEqual(worn.healthPercent(), 50.0));
+  const std::optional<double> worn = battery(50.0, 100.0).healthPercent();
+  TEST_CHECK(worn.has_value());
+  TEST_CHECK(nearlyEqual(*worn, 50.0));
 
   // A fuel gauge can learn a full-charge capacity above the vendor's design
   // value, which must not be reported as more than 100% health.
-  const UPowerDeviceInfo aboveDesign = battery(74.8218, 72.5696);
-  TEST_CHECK(aboveDesign.hasHealth());
-  TEST_CHECK(nearlyEqual(aboveDesign.healthPercent(), 100.0));
+  const std::optional<double> aboveDesign = battery(74.8218, 72.5696).healthPercent();
+  TEST_CHECK(aboveDesign.has_value());
+  TEST_CHECK(nearlyEqual(*aboveDesign, 100.0));
 
-  TEST_CHECK(!battery(74.8218, 0.0).hasHealth());
-  TEST_CHECK(!battery(0.0, 72.5696).hasHealth());
-  TEST_CHECK(nearlyEqual(battery(74.8218, 0.0).healthPercent(), 0.0));
+  TEST_CHECK(!battery(74.8218, 0.0).healthPercent().has_value());
+  TEST_CHECK(!battery(0.0, 72.5696).healthPercent().has_value());
+  TEST_CHECK(!battery(0.0, 0.0).healthPercent().has_value());
 
   return 0;
 }

--- a/tests/battery_health_test.cpp
+++ b/tests/battery_health_test.cpp
@@ -1,0 +1,38 @@
+#include "dbus/upower/upower_service.h"
+#include "tests/test_check.h"
+
+#include <cmath>
+
+namespace {
+
+  UPowerDeviceInfo battery(double energyFull, double energyFullDesign) {
+    UPowerDeviceInfo info;
+    info.type = UPowerDeviceType::Battery;
+    info.powerSupply = true;
+    info.isPresent = true;
+    info.energyFull = energyFull;
+    info.energyFullDesign = energyFullDesign;
+    return info;
+  }
+
+  bool nearlyEqual(double lhs, double rhs) { return std::fabs(lhs - rhs) < 1e-9; }
+
+} // namespace
+
+int main() {
+  const UPowerDeviceInfo worn = battery(50.0, 100.0);
+  TEST_CHECK(worn.hasHealth());
+  TEST_CHECK(nearlyEqual(worn.healthPercent(), 50.0));
+
+  // A fuel gauge can learn a full-charge capacity above the vendor's design
+  // value, which must not be reported as more than 100% health.
+  const UPowerDeviceInfo aboveDesign = battery(74.8218, 72.5696);
+  TEST_CHECK(aboveDesign.hasHealth());
+  TEST_CHECK(nearlyEqual(aboveDesign.healthPercent(), 100.0));
+
+  TEST_CHECK(!battery(74.8218, 0.0).hasHealth());
+  TEST_CHECK(!battery(0.0, 72.5696).hasHealth());
+  TEST_CHECK(nearlyEqual(battery(74.8218, 0.0).healthPercent(), 0.0));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Move the battery health calculation onto `UPowerDeviceInfo` as `hasHealth()` and `healthPercent()`, clamped to `[0, 100]`.
- Point the bar tooltip and the control center Power tab at that one definition.
- Add `battery_health_test`, covering a worn battery, a battery reporting above its design capacity, and the missing-data guards.

## Motivation

`BatteryWidget::syncState()` printed the raw `EnergyFull / EnergyFullDesign` ratio, while `PowerTab::syncBatteryHealth()` clamped the same ratio. The two views therefore disagreed about the same battery.

A battery whose learned full-charge capacity exceeds its design capacity reports health above 100%. `EnergyFullDesign` is written once by the vendor; `EnergyFull` is re-learned by the fuel gauge and can be higher on a healthy pack.

On a Framework 13:

```
energy-full:         74.8218 Wh
energy-full-design:  72.5696 Wh
```

At the same moment, the bar tooltip read `Health 103%` and the Power tab read `Health 100%`.

`docs/user/control-center/index.mdx` describes the figure as "current full-charge capacity as a percentage of the original design capacity", so the clamped value is the documented one. Sharing one definition keeps the two views from drifting apart again.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None.

## Testing

- `just format` with clang-format 22.1.8 — no diff.
- `just build` — clean, no new warnings.
- `just test` — 99 passed, 1 failed. The failure is `noctalia:process` (`completion-only async command stdout was wrong`). It fails identically on unmodified `main` on my NixOS host, so it is pre-existing and unrelated to this change.
- clang-tidy 22.1.8 with `-warnings-as-errors=*` on the four changed files — clean. I ran it on those files rather than through `just lint`, which hardcodes `-j $(nproc)`.
- Reproduced the mismatch on the packaged build under Sway against `upower -i /org/freedesktop/UPower/devices/battery_BAT1`.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="621" height="434" alt="image" src="https://github.com/user-attachments/assets/bdae32f9-396a-452e-84b2-35c1133a2fd7" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in `docs/user/` when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Reuses the existing `power.battery.tooltip.health` string, so there is no translation impact.

I used Claude Code to write this change, and reviewed it myself. The commit carries an `Assisted-by:` trailer.
