### PR TITLE
Ellipsize home media title so shortcut buttons stay square

### DIFF
--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -423,18 +423,24 @@ std::unique_ptr<Flex> HomeTab::create() {
               .text = "...",
               .fontSize = Style::fontSizeBody * 0.95F * scale,
               .color = colorSpecFromRole(ColorRole::OnSurface),
+              .maxLines = 1,
+              .ellipsize = TextEllipsize::End,
           }),
           ui::label({
               .out = &m_mediaArtist,
               .text = i18n::tr("control-center.home.media.no-active-player"),
               .fontSize = Style::fontSizeCaption * scale,
               .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+              .maxLines = 1,
+              .ellipsize = TextEllipsize::End,
           }),
           ui::label({
               .out = &m_mediaStatus,
               .text = i18n::tr("control-center.home.media.idle"),
               .fontSize = Style::fontSizeCaption * scale,
               .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+              .maxLines = 1,
+              .ellipsize = TextEllipsize::End,
           }),
           ui::label({
               .out = &m_mediaProgress,
@@ -442,6 +448,8 @@ std::unique_ptr<Flex> HomeTab::create() {
               .fontSize = Style::fontSizeCaption * scale,
               .color = colorSpecFromRole(ColorRole::Secondary),
               .visible = false,
+              .maxLines = 1,
+              .ellipsize = TextEllipsize::End,
           })
       )
   );
@@ -798,14 +806,16 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
   // height, so this runs again after that final layout pass below.
   resizeMediaArtToCard();
 
-  // Labels auto-wrap to mediaText's assigned width via Flex stretch propagation.
-  for (Label* label : {m_mediaArtist, m_mediaStatus, m_mediaProgress}) {
+  // Keep the media card height stable: one ellipsized line each, capped to the
+  // text column width. Wrapping a long title used to grow this card and stretch
+  // the adjacent shortcut buttons (same bottom-row height).
+  const float mediaTextWrap = m_mediaText != nullptr ? innerWidth(m_mediaText) : 1.0F;
+  for (Label* label : {m_mediaTrack, m_mediaArtist, m_mediaStatus, m_mediaProgress}) {
     if (label != nullptr) {
+      label->setMaxWidth(mediaTextWrap);
       label->setMaxLines(1);
+      label->setEllipsize(TextEllipsize::End);
     }
-  }
-  if (m_mediaTrack != nullptr) {
-    m_mediaTrack->setMaxLines(2);
   }
 
   if (m_userCard != nullptr) {
@@ -877,9 +887,9 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
       const float dateH = std::max(0.0F, avail - mediaH);
 
       m_mediaCard->setMinHeight(mediaH);
-      m_mediaCard->setMaxHeight(0.0F);
+      m_mediaCard->setMaxHeight(mediaH);
       m_dateTimeCard->setMinHeight(dateH);
-      m_dateTimeCard->setMaxHeight(0.0F);
+      m_dateTimeCard->setMaxHeight(dateH);
     }
   }
 


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4113.

Control Center home media card grew with long titles and stretched adjacent shortcut buttons.

`HomeTab::doLayout` / `create`: one-line ellipsis on track/artist; `setMaxHeight(mediaH)` on the media card (was 0 = uncapped).

SHA: `eedf76a8d656381be0fd46d2c077c8242e39a659`
