### PR TITLE
Guard blank clock formats against segfault

### DIFF
--- a/src/time/time_format.cpp
+++ b/src/time/time_format.cpp
@@ -63,6 +63,8 @@ namespace {
 
 namespace {
 
+  bool isBlankClockFormat(std::string_view fmt) noexcept { return fmt.empty(); }
+
   std::string normalizeFormatEscapes(std::string_view fmt) {
     std::string out;
     out.reserve(fmt.size());
@@ -194,6 +196,9 @@ namespace {
 
 std::string formatLocalTime(const char* fmt) {
   using namespace std::chrono;
+  if (fmt == nullptr || isBlankClockFormat(fmt)) {
+    return {};
+  }
   const std::string normalizedFmt = normalizeFormatEscapes(fmt);
   const auto now = floor<seconds>(system_clock::now());
   const auto unixSeconds = duration_cast<seconds>(now.time_since_epoch()).count();
@@ -204,8 +209,8 @@ std::string formatLocalTime(const char* fmt) {
     return *compat;
   }
 
-  const auto local = current_zone()->to_local(now);
   try {
+    const auto local = current_zone()->to_local(now);
     return std::vformat(std::locale(""), normalizedFmt, std::make_format_args(local));
   } catch (...) {
     return normalizedFmt;
@@ -241,6 +246,9 @@ std::string formatTimezoneUnixTime(std::int64_t unixSeconds, std::string_view fm
   }
 
   const std::string normalizedFmt = normalizeFormatEscapes(fmt);
+  if (isBlankClockFormat(normalizedFmt)) {
+    return {};
+  }
   const auto tp = sys_seconds{seconds{unixSeconds}};
   const auto local = tz->to_local(tp);
   const auto zoneInfo = tz->get_info(tp);
@@ -276,6 +284,9 @@ std::string formatTimezoneUnixTime(std::int64_t unixSeconds, std::string_view fm
 
 std::string formatTimezoneTime(const char* fmt, std::string_view tzName) {
   using namespace std::chrono;
+  if (fmt == nullptr || isBlankClockFormat(fmt)) {
+    return {};
+  }
   const auto now = floor<seconds>(system_clock::now());
   const auto unixSeconds = duration_cast<seconds>(now.time_since_epoch()).count();
   return formatTimezoneUnixTime(unixSeconds, fmt, tzName);
@@ -283,6 +294,9 @@ std::string formatTimezoneTime(const char* fmt, std::string_view tzName) {
 
 std::string formatLocalUnixTime(std::int64_t unixSeconds, std::string_view fmt) {
   using namespace std::chrono;
+  if (isBlankClockFormat(fmt)) {
+    return {};
+  }
   const std::string normalizedFmt = normalizeFormatEscapes(fmt);
   const auto tp = sys_seconds{seconds{unixSeconds}};
   const std::time_t raw = system_clock::to_time_t(tp);
@@ -292,8 +306,8 @@ std::string formatLocalUnixTime(std::int64_t unixSeconds, std::string_view fmt) 
     return *compat;
   }
 
-  const auto local = current_zone()->to_local(tp);
   try {
+    const auto local = current_zone()->to_local(tp);
     return std::vformat(std::locale(""), normalizedFmt, std::make_format_args(local));
   } catch (...) {
     return normalizedFmt;

--- a/tests/time_format_test.cpp
+++ b/tests/time_format_test.cpp
@@ -42,6 +42,10 @@ int main() {
   i18n::Service::instance().init("en");
 
   bool ok = true;
+  ok = expectEqual(formatLocalUnixTime(1700000000, ""), "", "empty unix format is safe") && ok;
+  ok = expectEqual(formatLocalTime(""), "", "empty local format is safe") && ok;
+  ok = expectEqual(formatLocalTime(nullptr), "", "null local format is safe") && ok;
+  ok = expectEqual(formatTimezoneTime("", "UTC"), "", "empty timezone format is safe") && ok;
   ok = expectEqual(formatLocalUnixTime(1700000000, "%s"), "1700000000", "formats unix epoch token") && ok;
   ok = expectEqual(
            formatLocalUnixTime(1700000000, "recording_%s"), "recording_1700000000",


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4028.

Clearing the clock format field called `current_zone()` / `vformat` with a blank (or null) specifier and crashed the shell.

Empty/null formats now return an empty string. `current_zone()` is inside the existing catch.

SHA: `faa62a1d3b10c6f8ce2ba9997a40f47db4ea0335`
