### PR TITLE
Close 1px dock-to-screen gap on fractional scale

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1153,6 +1153,7 @@ if build_tests
     'desktop_entry_launch',
     'desktop_entry_localization',
     'disk_mounts',
+    'dock_edge_overlap',
     'dock_pinned_apps',
     'event_link',
     'fcitx_status',

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -784,6 +784,7 @@ void Dock::createInstance(const WaylandOutput& output) {
   instance->outputName = output.name;
   instance->output = output.output;
   instance->scale = output.scale;
+  instance->fractionalScale = (output.configuredScaleNumerator % wayland::kScaleNumeratorBase) != 0;
   instance->outputLogicalX = output.logicalX;
   instance->outputLogicalY = output.logicalY;
   instance->outputLogicalWidth = output.effectiveLogicalWidth();
@@ -791,7 +792,7 @@ void Dock::createInstance(const WaylandOutput& output) {
 
   const auto& shadowConfig = m_config->config().shell.shadow;
   LayerSurfaceConfig lsCfg = shell::dock::makeLayerSurfaceConfig(
-      cfg, shadowConfig, cfg.pinned.size() + shell::dock::dockLauncherButtonCount(cfg)
+      cfg, shadowConfig, cfg.pinned.size() + shell::dock::dockLauncherButtonCount(cfg), instance->fractionalScale
   );
 
   instance->surface = std::make_unique<LayerSurface>(m_platform->wayland(), std::move(lsCfg));

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -11,8 +11,9 @@ namespace shell::dock {
 
     constexpr std::int32_t kCellPad = 6;
     constexpr std::int32_t kAutoHideTriggerPx = 2;
-    // Fractional scale (e.g. niri 1.75) can leave a 1 device-pixel gap at the
-    // output edge; overlap the screen edge when the dock is flush (#4152).
+    // A non-integer output scale can round the flush edge a device pixel short of the output and
+    // leave a visible gap. One logical pixel of overlap covers it. At integer scales the edge
+    // lands exactly, and the same overlap would only clip the panel's own bottom row.
     constexpr std::int32_t kScreenEdgeOverlapPx = 1;
     constexpr float kAutoHideSlideExtraPx = 16.0F;
     // Keep in sync with dock_items instance-count badge geometry.
@@ -26,6 +27,11 @@ namespace shell::dock {
         return 0;
       }
       return cfg.marginEdge;
+    }
+
+    [[nodiscard]] std::int32_t dockScreenEdgeOverlap(const DockConfig& cfg, bool fractionalScale) noexcept {
+      const bool flush = cfg.marginEdge <= 0 && dockAutoHideEdgeGutter(cfg) == 0;
+      return flush && fractionalScale ? kScreenEdgeOverlapPx : 0;
     }
 
     [[nodiscard]] float dockHoverZoomPeakScale(const DockConfig& cfg) noexcept {
@@ -177,8 +183,9 @@ namespace shell::dock {
 
   std::size_t dockLauncherButtonCount(const DockConfig& cfg) { return dockLauncherButtonCount(cfg.launcherPosition); }
 
-  DockSurfaceGeometry
-  computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
+  DockSurfaceGeometry computeSurfaceGeometry(
+      const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount, bool fractionalScale
+  ) {
     const DockEdge edge = cfg.position;
     const bool vertical = isVerticalEdge(edge);
     const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
@@ -196,6 +203,7 @@ namespace shell::dock {
     const bool isRight = edge == DockEdge::Right;
     const std::int32_t mEdge = cfg.marginEdge;
     const int edgeGutter = dockAutoHideEdgeGutter(cfg);
+    const std::int32_t edgeOverlap = dockScreenEdgeOverlap(cfg, fractionalScale);
 
     DockSurfaceGeometry geometry;
     if (!vertical) {
@@ -206,7 +214,7 @@ namespace shell::dock {
         if (edgeGutter > 0) {
           geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + edgeGutter + zoomPad);
         } else {
-          geometry.marginBottom = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.down);
+          geometry.marginBottom = mEdge <= 0 ? -edgeOverlap : std::max(0, mEdge - sb.down);
           geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(mEdge, sb.down) + zoomPad);
         }
         geometry.exclusiveZone = cfg.reserveSpace ? (panelH + std::min(mEdge, sb.down)) : 0;
@@ -214,7 +222,7 @@ namespace shell::dock {
         if (edgeGutter > 0) {
           geometry.surfaceH = static_cast<std::uint32_t>(edgeBadgePad + sb.down + panelH + edgeGutter + zoomPad);
         } else {
-          geometry.marginTop = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.up);
+          geometry.marginTop = mEdge <= 0 ? -edgeOverlap : std::max(0, mEdge - sb.up);
           geometry.surfaceH =
               static_cast<std::uint32_t>(edgeBadgePad + std::min(mEdge, sb.up) + panelH + sb.down + zoomPad);
         }
@@ -230,7 +238,7 @@ namespace shell::dock {
       if (edgeGutter > 0) {
         geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + edgeGutter + zoomPad);
       } else {
-        geometry.marginRight = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.right);
+        geometry.marginRight = mEdge <= 0 ? -edgeOverlap : std::max(0, mEdge - sb.right);
         geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + std::min(mEdge, sb.right) + zoomPad);
       }
       geometry.exclusiveZone = cfg.reserveSpace ? (panelH + std::min(mEdge, sb.right)) : 0;
@@ -238,7 +246,7 @@ namespace shell::dock {
       if (edgeGutter > 0) {
         geometry.surfaceW = static_cast<std::uint32_t>(sb.right + panelH + edgeGutter + zoomPad);
       } else {
-        geometry.marginLeft = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.left);
+        geometry.marginLeft = mEdge <= 0 ? -edgeOverlap : std::max(0, mEdge - sb.left);
         geometry.surfaceW = static_cast<std::uint32_t>(std::min(mEdge, sb.left) + panelH + sb.right + zoomPad);
       }
       geometry.exclusiveZone = cfg.reserveSpace ? (std::min(mEdge, sb.left) + panelH) : 0;
@@ -246,9 +254,10 @@ namespace shell::dock {
     return geometry;
   }
 
-  LayerSurfaceConfig
-  makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
-    const auto geometry = computeSurfaceGeometry(cfg, shadow, itemCount);
+  LayerSurfaceConfig makeLayerSurfaceConfig(
+      const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount, bool fractionalScale
+  ) {
+    const auto geometry = computeSurfaceGeometry(cfg, shadow, itemCount, fractionalScale);
     return LayerSurfaceConfig{
         .nameSpace = "noctalia-dock",
         .layer = layerShellLayerFromConfig(cfg.layer),
@@ -350,20 +359,25 @@ namespace shell::dock {
     return {-(contentRight + kAutoHideSlideExtraPx), 0.0F};
   }
 
-  std::vector<InputRect>
-  computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden) {
+  std::vector<InputRect> computeInputRegion(
+      const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden,
+      bool fractionalScale
+  ) {
     if (hidden) {
       const DockEdge edge = cfg.position;
+      // The part of the surface pushed past the output edge cannot be hovered, so the trigger
+      // strip grows by the overlap to keep its on-screen thickness.
+      const int trigger = kAutoHideTriggerPx + dockScreenEdgeOverlap(cfg, fractionalScale);
       if (edge == DockEdge::Bottom) {
-        return {InputRect{0, surfaceH - kAutoHideTriggerPx, surfaceW, kAutoHideTriggerPx}};
+        return {InputRect{0, surfaceH - trigger, surfaceW, trigger}};
       }
       if (edge == DockEdge::Left) {
-        return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};
+        return {InputRect{0, 0, trigger, surfaceH}};
       }
       if (edge == DockEdge::Right) {
-        return {InputRect{surfaceW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfaceH}};
+        return {InputRect{surfaceW - trigger, 0, trigger, surfaceH}};
       }
-      return {InputRect{0, 0, surfaceW, kAutoHideTriggerPx}};
+      return {InputRect{0, 0, surfaceW, trigger}};
     }
 
     return {InputRect{

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -11,6 +11,9 @@ namespace shell::dock {
 
     constexpr std::int32_t kCellPad = 6;
     constexpr std::int32_t kAutoHideTriggerPx = 2;
+    // Fractional scale (e.g. niri 1.75) can leave a 1 device-pixel gap at the
+    // output edge; overlap the screen edge when the dock is flush (#4152).
+    constexpr std::int32_t kScreenEdgeOverlapPx = 1;
     constexpr float kAutoHideSlideExtraPx = 16.0F;
     // Keep in sync with dock_items instance-count badge geometry.
     constexpr float kBadgeSizeRatio = 0.30F;
@@ -203,7 +206,7 @@ namespace shell::dock {
         if (edgeGutter > 0) {
           geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + edgeGutter + zoomPad);
         } else {
-          geometry.marginBottom = std::max(0, mEdge - sb.down);
+          geometry.marginBottom = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.down);
           geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(mEdge, sb.down) + zoomPad);
         }
         geometry.exclusiveZone = cfg.reserveSpace ? (panelH + std::min(mEdge, sb.down)) : 0;
@@ -211,7 +214,7 @@ namespace shell::dock {
         if (edgeGutter > 0) {
           geometry.surfaceH = static_cast<std::uint32_t>(edgeBadgePad + sb.down + panelH + edgeGutter + zoomPad);
         } else {
-          geometry.marginTop = std::max(0, mEdge - sb.up);
+          geometry.marginTop = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.up);
           geometry.surfaceH =
               static_cast<std::uint32_t>(edgeBadgePad + std::min(mEdge, sb.up) + panelH + sb.down + zoomPad);
         }
@@ -227,7 +230,7 @@ namespace shell::dock {
       if (edgeGutter > 0) {
         geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + edgeGutter + zoomPad);
       } else {
-        geometry.marginRight = std::max(0, mEdge - sb.right);
+        geometry.marginRight = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.right);
         geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + std::min(mEdge, sb.right) + zoomPad);
       }
       geometry.exclusiveZone = cfg.reserveSpace ? (panelH + std::min(mEdge, sb.right)) : 0;
@@ -235,7 +238,7 @@ namespace shell::dock {
       if (edgeGutter > 0) {
         geometry.surfaceW = static_cast<std::uint32_t>(sb.right + panelH + edgeGutter + zoomPad);
       } else {
-        geometry.marginLeft = std::max(0, mEdge - sb.left);
+        geometry.marginLeft = mEdge <= 0 ? -kScreenEdgeOverlapPx : std::max(0, mEdge - sb.left);
         geometry.surfaceW = static_cast<std::uint32_t>(std::min(mEdge, sb.left) + panelH + sb.right + zoomPad);
       }
       geometry.exclusiveZone = cfg.reserveSpace ? (std::min(mEdge, sb.left) + panelH) : 0;

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -49,17 +49,24 @@ namespace shell::dock {
   [[nodiscard]] std::int32_t dockHoverZoomMainPad(const DockConfig& cfg);
   [[nodiscard]] std::size_t dockLauncherButtonCount(DockLauncherPosition position);
   [[nodiscard]] std::size_t dockLauncherButtonCount(const DockConfig& cfg);
-  [[nodiscard]] DockSurfaceGeometry
-  computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
-  [[nodiscard]] LayerSurfaceConfig
-  makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
+  // `fractionalScale` marks an output whose scale is not an integer: a flush dock overlaps the
+  // screen edge by a logical pixel there, because the compositor can otherwise round the edge a
+  // device pixel short and leave a gap.
+  [[nodiscard]] DockSurfaceGeometry computeSurfaceGeometry(
+      const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount, bool fractionalScale
+  );
+  [[nodiscard]] LayerSurfaceConfig makeLayerSurfaceConfig(
+      const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount, bool fractionalScale
+  );
   [[nodiscard]] DockPanelGeometry
   computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH);
   [[nodiscard]] std::pair<float, float> computeHiddenSlideDelta(
       const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
       const DockPanelGeometry& panel
   );
-  [[nodiscard]] std::vector<InputRect>
-  computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden);
+  [[nodiscard]] std::vector<InputRect> computeInputRegion(
+      const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden,
+      bool fractionalScale
+  );
 
 } // namespace shell::dock

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -146,7 +146,9 @@ namespace shell::dock {
     }
 
     if (!dockUsesAnyAutoHide(cfg)) {
-      instance.surface->setInputRegion(shell::dock::computeInputRegion(cfg, panelGeometry, surfW, surfH, false));
+      instance.surface->setInputRegion(
+          shell::dock::computeInputRegion(cfg, panelGeometry, surfW, surfH, false, instance.fractionalScale)
+      );
       return;
     }
 
@@ -157,7 +159,9 @@ namespace shell::dock {
       instance.surface->setInputRegion({InputRect{0, 0, surfW, surfH}});
       return;
     }
-    instance.surface->setInputRegion(shell::dock::computeInputRegion(cfg, DockPanelGeometry{}, surfW, surfH, true));
+    instance.surface->setInputRegion(
+        shell::dock::computeInputRegion(cfg, DockPanelGeometry{}, surfW, surfH, true, instance.fractionalScale)
+    );
   }
 
   void applyDockCompositorBlur(DockInstance& instance, const DockConfig& cfg) {
@@ -363,7 +367,7 @@ namespace shell::dock {
     }
 
     const auto surfaceGeometry = shell::dock::computeSurfaceGeometry(
-        cfg, shadowConfig, instance.items.size() + shell::dock::dockLauncherButtonCount(cfg)
+        cfg, shadowConfig, instance.items.size() + shell::dock::dockLauncherButtonCount(cfg), instance.fractionalScale
     );
 
     if (instance.surface->width() != surfaceGeometry.surfaceW

--- a/src/shell/dock/dock_instance.h
+++ b/src/shell/dock/dock_instance.h
@@ -27,6 +27,8 @@ namespace shell::dock {
     std::uint32_t outputName = 0;
     wl_output* output = nullptr;
     std::int32_t scale = 1;
+    // Output scale is not an integer, so a flush dock has to overlap the screen edge.
+    bool fractionalScale = false;
     std::int32_t outputLogicalX = 0;
     std::int32_t outputLogicalY = 0;
     std::int32_t outputLogicalWidth = 0;

--- a/tests/dock_edge_overlap_test.cpp
+++ b/tests/dock_edge_overlap_test.cpp
@@ -1,0 +1,85 @@
+// A flush dock only overlaps the screen edge on a fractionally scaled output, where the
+// compositor can round the edge a device pixel short. At an integer scale the overlap would
+// clip the panel's own edge row, so the surface must sit exactly on the boundary.
+
+#include "config/config_types.h"
+#include "shell/dock/dock_geometry.h"
+#include "tests/test_check.h"
+#include "wayland/surface.h"
+
+#include <cstddef>
+
+namespace {
+
+  constexpr std::size_t kItemCount = 4;
+
+  DockConfig flushDock(DockEdge edge) {
+    DockConfig cfg;
+    cfg.position = edge;
+    cfg.marginEdge = 0;
+    cfg.shadow = false;
+    return cfg;
+  }
+
+  shell::dock::DockSurfaceGeometry geometryFor(const DockConfig& cfg, bool fractionalScale) {
+    const ShellConfig::ShadowConfig shadow;
+    return shell::dock::computeSurfaceGeometry(cfg, shadow, kItemCount, fractionalScale);
+  }
+
+  int edgeMargin(const shell::dock::DockSurfaceGeometry& geometry, DockEdge edge) {
+    switch (edge) {
+    case DockEdge::Bottom:
+      return geometry.marginBottom;
+    case DockEdge::Top:
+      return geometry.marginTop;
+    case DockEdge::Left:
+      return geometry.marginLeft;
+    case DockEdge::Right:
+      return geometry.marginRight;
+    }
+    return 0;
+  }
+
+} // namespace
+
+int main() {
+  constexpr DockEdge kEdges[] = {DockEdge::Bottom, DockEdge::Top, DockEdge::Left, DockEdge::Right};
+
+  for (const DockEdge edge : kEdges) {
+    const DockConfig cfg = flushDock(edge);
+    TEST_CHECK(edgeMargin(geometryFor(cfg, /*fractionalScale=*/false), edge) == 0);
+    TEST_CHECK(edgeMargin(geometryFor(cfg, /*fractionalScale=*/true), edge) == -1);
+
+    // Surface size and reserved space describe the dock itself and must not move with the
+    // overlap, or the dock would reserve a pixel it does not paint.
+    const auto integerGeometry = geometryFor(cfg, /*fractionalScale=*/false);
+    const auto fractionalGeometry = geometryFor(cfg, /*fractionalScale=*/true);
+    TEST_CHECK(integerGeometry.surfaceW == fractionalGeometry.surfaceW);
+    TEST_CHECK(integerGeometry.surfaceH == fractionalGeometry.surfaceH);
+    TEST_CHECK(integerGeometry.exclusiveZone == fractionalGeometry.exclusiveZone);
+  }
+
+  // A dock held off the edge by a margin is already clear of the rounding, so it never overlaps.
+  for (const DockEdge edge : kEdges) {
+    DockConfig cfg = flushDock(edge);
+    cfg.marginEdge = 8;
+    TEST_CHECK(edgeMargin(geometryFor(cfg, /*fractionalScale=*/true), edge) >= 0);
+  }
+
+  // The hidden auto-hide trigger strip keeps its on-screen thickness: the part of the surface
+  // pushed past the output edge cannot be hovered.
+  {
+    DockConfig cfg = flushDock(DockEdge::Bottom);
+    cfg.autoHide = true;
+    const auto integerRegion =
+        shell::dock::computeInputRegion(cfg, shell::dock::DockPanelGeometry{}, 200, 60, true, false);
+    const auto fractionalRegion =
+        shell::dock::computeInputRegion(cfg, shell::dock::DockPanelGeometry{}, 200, 60, true, true);
+    TEST_CHECK(integerRegion.size() == 1);
+    TEST_CHECK(fractionalRegion.size() == 1);
+    TEST_CHECK(fractionalRegion[0].height == integerRegion[0].height + 1);
+    TEST_CHECK(fractionalRegion[0].y == integerRegion[0].y - 1);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4152.

Flush docks (`margin_edge = 0`) can sit 1 device pixel off the output edge at fractional scale (repro: niri 1.75).

Layer-shell screen-edge margin is -1px when the dock is flush.

SHA: `7412542104a82bb49cf71ed6353114db36577411`
