### PR TITLE
noctalia #4181 electron color-scheme order

### DIFF
--- a/assets/templates/gtk/apply.sh
+++ b/assets/templates/gtk/apply.sh
@@ -83,23 +83,23 @@ sync_system_appearance() {
         local schemas
         schemas=$(gsettings list-schemas 2>/dev/null || true)
         if [[ "$schemas" == *"org.gnome.desktop.interface"* ]]; then
-            gsettings set org.gnome.desktop.interface color-scheme "prefer-$mode" \
-                || echo "Error running gsettings set color-scheme" >&2
             if [ "$theme_available" = "true" ]; then
                 gsettings set org.gnome.desktop.interface gtk-theme "$target_theme" \
                     || echo "Error running gsettings set gtk-theme" >&2
             fi
+            gsettings set org.gnome.desktop.interface color-scheme "prefer-$mode" \
+                || echo "Error running gsettings set color-scheme" >&2
             return
         fi
     fi
 
     if [ -n "$has_dconf" ]; then
-        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-$mode'" \
-            || echo "Error running dconf write color-scheme" >&2
         if [ "$theme_available" = "true" ]; then
             dconf write /org/gnome/desktop/interface/gtk-theme "'$target_theme'" \
                 || echo "Error running dconf write gtk-theme" >&2
         fi
+        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-$mode'" \
+            || echo "Error running dconf write color-scheme" >&2
     fi
 }
 

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -648,9 +648,14 @@ void Application::initStyleThemeAndWayland() {
     lastResolvedThemeMode = resolvedMode;
     const bool colorsChanged = !lastGeneratedPalette.has_value() || *lastGeneratedPalette != generated;
     lastGeneratedPalette = generated;
-    if (colorsChanged) {
-      m_templateApplyService.setAfterApplyCallback([this]() { m_hookManager.fire(HookKind::ColorsChanged); });
-    }
+    m_templateApplyService.setAfterApplyCallback(
+        [this, resolvedMode, colorsChanged]() {
+          syncGSettingsColorScheme(resolvedMode);
+          if (colorsChanged) {
+            m_hookManager.fire(HookKind::ColorsChanged);
+          }
+        }
+    );
     m_templateApplyService.apply(generated, mode);
     if (previousMode.has_value() && *previousMode != resolvedMode) {
       m_hookManager.fire(
@@ -660,7 +665,6 @@ void Application::initStyleThemeAndWayland() {
            {"NOCTALIA_THEME_MODE_CONFIGURED", configuredMode}}
       );
     }
-    syncGSettingsColorScheme(resolvedMode);
   });
   m_themeService.apply();
   syncGSettingsColorScheme(m_themeService.resolvedMode());


### PR DESCRIPTION
## What

- Write gtk-theme before color-scheme in gtk apply.sh so gsettings land gtk-theme then color-scheme.
- Independent verify PASS on `e0a9fd328eb73c93c8c781b502e8bfd4f6ba3554` (busctl order). Electron nativeTheme repro was not run.

## Why

Fixes noctalia-dev/noctalia#4181. Toggling dark/light often wrote color-scheme first, so Electron nativeTheme stuck on the old mode.
