### PR TITLE
Fire colors_changed only when the palette changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1206,6 +1206,7 @@ if build_tests
     'string_utils',
     'system_monitor_service',
     'taskbar_widget',
+    'template_apply_notify',
     'template_hook_async',
     'template_hook_runner',
     'time_format',

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -635,6 +635,15 @@ void Application::initStyleThemeAndWayland() {
     }
   });
 
+  // Runs once per applied generation: the gsettings color-scheme write has to land after the
+  // gtk-theme templates, and colors_changed only concerns a palette that actually changed.
+  m_templateApplyService.setAfterApplyCallback([this](std::string_view appliedMode, bool paletteChanged) {
+    syncGSettingsColorScheme(appliedMode);
+    if (paletteChanged) {
+      m_hookManager.fire(HookKind::ColorsChanged);
+    }
+  });
+
   m_themeService.setResolvedCallback([this, lastResolvedThemeMode = std::optional<std::string>{},
                                       lastGeneratedPalette = std::optional<noctalia::theme::GeneratedPalette>{},
                                       syncScriptApiWallpaperDirectory](
@@ -648,15 +657,7 @@ void Application::initStyleThemeAndWayland() {
     lastResolvedThemeMode = resolvedMode;
     const bool colorsChanged = !lastGeneratedPalette.has_value() || *lastGeneratedPalette != generated;
     lastGeneratedPalette = generated;
-    m_templateApplyService.setAfterApplyCallback(
-        [this, resolvedMode, colorsChanged]() {
-          syncGSettingsColorScheme(resolvedMode);
-          if (colorsChanged) {
-            m_hookManager.fire(HookKind::ColorsChanged);
-          }
-        }
-    );
-    m_templateApplyService.apply(generated, mode);
+    m_templateApplyService.apply(generated, mode, /*force=*/false, /*paletteChanged=*/colorsChanged);
     if (previousMode.has_value() && *previousMode != resolvedMode) {
       m_hookManager.fire(
           HookKind::ThemeModeChanged,

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -468,8 +468,7 @@ void BatteryWidget::syncState(Renderer& renderer) {
       m_overlayGlyph->setVisible(stateGlyph != nullptr);
     }
   } else if (m_displayMode == BatteryDisplayMode::Glyph) {
-    const ColorSpec iconColor =
-        isWarning ? m_warningColor : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface));
+    const ColorSpec iconColor = isWarning ? m_warningColor : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface));
     const ColorSpec labelColor =
         isWarning ? m_warningColor : widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
 

--- a/src/shell/panel/plugin_panel.cpp
+++ b/src/shell/panel/plugin_panel.cpp
@@ -243,9 +243,7 @@ void PluginPanel::onOpen(std::string_view context) {
   }
 }
 
