### PR TITLE
Decode WebP/VP8X album art (Navidrome size= fallback)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -195,8 +195,9 @@ if not cc.has_header('stb/stb_image_write.h')
   error('stb/stb_image_write.h not found')
 endif
 
-# ── System: libwebp (WebP decode and thumbnail encode) ───────────────────────
-libwebp_dep = dependency('libwebp', required: true)
+# ── System: libwebp (WebP decode and thumbnail encode; demux for animations) ─
+libwebp_dep       = dependency('libwebp', required: true)
+libwebpdemux_dep  = dependency('libwebpdemux', required: true)
 
 # ── System: libjxl (JPEG XL decode) ───────────────────────────────────────────
 libjxl_dep          = dependency('libjxl', required: true)
@@ -1052,6 +1053,7 @@ _noctalia_system_dependencies = [
   tomlplusplus_dep,
   md4c_dep,
   libwebp_dep,
+  libwebpdemux_dep,
   libjxl_dep,
   libjxl_threads_dep,
   sndfile_dep,
@@ -1213,6 +1215,7 @@ if build_tests
     'upower_charge_limit',
     'upower_device_catalog',
     'virtual_grid_view_gesture',
+    'webp_decoder',
     'wayland_output_scale',
     'wayland_toplevels_identity',
     'widget_action',

--- a/src/dbus/mpris/mpris_art.cpp
+++ b/src/dbus/mpris/mpris_art.cpp
@@ -145,9 +145,8 @@ namespace mpris {
       hq += "/hqdefault.jpg";
       candidates.push_back(std::move(hq));
     }
-    if (const std::string stripped = withoutQueryParam(primaryUrl, "size");
-        !stripped.empty() && stripped != primaryUrl) {
-      candidates.push_back(stripped);
+    if (std::string stripped = withoutQueryParam(primaryUrl, "size"); !stripped.empty()) {
+      candidates.push_back(std::move(stripped));
     }
     return candidates;
   }

--- a/src/dbus/mpris/mpris_art.cpp
+++ b/src/dbus/mpris/mpris_art.cpp
@@ -29,6 +29,41 @@ namespace {
     return {};
   }
 
+  // Empty if `key` is not present. Used so cover APIs that 500 on size=N (common
+  // for Subsonic/Navidrome WebP) can fall back to the original bitstream.
+  [[nodiscard]] std::string withoutQueryParam(std::string_view url, std::string_view key) {
+    const auto queryPos = url.find('?');
+    if (queryPos == std::string_view::npos)
+      return {};
+    std::string out(url.substr(0, queryPos + 1));
+    std::string_view query = url.substr(queryPos + 1);
+    bool anyKept = false;
+    bool stripped = false;
+    while (!query.empty()) {
+      const auto ampPos = query.find('&');
+      const std::string_view pair = query.substr(0, ampPos);
+      const auto eqPos = pair.find('=');
+      const std::string_view k = pair.substr(0, eqPos);
+      if (k == key) {
+        stripped = true;
+      } else {
+        if (anyKept)
+          out.push_back('&');
+        out.append(pair);
+        anyKept = true;
+      }
+      if (ampPos == std::string_view::npos)
+        break;
+      query.remove_prefix(ampPos + 1);
+    }
+    if (!stripped)
+      return {};
+    if (!anyKept) {
+      out.pop_back();
+    }
+    return out;
+  }
+
   std::string deriveYouTubeThumbnailUrl(std::string_view sourceUrl, std::string_view quality) {
     if (sourceUrl.empty())
       return {};
@@ -109,6 +144,10 @@ namespace mpris {
       std::string hq(primaryUrl.substr(0, primaryUrl.size() - kMaxres.size()));
       hq += "/hqdefault.jpg";
       candidates.push_back(std::move(hq));
+    }
+    if (const std::string stripped = withoutQueryParam(primaryUrl, "size");
+        !stripped.empty() && stripped != primaryUrl) {
+      candidates.push_back(stripped);
     }
     return candidates;
   }

--- a/src/render/core/image_decoder.cpp
+++ b/src/render/core/image_decoder.cpp
@@ -218,19 +218,41 @@ namespace {
   }
 
   std::expected<DecodedRasterImage, std::string> decodeWebP(const std::uint8_t* data, std::size_t size) {
-    int width = 0, height = 0;
-    std::uint8_t* rgba = WebPDecodeRGBA(data, size, &width, &height);
-    if (rgba == nullptr) {
+    // WebPDecoderConfig decodes still VP8/VP8L and the first frame of animated
+    // VP8X (typical album art). WebPDecodeRGBA() returns null on some VP8X bitstreams.
+    WebPDecoderConfig config;
+    if (!WebPInitDecoderConfig(&config)) {
+      return std::unexpected("libwebp: failed to init decoder");
+    }
+    if (WebPGetFeatures(data, size, &config.input) != VP8_STATUS_OK) {
+      return std::unexpected("libwebp: failed to read WebP header");
+    }
+    config.output.colorspace = MODE_RGBA;
+    if (WebPDecode(data, size, &config) != VP8_STATUS_OK || config.output.u.RGBA.rgba == nullptr) {
+      WebPFreeDecBuffer(&config.output);
       return std::unexpected("libwebp: failed to decode WebP image");
     }
 
+    const int width = config.output.width;
+    const int height = config.output.height;
+    const int stride = config.output.u.RGBA.stride;
     DecodedRasterImage decoded;
     decoded.width = width;
     decoded.height = height;
-    std::size_t bytes = static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4;
-    decoded.pixels.resize(bytes);
-    std::memcpy(decoded.pixels.data(), rgba, bytes);
-    WebPFree(rgba);
+    const std::size_t rowBytes = static_cast<std::size_t>(width) * 4;
+    decoded.pixels.resize(rowBytes * static_cast<std::size_t>(height));
+    const std::uint8_t* rgba = config.output.u.RGBA.rgba;
+    if (stride == static_cast<int>(rowBytes)) {
+      std::memcpy(decoded.pixels.data(), rgba, decoded.pixels.size());
+    } else {
+      for (int y = 0; y < height; ++y) {
+        std::memcpy(
+            decoded.pixels.data() + static_cast<std::size_t>(y) * rowBytes,
+            rgba + static_cast<std::size_t>(y) * static_cast<std::size_t>(stride), rowBytes
+        );
+      }
+    }
+    WebPFreeDecBuffer(&config.output);
     return decoded;
   }
 

--- a/src/render/core/image_decoder.cpp
+++ b/src/render/core/image_decoder.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 #include <webp/decode.h>
+#include <webp/demux.h>
 
 #define WUFFS_IMPLEMENTATION
 #include "wuffs-v0.4.c"
@@ -217,42 +218,61 @@ namespace {
     return decoded;
   }
 
-  std::expected<DecodedRasterImage, std::string> decodeWebP(const std::uint8_t* data, std::size_t size) {
-    // WebPDecoderConfig decodes still VP8/VP8L and the first frame of animated
-    // VP8X (typical album art). WebPDecodeRGBA() returns null on some VP8X bitstreams.
-    WebPDecoderConfig config;
-    if (!WebPInitDecoderConfig(&config)) {
-      return std::unexpected("libwebp: failed to init decoder");
+  // libwebp's still decoder rejects an animated bitstream outright, so animated cover art is
+  // shown as its first frame.
+  std::expected<DecodedRasterImage, std::string> decodeWebPFirstFrame(const std::uint8_t* data, std::size_t size) {
+    WebPAnimDecoderOptions options;
+    if (!WebPAnimDecoderOptionsInit(&options)) {
+      return std::unexpected("libwebp: failed to init animation decoder");
     }
-    if (WebPGetFeatures(data, size, &config.input) != VP8_STATUS_OK) {
+    options.color_mode = MODE_RGBA;
+
+    const WebPData webpData{.bytes = data, .size = size};
+    WebPAnimDecoder* decoder = WebPAnimDecoderNew(&webpData, &options);
+    if (decoder == nullptr) {
+      return std::unexpected("libwebp: failed to open WebP animation");
+    }
+
+    WebPAnimInfo info;
+    std::uint8_t* frame = nullptr;
+    int timestamp = 0;
+    if (!WebPAnimDecoderGetInfo(decoder, &info) || !WebPAnimDecoderGetNext(decoder, &frame, &timestamp)) {
+      WebPAnimDecoderDelete(decoder);
+      return std::unexpected("libwebp: failed to decode first WebP animation frame");
+    }
+
+    // The frame buffer belongs to the decoder and holds one tightly packed RGBA canvas.
+    DecodedRasterImage decoded;
+    decoded.width = static_cast<int>(info.canvas_width);
+    decoded.height = static_cast<int>(info.canvas_height);
+    const std::size_t bytes = static_cast<std::size_t>(info.canvas_width) * info.canvas_height * 4;
+    decoded.pixels.assign(frame, frame + bytes);
+    WebPAnimDecoderDelete(decoder);
+    return decoded;
+  }
+
+  std::expected<DecodedRasterImage, std::string> decodeWebP(const std::uint8_t* data, std::size_t size) {
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(data, size, &features) != VP8_STATUS_OK) {
       return std::unexpected("libwebp: failed to read WebP header");
     }
-    config.output.colorspace = MODE_RGBA;
-    if (WebPDecode(data, size, &config) != VP8_STATUS_OK || config.output.u.RGBA.rgba == nullptr) {
-      WebPFreeDecBuffer(&config.output);
+    if (features.has_animation) {
+      return decodeWebPFirstFrame(data, size);
+    }
+
+    int width = 0, height = 0;
+    std::uint8_t* rgba = WebPDecodeRGBA(data, size, &width, &height);
+    if (rgba == nullptr) {
       return std::unexpected("libwebp: failed to decode WebP image");
     }
 
-    const int width = config.output.width;
-    const int height = config.output.height;
-    const int stride = config.output.u.RGBA.stride;
     DecodedRasterImage decoded;
     decoded.width = width;
     decoded.height = height;
-    const std::size_t rowBytes = static_cast<std::size_t>(width) * 4;
-    decoded.pixels.resize(rowBytes * static_cast<std::size_t>(height));
-    const std::uint8_t* rgba = config.output.u.RGBA.rgba;
-    if (stride == static_cast<int>(rowBytes)) {
-      std::memcpy(decoded.pixels.data(), rgba, decoded.pixels.size());
-    } else {
-      for (int y = 0; y < height; ++y) {
-        std::memcpy(
-            decoded.pixels.data() + static_cast<std::size_t>(y) * rowBytes,
-            rgba + static_cast<std::size_t>(y) * static_cast<std::size_t>(stride), rowBytes
-        );
-      }
-    }
-    WebPFreeDecBuffer(&config.output);
+    const std::size_t bytes = static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4;
+    decoded.pixels.resize(bytes);
+    std::memcpy(decoded.pixels.data(), rgba, bytes);
+    WebPFree(rgba);
     return decoded;
   }
 

--- a/tests/webp_decoder_test.cpp
+++ b/tests/webp_decoder_test.cpp
@@ -1,0 +1,83 @@
+#include "render/core/image_decoder.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <expected>
+#include <print>
+#include <string>
+
+namespace {
+
+  bool check(bool condition, const char* message) {
+    if (!condition) {
+      std::println(stderr, "webp_decoder_test: FAIL: {}", message);
+    }
+    return condition;
+  }
+
+  bool checkDecoded(const std::expected<DecodedRasterImage, std::string>& result, const char* message) {
+    if (result) {
+      return true;
+    }
+    const std::string detail = std::string(message) + ": " + result.error();
+    return check(false, detail.c_str());
+  }
+
+  // 16x16 lossless still, solid opaque red.
+  constexpr std::array<std::uint8_t, 36> kStillRed = {
+      0x52, 0x49, 0x46, 0x46, 0x1C, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x4C, 0x0F, 0x00,
+      0x00, 0x00, 0x2F, 0x0F, 0xC0, 0x03, 0x00, 0x07, 0x10, 0xFD, 0x8F, 0xFE, 0x07, 0x22, 0xA2, 0xFF, 0x01, 0x00,
+  };
+
+  // 16x16 lossless VP8X animation: frame 1 solid red, frame 2 solid blue. The still decoder
+  // rejects it, so it also pins that the decoder returns the *first* frame and not the last.
+  constexpr std::array<std::uint8_t, 140> kAnimatedRedThenBlue = {
+      0x52, 0x49, 0x46, 0x46, 0x84, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x58, 0x0A, 0x00,
+      0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x41, 0x4E, 0x49, 0x4D, 0x06, 0x00,
+      0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x41, 0x4E, 0x4D, 0x46, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x64, 0x00, 0x00, 0x02, 0x56, 0x50, 0x38, 0x4C,
+      0x0F, 0x00, 0x00, 0x00, 0x2F, 0x0F, 0xC0, 0x03, 0x00, 0x07, 0x10, 0xFD, 0x8F, 0xFE, 0x07, 0x22, 0xA2, 0xFF,
+      0x01, 0x00, 0x41, 0x4E, 0x4D, 0x46, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00,
+      0x00, 0x0F, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x56, 0x50, 0x38, 0x4C, 0x0F, 0x00, 0x00, 0x00, 0x2F, 0x0F,
+      0xC0, 0x03, 0x00, 0x07, 0x10, 0xD1, 0xFF, 0xFE, 0x07, 0x22, 0xA2, 0xFF, 0x01, 0x00,
+  };
+
+  bool
+  checkSolid(const DecodedRasterImage& image, std::uint8_t r, std::uint8_t g, std::uint8_t b, const char* message) {
+    if (image.pixels.size() != static_cast<std::size_t>(image.width) * image.height * 4) {
+      return check(false, message);
+    }
+    for (std::size_t i = 0; i < image.pixels.size(); i += 4) {
+      if (image.pixels[i] != r || image.pixels[i + 1] != g || image.pixels[i + 2] != b || image.pixels[i + 3] != 0xFF) {
+        return check(false, message);
+      }
+    }
+    return true;
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  const auto still = decodeRasterImage(kStillRed.data(), kStillRed.size());
+  ok = checkDecoded(still, "still WebP failed to decode") && ok;
+  if (still) {
+    ok = check(still->width == 16 && still->height == 16, "still WebP decoded to the wrong size") && ok;
+    ok = checkSolid(*still, 0xFF, 0x00, 0x00, "still WebP did not decode to opaque red") && ok;
+  }
+
+  const auto animated = decodeRasterImage(kAnimatedRedThenBlue.data(), kAnimatedRedThenBlue.size());
+  ok = checkDecoded(animated, "animated WebP failed to decode") && ok;
+  if (animated) {
+    ok = check(animated->width == 16 && animated->height == 16, "animated WebP decoded to the wrong size") && ok;
+    ok = checkSolid(*animated, 0xFF, 0x00, 0x00, "animated WebP did not decode to its first frame") && ok;
+  }
+
+  // A truncated animation must fail rather than hand back a half-built canvas.
+  const auto truncated = decodeRasterImage(kAnimatedRedThenBlue.data(), 48);
+  ok = check(!truncated.has_value(), "truncated animated WebP decoded instead of failing") && ok;
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4172.

WebP covers from mpris (Navidrome/Feishin `getCoverArt.view?size=300`) never showed in the bar widget or control center. Logs were `artwork unresolved`.

- `mpris::artFetchCandidates`: after the primary URL, retry with the `size` query param stripped.
- `decodeWebP`: `WebPDecoderConfig` + `WebPDecode` so still VP8/VP8L and the first frame of animated VP8X decode.

SHA: `85682273ebe4d56ca623ff91ff83d5abd1fe4ffd`
