### PR TITLE
Close plugin panels on second toggle with context

### DIFF
--- a/src/shell/panel/plugin_panel.cpp
+++ b/src/shell/panel/plugin_panel.cpp
@@ -233,6 +233,7 @@ void PluginPanel::onOpen(std::string_view context) {
   closeContextMenu();
   ++m_openGeneration;
   m_open = true;
+  m_openContext = std::string(context);
   if (m_runtime != nullptr) {
     (void)m_runtime->enqueueCallStrings("onOpen", std::string(context), {}, makeScriptSnapshot());
   }
@@ -242,9 +243,14 @@ void PluginPanel::onOpen(std::string_view context) {
   }
 }
 
+bool PluginPanel::isContextActive(std::string_view context) const {
+  return m_open && m_openContext == context;
+}
+
 void PluginPanel::onClose() {
   ++m_openGeneration;
   m_open = false;
+  m_openContext.clear();
   closeContextMenu();
   m_tickTimer.stop();
   releaseCapturedKeys();

--- a/src/shell/panel/plugin_panel.h
+++ b/src/shell/panel/plugin_panel.h
@@ -60,6 +60,7 @@ public:
   void onOpen(std::string_view context) override;
   void onClose() override;
   void onFrameTick(float deltaMs) override;
+  [[nodiscard]] bool isContextActive(std::string_view context) const override;
 
   [[nodiscard]] float preferredWidth() const override { return scaled(m_preferredWidth); }
   [[nodiscard]] float preferredHeight() const override { return scaled(m_preferredHeight); }
@@ -135,6 +136,7 @@ private:
   bool m_wantsSecondTicks = false;
   bool m_needsFrameTick = false;
   bool m_open = false;
+  std::string m_openContext;
   std::uint64_t m_openGeneration = 0;
   bool m_hasOnIpc = false;
   bool m_hasOnIpcKnown = false;


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4157.

`panel-toggle <plugin-panel> <context>` never closed: `PluginPanel` inherited `Panel::isContextActive`, which always returns false, so a second click called `onOpen` again.

Remember the last open context and treat a matching toggle as close (control-center tab switching is unchanged).

## Checkable
- Add a Timer (or any plugin) widget; left click `panel-toggle noctalia/timer:panel context`
- First click opens the panel
- Second click closes it (does not reopen)
- Same widget without the `context` argument still toggles
- Control Center tab gestures still switch tabs instead of always closing
