### PR TITLE
fix(ui): ellipsize labels on stretched buttons

### DIFF
--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -699,7 +699,13 @@ void Button::applyLabelMaxWidth() {
   if (m_label == nullptr) {
     return;
   }
-  const float maxBtnWidth = maxWidth();
+  // Prefer an explicit maxWidth, but also honor the box a parent already assigned
+  // (equal-width segmented buttons never call setMaxWidth, so Russian power-profile
+  // labels overflow the battery/power card without this).
+  float maxBtnWidth = maxWidth();
+  if (width() > 0.0F && (arrangingByLayout() || sizeAssignedByLayout())) {
+    maxBtnWidth = maxBtnWidth > 0.0F ? std::min(maxBtnWidth, width()) : width();
+  }
   if (maxBtnWidth > 0.0F) {
     const float padding = paddingLeft() + paddingRight();
     const float glyphW = (m_glyph != nullptr && m_glyph->visible()) ? m_glyph->width() + gap() : 0.0F;
@@ -731,6 +737,20 @@ void Button::doLayout(Renderer& renderer) {
   // box instead of collapsing back to intrinsic content width.
   if (assignedWidth > 0.0F || assignedHeight > 0.0F) {
     setSizeFromLayout(std::max(width(), assignedWidth), std::max(height(), assignedHeight));
+  }
+
+  // After the stretch pass we finally know the button box. Re-cap the label so
+  // equal-width segments ellipsize instead of painting past their neighbors.
+  if (m_label != nullptr && width() > 0.0F) {
+    const float previousCap = m_label->maxWidth();
+    applyLabelMaxWidth();
+    if (m_label->maxWidth() != previousCap) {
+      m_label->measure(renderer);
+      Flex::doLayout(renderer);
+      if (assignedWidth > 0.0F || assignedHeight > 0.0F) {
+        setSizeFromLayout(std::max(width(), assignedWidth), std::max(height(), assignedHeight));
+      }
+    }
   }
 
   if (glyphOnly && m_contentAlign == ButtonContentAlign::Center) {

--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -695,25 +695,33 @@ void Button::applyVisualState() {
   markPaintDirty();
 }
 
-void Button::applyLabelMaxWidth() {
+void Button::applyLabelMaxWidth(bool honorAssignedBox) {
   if (m_label == nullptr) {
     return;
   }
-  // Prefer an explicit maxWidth, but also honor the box a parent already assigned
-  // (equal-width segmented buttons never call setMaxWidth, so Russian power-profile
-  // labels overflow the battery/power card without this).
+  // Equal-width segmented buttons never call setMaxWidth, so their labels only learn their
+  // budget from the box a parent assigned.
   float maxBtnWidth = maxWidth();
-  if (width() > 0.0F && (arrangingByLayout() || sizeAssignedByLayout())) {
+  if (honorAssignedBox && width() > 0.0F && (arrangingByLayout() || sizeAssignedByLayout())) {
     maxBtnWidth = maxBtnWidth > 0.0F ? std::min(maxBtnWidth, width()) : width();
   }
-  if (maxBtnWidth > 0.0F) {
-    const float padding = paddingLeft() + paddingRight();
-    const float glyphW = (m_glyph != nullptr && m_glyph->visible()) ? m_glyph->width() + gap() : 0.0F;
-    m_label->setMaxWidth(std::max(0.0F, maxBtnWidth - padding - glyphW));
-    m_label->setEllipsize(TextEllipsize::End);
-  } else {
+  if (maxBtnWidth <= 0.0F) {
     m_label->setMaxWidth(0.0F);
+    return;
   }
+
+  const float padding = paddingLeft() + paddingRight();
+  // A glyph only eats into the label's width when it sits beside it; stacked above (vertical
+  // buttons such as the control-center tiles) the label owns the full inner width.
+  const bool glyphSharesRow = m_glyph != nullptr && m_glyph->visible() && direction() == FlexDirection::Horizontal;
+  const float glyphW = glyphSharesRow ? m_glyph->width() + gap() : 0.0F;
+  // Ceil: Label ceils its own box, so a cap derived back out of that box can land a fraction
+  // under the text it already fits and ellipsize a label that does not overflow.
+  m_label->setMaxWidth(std::ceil(std::max(0.0F, maxBtnWidth - padding - glyphW)));
+  // A budget without a line limit wraps instead of ellipsizing: Pango only draws the ellipsis
+  // once the content exceeds an explicit line budget.
+  m_label->setMaxLines(1);
+  m_label->setEllipsize(TextEllipsize::End);
 }
 
 void Button::doLayout(Renderer& renderer) {
@@ -723,12 +731,13 @@ void Button::doLayout(Renderer& renderer) {
   const bool hasVisibleLabel = m_label != nullptr && m_label->visible();
   const bool glyphOnly = m_glyph != nullptr && !hasVisibleLabel;
 
-  if (m_label != nullptr) {
-    applyLabelMaxWidth();
-    m_label->measure(renderer);
-  }
+  // The label's budget subtracts the glyph's measured width, so the glyph measures first.
   if (m_glyph != nullptr) {
     m_glyph->measure(renderer);
+  }
+  if (m_label != nullptr) {
+    applyLabelMaxWidth(/*honorAssignedBox=*/true);
+    m_label->measure(renderer);
   }
 
   Flex::doLayout(renderer);
@@ -737,20 +746,6 @@ void Button::doLayout(Renderer& renderer) {
   // box instead of collapsing back to intrinsic content width.
   if (assignedWidth > 0.0F || assignedHeight > 0.0F) {
     setSizeFromLayout(std::max(width(), assignedWidth), std::max(height(), assignedHeight));
-  }
-
-  // After the stretch pass we finally know the button box. Re-cap the label so
-  // equal-width segments ellipsize instead of painting past their neighbors.
-  if (m_label != nullptr && width() > 0.0F) {
-    const float previousCap = m_label->maxWidth();
-    applyLabelMaxWidth();
-    if (m_label->maxWidth() != previousCap) {
-      m_label->measure(renderer);
-      Flex::doLayout(renderer);
-      if (assignedWidth > 0.0F || assignedHeight > 0.0F) {
-        setSizeFromLayout(std::max(width(), assignedWidth), std::max(height(), assignedHeight));
-      }
-    }
   }
 
   if (glyphOnly && m_contentAlign == ButtonContentAlign::Center) {
@@ -841,7 +836,8 @@ void Button::doLayout(Renderer& renderer) {
 }
 
 LayoutSize Button::doMeasure(Renderer& renderer, const LayoutConstraints& constraints) {
-  applyLabelMaxWidth();
+  // Measuring reports intrinsic size; the assigned box is last pass's and would cap it.
+  applyLabelMaxWidth(/*honorAssignedBox=*/false);
   return measureByLayout(renderer, constraints);
 }
 

--- a/src/ui/controls/button.h
+++ b/src/ui/controls/button.h
@@ -113,7 +113,9 @@ private:
   void applyColors(const Color& bg, const Color& border, const Color& label);
 
   // Constrain the label to the button's max width (minus padding/glyph) and ellipsize on overflow.
-  void applyLabelMaxWidth();
+  // `honorAssignedBox` also caps against the box a parent assigned, which equal-width segmented
+  // buttons rely on; measuring must not, or the label reports the previous pass's width.
+  void applyLabelMaxWidth(bool honorAssignedBox);
 
   void ensureBadge();
 

--- a/tests/button_layout_test.cpp
+++ b/tests/button_layout_test.cpp
@@ -2,7 +2,10 @@
 #include "render/core/texture_manager.h"
 #include "ui/controls/button.h"
 #include "ui/controls/glyph.h"
+#include "ui/controls/label.h"
+#include "ui/style.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <print>
@@ -13,10 +16,30 @@ namespace {
 
   class StubRenderer final : public Renderer {
   public:
+    // Fixed-advance shaping, so a wrap budget maps to an exact character count and the
+    // resulting line count is predictable.
     TextMetrics measureText(
-        std::string_view, float fontSize, FontWeight, float, int, TextAlign, std::string_view, TextEllipsize, bool
+        std::string_view text, float fontSize, FontWeight, float maxWidth, int maxLines, TextAlign, std::string_view,
+        TextEllipsize, bool
     ) override {
-      return TextMetrics{.bottom = fontSize};
+      constexpr float kAdvance = 10.0F;
+      const float natural = static_cast<float>(text.size()) * kAdvance;
+      float width = natural;
+      int lineCount = text.empty() ? 0 : 1;
+      if (maxWidth > 0.0F && natural > maxWidth) {
+        const float perLine = std::floor(maxWidth / kAdvance) * kAdvance;
+        lineCount = perLine > 0.0F ? static_cast<int>(std::ceil(natural / perLine)) : 1;
+        if (maxLines > 0) {
+          lineCount = std::min(lineCount, maxLines);
+        }
+        width = maxWidth;
+      }
+      return TextMetrics{
+          .width = width,
+          .right = width,
+          .bottom = fontSize * static_cast<float>(lineCount),
+          .lineCount = lineCount,
+      };
     }
 
     TextMetrics measureFont(float fontSize, FontWeight) override { return TextMetrics{.bottom = fontSize}; }
@@ -84,6 +107,83 @@ int main() {
     std::println(
         stderr, "button_layout_test: expected a 21px glyph in a 32px button at (5.5, 5.5), got ({}, {})", glyph->x(),
         glyph->y()
+    );
+    return 1;
+  }
+
+  // A button stretched narrower than its text keeps the label on one line and hands it a
+  // budget derived from the assigned box, rather than wrapping inside a fixed-height row.
+  Button stretched;
+  stretched.setText("a segmented label");
+  stretched.setPadding(6.0F);
+  stretched.arrange(renderer, LayoutRect{.x = 0.0F, .y = 0.0F, .width = 90.0F, .height = 30.0F});
+
+  const Label* stretchedLabel = stretched.label();
+  if (stretchedLabel == nullptr) {
+    std::println(stderr, "button_layout_test: stretched button has no label");
+    return 1;
+  }
+  if (!near(stretchedLabel->maxWidth(), 78.0F)) {
+    std::println(
+        stderr, "button_layout_test: expected a 78px label budget in a 90px button, got {}", stretchedLabel->maxWidth()
+    );
+    return 1;
+  }
+  if (stretchedLabel->ellipsize() != TextEllipsize::End) {
+    std::println(stderr, "button_layout_test: stretched label does not ellipsize");
+    return 1;
+  }
+  if (stretchedLabel->height() > Style::fontSizeBody * 1.5F) {
+    std::println(
+        stderr, "button_layout_test: stretched label wrapped instead of ellipsizing (height {})",
+        stretchedLabel->height()
+    );
+    return 1;
+  }
+
+  // An unconstrained button must not inherit a budget and must not clip its own text.
+  Button intrinsic;
+  intrinsic.setText("fits");
+  intrinsic.setPadding(6.0F);
+  intrinsic.layout(renderer);
+  const Label* intrinsicLabel = intrinsic.label();
+  if (intrinsicLabel == nullptr || !near(intrinsicLabel->maxWidth(), 0.0F)) {
+    std::println(stderr, "button_layout_test: unconstrained button capped its label");
+    return 1;
+  }
+
+  // A glyph stacked above the label (control-center tiles) leaves the full inner width to the
+  // label; only a glyph beside it takes a share.
+  Button stacked;
+  stacked.setGlyph("home");
+  stacked.setGlyphSize(21.0F);
+  stacked.setText("Bluetooth");
+  stacked.setPadding(6.0F);
+  stacked.setDirection(FlexDirection::Vertical);
+  stacked.arrange(renderer, LayoutRect{.x = 0.0F, .y = 0.0F, .width = 90.0F, .height = 60.0F});
+  if (stacked.label() == nullptr || !near(stacked.label()->maxWidth(), 78.0F)) {
+    std::println(
+        stderr, "button_layout_test: stacked glyph stole label width, budget {}",
+        stacked.label() == nullptr ? -1.0F : stacked.label()->maxWidth()
+    );
+    return 1;
+  }
+
+  Button beside;
+  beside.setGlyph("home");
+  beside.setGlyphSize(21.0F);
+  beside.setText("Bluetooth");
+  beside.setPadding(6.0F);
+  beside.arrange(renderer, LayoutRect{.x = 0.0F, .y = 0.0F, .width = 90.0F, .height = 30.0F});
+  if (beside.label() == nullptr || beside.glyph() == nullptr) {
+    std::println(stderr, "button_layout_test: row button missing label or glyph");
+    return 1;
+  }
+  const float besideExpected = std::ceil(78.0F - (beside.glyph()->width() + beside.gap()));
+  if (!near(beside.label()->maxWidth(), besideExpected)) {
+    std::println(
+        stderr, "button_layout_test: expected a {}px budget beside a glyph, got {}", besideExpected,
+        beside.label()->maxWidth()
     );
     return 1;
   }


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4065.

Russian (and other long) power-profile labels overflow equal-width segmented buttons because those segments never set `Button::maxWidth`.

Cap the label to the assigned button box and ellipsize at the end.

SHA: `129cd8733a1b4ccc8b77b7782a1ca52e95e57dc3`