-bool PluginPanel::isContextActive(std::string_view context) const {
-  return m_open && m_openContext == context;
-}
+bool PluginPanel::isContextActive(std::string_view context) const { return m_open && m_openContext == context; }
 
 void PluginPanel::onClose() {
   ++m_openGeneration;

--- a/src/theme/template_apply_service.cpp
+++ b/src/theme/template_apply_service.cpp
@@ -188,31 +188,18 @@ namespace noctalia::theme {
 
   void TemplateApplyService::apply(const GeneratedPalette& palette, std::string_view defaultMode, bool force) const {
     ApplyRequest request = makeRequest(palette, defaultMode);
-    std::function<void()> afterApplyCallback;
     {
       std::scoped_lock lock(m_mutex);
       // Skip rendering and hooks when palette and template inputs are unchanged. Config values
       // are captured only when an application is queued; forced IPC re-application bypasses
       // this deduplication.
       if (!force && m_lastAppliedRequest.has_value() && sameInputs(request, *m_lastAppliedRequest)) {
-        // A queued request has not been applied yet; it fires the callback when it lands.
-        if (m_afterApplyCallback && !m_inFlight && !m_pendingRequest.has_value()) {
-          afterApplyCallback = m_afterApplyCallback;
-        }
-        if (!afterApplyCallback) {
-          return;
-        }
-      } else {
-        request.undoBuiltinIds = syncAppliedBuiltinIds(request.templates);
-        request.generation = ++m_nextGeneration;
-        m_lastAppliedRequest = request;
-        m_pendingRequest = std::move(request);
+        return;
       }
-    }
-
-    if (afterApplyCallback) {
-      DeferredCall::callLater(std::move(afterApplyCallback));
-      return;
+      request.undoBuiltinIds = syncAppliedBuiltinIds(request.templates);
+      request.generation = ++m_nextGeneration;
+      m_lastAppliedRequest = request;
+      m_pendingRequest = std::move(request);
     }
     m_cv.notify_one();
   }

--- a/src/theme/template_apply_service.cpp
+++ b/src/theme/template_apply_service.cpp
@@ -181,27 +181,53 @@ namespace noctalia::theme {
     }
   }
 
-  void TemplateApplyService::setAfterApplyCallback(std::function<void()> callback) const {
+  void TemplateApplyService::setAfterApplyCallback(
+      std::function<void(std::string_view appliedMode, bool paletteChanged)> callback
+  ) const {
     std::scoped_lock lock(m_mutex);
     m_afterApplyCallback = std::move(callback);
   }
 
-  void TemplateApplyService::apply(const GeneratedPalette& palette, std::string_view defaultMode, bool force) const {
+  void TemplateApplyService::apply(
+      const GeneratedPalette& palette, std::string_view defaultMode, bool force, bool paletteChanged
+  ) const {
     ApplyRequest request = makeRequest(palette, defaultMode);
+    bool queued = false;
+    std::function<void()> undeliverable;
     {
       std::scoped_lock lock(m_mutex);
+      m_paletteChangedOwed = m_paletteChangedOwed || paletteChanged;
+
       // Skip rendering and hooks when palette and template inputs are unchanged. Config values
       // are captured only when an application is queued; forced IPC re-application bypasses
       // this deduplication.
       if (!force && m_lastAppliedRequest.has_value() && sameInputs(request, *m_lastAppliedRequest)) {
-        return;
+        // The applied mode already matches, so only an owed palette change is still worth
+        // reporting. It rides on the application queued or in flight; with neither, no worker
+        // pass is left to carry it.
+        if (m_paletteChangedOwed && !m_inFlight && !m_pendingRequest.has_value()) {
+          m_paletteChangedOwed = false;
+          if (m_afterApplyCallback) {
+            undeliverable = [callback = m_afterApplyCallback, mode = request.defaultMode]() {
+              callback(mode, /*paletteChanged=*/true);
+            };
+          }
+        }
+      } else {
+        request.undoBuiltinIds = syncAppliedBuiltinIds(request.templates);
+        request.generation = ++m_nextGeneration;
+        m_lastAppliedRequest = request;
+        m_pendingRequest = std::move(request);
+        queued = true;
       }
-      request.undoBuiltinIds = syncAppliedBuiltinIds(request.templates);
-      request.generation = ++m_nextGeneration;
-      m_lastAppliedRequest = request;
-      m_pendingRequest = std::move(request);
     }
-    m_cv.notify_one();
+
+    if (undeliverable) {
+      DeferredCall::callLater(std::move(undeliverable));
+    }
+    if (queued) {
+      m_cv.notify_one();
+    }
   }
 
   bool TemplateApplyService::reapplyLast() const {
@@ -216,7 +242,8 @@ namespace noctalia::theme {
       defaultMode = m_lastAppliedRequest->defaultMode;
     }
 
-    apply(palette, defaultMode, /*force=*/true);
+    // A forced re-render rewrites every template, so consumers hear about it as a colour change.
+    apply(palette, defaultMode, /*force=*/true, /*paletteChanged=*/true);
     return true;
   }
 
@@ -488,8 +515,13 @@ namespace noctalia::theme {
       {
         std::scoped_lock lock(m_mutex);
         m_inFlight = false;
-        if (!m_shutdown && request.generation == m_nextGeneration) {
-          afterApplyCallback = m_afterApplyCallback;
+        // A superseded generation reports nothing and leaves an owed palette change to the
+        // generation that replaced it.
+        if (!m_shutdown && request.generation == m_nextGeneration && m_afterApplyCallback) {
+          const bool paletteChanged = std::exchange(m_paletteChangedOwed, false);
+          afterApplyCallback = [callback = m_afterApplyCallback, mode = request.defaultMode, paletteChanged]() {
+            callback(mode, paletteChanged);
+          };
         }
       }
       if (afterApplyCallback) {

--- a/src/theme/template_apply_service.h
+++ b/src/theme/template_apply_service.h
@@ -31,8 +31,15 @@ namespace noctalia::theme {
     TemplateApplyService(const TemplateApplyService&) = delete;
     TemplateApplyService& operator=(const TemplateApplyService&) = delete;
 
-    void apply(const GeneratedPalette& palette, std::string_view defaultMode, bool force = false) const;
-    void setAfterApplyCallback(std::function<void()> callback) const;
+    // Every completed application notifies, carrying the mode it applied. `paletteChanged`
+    // marks this apply as one whose palette differs from the last; the flag is owed until a
+    // non-superseded application reports it, so a later apply() that coalesces with,
+    // supersedes, or deduplicates against this one still passes it on.
+    void apply(
+        const GeneratedPalette& palette, std::string_view defaultMode, bool force = false, bool paletteChanged = false
+    ) const;
+    // The notification handler. Sticky: set once.
+    void setAfterApplyCallback(std::function<void(std::string_view appliedMode, bool paletteChanged)> callback) const;
     void registerIpc(IpcService& ipc);
 
   private:
@@ -79,7 +86,9 @@ namespace noctalia::theme {
     mutable std::uint64_t m_nextGeneration = 0;
     mutable bool m_shutdown = false;
     mutable bool m_inFlight = false;
-    mutable std::function<void()> m_afterApplyCallback;
+    mutable std::function<void(std::string_view appliedMode, bool paletteChanged)> m_afterApplyCallback;
+    // A palette change has been reported to apply() and not yet passed on to the handler.
+    mutable bool m_paletteChangedOwed = false;
     mutable std::unique_ptr<HookRunner> m_hookRunner;
   };
 

--- a/tests/template_apply_notify_test.cpp
+++ b/tests/template_apply_notify_test.cpp
@@ -1,0 +1,123 @@
+// A requested after-apply notification is owed until an application delivers it. Later
+// applies that coalesce with, supersede, or deduplicate against the requesting one must not
+// swallow it, and an application that did not ask for one must stay silent.
+
+#include "config/config_service.h"
+#include "core/deferred_call.h"
+#include "tests/test_check.h"
+#include "theme/palette.h"
+#include "theme/template_apply_service.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unistd.h>
+
+namespace {
+
+  using noctalia::theme::GeneratedPalette;
+  using noctalia::theme::TemplateApplyService;
+
+  GeneratedPalette paletteWith(std::uint32_t surface) {
+    GeneratedPalette palette;
+    palette.dark["mSurface"] = surface;
+    palette.light["mSurface"] = surface;
+    return palette;
+  }
+
+  // The worker applies once the request stream has been quiet for its coalescing window and
+  // posts the notification through the deferred-call queue the main loop drains.
+  void settle() {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(400);
+    while (std::chrono::steady_clock::now() < deadline) {
+      for (auto& call : DeferredCall::takePending()) {
+        call();
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    for (auto& call : DeferredCall::takePending()) {
+      call();
+    }
+  }
+
+} // namespace
+
+int main() {
+  const std::filesystem::path root =
+      std::filesystem::temp_directory_path() / ("noctalia-template-notify-" + std::to_string(::getpid()));
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root / "config");
+  std::filesystem::create_directories(root / "state");
+  std::filesystem::create_directories(root / "data");
+  ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+  ::setenv("NOCTALIA_STATE_HOME", (root / "state").c_str(), 1);
+  ::setenv("NOCTALIA_DATA_HOME", (root / "data").c_str(), 1);
+
+  int applications = 0;
+  int paletteChanges = 0;
+  std::string lastMode;
+  {
+    ConfigService config;
+    TemplateApplyService service(config);
+    service.setAfterApplyCallback([&](std::string_view appliedMode, bool paletteChanged) {
+      ++applications;
+      paletteChanges += paletteChanged ? 1 : 0;
+      lastMode = appliedMode;
+    });
+
+    // A plain application that changed the palette.
+    service.apply(paletteWith(0x111111), "dark", /*force=*/false, /*paletteChanged=*/true);
+    settle();
+    TEST_CHECK(applications == 1);
+    TEST_CHECK(paletteChanges == 1);
+    TEST_CHECK(lastMode == "dark");
+
+    // A same-palette apply deduplicates against the queued one. It must not cancel the palette
+    // change the queued one is still owed.
+    applications = 0;
+    paletteChanges = 0;
+    service.apply(paletteWith(0x222222), "dark", /*force=*/false, /*paletteChanged=*/true);
+    service.apply(paletteWith(0x222222), "dark", /*force=*/false, /*paletteChanged=*/false);
+    settle();
+    TEST_CHECK(applications == 1);
+    TEST_CHECK(paletteChanges == 1);
+
+    // A different palette supersedes the queued request before it runs. The superseding
+    // generation inherits the owed palette change instead of dropping it.
+    applications = 0;
+    paletteChanges = 0;
+    service.apply(paletteWith(0x333333), "dark", /*force=*/false, /*paletteChanged=*/true);
+    service.apply(paletteWith(0x444444), "dark", /*force=*/false, /*paletteChanged=*/false);
+    settle();
+    TEST_CHECK(applications == 1);
+    TEST_CHECK(paletteChanges == 1);
+
+    // An application that only switched mode still reports, so a consumer ordered behind the
+    // templates runs, but it is not a palette change.
+    applications = 0;
+    paletteChanges = 0;
+    service.apply(paletteWith(0x444444), "light", /*force=*/false, /*paletteChanged=*/false);
+    settle();
+    TEST_CHECK(applications == 1);
+    TEST_CHECK(paletteChanges == 0);
+    TEST_CHECK(lastMode == "light");
+
+    // A palette change owed by an apply that has nothing left to render still lands.
+    applications = 0;
+    paletteChanges = 0;
+    service.apply(paletteWith(0x444444), "light", /*force=*/false, /*paletteChanged=*/true);
+    settle();
+    TEST_CHECK(applications == 1);
+    TEST_CHECK(paletteChanges == 1);
+  }
+
+  ::unsetenv("NOCTALIA_CONFIG_HOME");
+  ::unsetenv("NOCTALIA_STATE_HOME");
+  ::unsetenv("NOCTALIA_DATA_HOME");
+  std::filesystem::remove_all(root);
+  return 0;
+}


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#3814.

The template after-apply callback stayed attached after a real palette change, so later same-palette applies (UI scale, unrelated toggles) still fired `colors_changed`.

Attach the hook only when the generated palette actually changed, and do not invoke after-apply on the identical-input skip path.

## Checkable
- Set `[hooks] colors_changed = "notify-send 'colors changed' 'colors changed'"`
- Toggle an unrelated setting (e.g. interface scale): no colors-changed notification
- Change theme mode or palette: notification fires
- Wallpaper-driven palette change still fires the hook after templates apply
