### PR TITLE
Destroy dock tooltips when auto-hide starts

### DIFF
--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -406,6 +406,9 @@ namespace shell::dock {
   }
 
   void startHideFadeOut(DockInstance& inst, ConfigService& config) {
+    // xdg tooltips are not parent-transformed with the slide; destroy immediately
+    // so they cannot remain pinned after auto-hide starts (#4177).
+    TooltipManager::instance().forceDestroy();
     if (inst.hideAnimId != 0) {
       inst.animations.cancel(inst.hideAnimId);
       inst.hideAnimId = 0;


### PR DESCRIPTION
Fixes noctalia-dev/noctalia#4177.

Dock auto-hide slides the panel with a scene transform. xdg tooltips stay at their last position, so a race on pointer leave left an orphan tooltip.

`startHideFadeOut` now `forceDestroy()`s the tooltip immediately.

SHA: `42e64da1b57c240feaf568351835bddba0166670`
