### PR TITLE
fix(config): wallpaper overridden by first settings.toml save

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1150,6 +1150,7 @@ if build_tests
     'config_override_mutation',
     'config_path_resolution',
     'config_schema_roundtrip',
+    'config_wallpaper_precedence',
     'config_widget',
     'context_menu_popup',
     'cpu_freq',

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -1976,7 +1976,6 @@ bool ConfigService::commitOverrideTable(toml::table next, bool* changed) {
   if (changed != nullptr) {
     *changed = true;
   }
-  extractWallpaperFromOverrides();
   loadAll();
   fireReloadCallbacks();
   return true;
@@ -2128,7 +2127,6 @@ bool ConfigService::renameOverrideTable(
   }
 
   m_ownOverridesWritePending = true;
-  extractWallpaperFromOverrides();
   loadAll();
   fireReloadCallbacks();
   return true;

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1539,7 +1539,6 @@ void ConfigService::loadAll() {
       m_overridesTable = std::move(effectiveOverrides);
       if (writeOverridesToFile()) {
         m_ownOverridesWritePending = m_inotify.fd() >= 0 && m_overridesWatchWd >= 0;
-        extractWallpaperFromOverrides();
       } else {
         kLog.warn("failed to persist migrated config overrides to {}", m_overridesPath);
         m_overridesTable = std::move(previousOverrides);

--- a/tests/config_wallpaper_precedence_test.cpp
+++ b/tests/config_wallpaper_precedence_test.cpp
@@ -1,0 +1,104 @@
+#include "config/config_service.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <print>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+namespace {
+
+  int g_failures = 0;
+
+  void expect(bool condition, std::string_view message) {
+    if (!condition) {
+      std::println(stderr, "config_wallpaper_precedence_test: FAIL: {}", message);
+      ++g_failures;
+    }
+  }
+
+  // Check that wallpaper setting from config.toml isn't dropped when state/settings.toml
+  // is written for the first time.
+  void checkConfigSurvivesFirstSidecarWrite() {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("noctalia-wallpaper-config-file-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config" / "noctalia");
+    std::filesystem::create_directories(root / "state" / "noctalia");
+    std::filesystem::create_directories(root / "data");
+    ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+    ::setenv("NOCTALIA_STATE_HOME", (root / "state").c_str(), 1);
+    ::setenv("NOCTALIA_DATA_HOME", (root / "data").c_str(), 1);
+
+    {
+      std::ofstream out(root / "config" / "noctalia" / "config.toml", std::ios::trunc);
+      out << "[wallpaper]\nenabled = true\n\n[wallpaper.default]\npath = \"/tmp/from-config.png\"\n";
+    }
+    const auto sidecar = root / "state" / "noctalia" / "settings.toml";
+    expect(!std::filesystem::exists(sidecar), "state dir should start without settings.toml");
+
+    ConfigService config;
+    expect(config.getDefaultWallpaperPath() == "/tmp/from-config.png", "path was not read from config.toml");
+
+    expect(config.setOverride({"accessibility", "ui_scale"}, 1.25), "setOverride failed");
+    expect(std::filesystem::exists(sidecar), "setOverride did not create settings.toml");
+
+    expect(
+        config.getDefaultWallpaperPath() == "/tmp/from-config.png",
+        "config.toml path was dropped by the first sidecar write"
+    );
+
+    ::unsetenv("NOCTALIA_CONFIG_HOME");
+    ::unsetenv("NOCTALIA_STATE_HOME");
+    ::unsetenv("NOCTALIA_DATA_HOME");
+    std::filesystem::remove_all(root);
+  }
+
+  // State settings loads last, so it should outranks config.toml
+  void checkSidecarPathOutranksConfigFilePath() {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("noctalia-wallpaper-sidecar-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config" / "noctalia");
+    std::filesystem::create_directories(root / "state" / "noctalia");
+    std::filesystem::create_directories(root / "data");
+    ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+    ::setenv("NOCTALIA_STATE_HOME", (root / "state").c_str(), 1);
+    ::setenv("NOCTALIA_DATA_HOME", (root / "data").c_str(), 1);
+
+    {
+      std::ofstream out(root / "config" / "noctalia" / "config.toml", std::ios::trunc);
+      out << "[wallpaper]\nenabled = true\n\n[wallpaper.default]\npath = \"/tmp/from-config.png\"\n";
+    }
+    ConfigService config;
+    config.setWallpaperPath(std::nullopt, "/tmp/picked.png");
+    expect(config.getDefaultWallpaperPath() == "/tmp/picked.png", "sidecar path did not win once set");
+
+    config.forceReload();
+    expect(config.getDefaultWallpaperPath() == "/tmp/picked.png", "sidecar path did not survive a reload");
+
+    config.setWallpaperPath("DP-9", "/tmp/dp9.png");
+    config.forceReload();
+    expect(config.getWallpaperPath("DP-9") == "/tmp/dp9.png", "per-monitor path did not survive a reload");
+    expect(config.getWallpaperPath("DP-8") == "/tmp/picked.png", "unconfigured monitor did not fall back to default");
+
+    ::unsetenv("NOCTALIA_CONFIG_HOME");
+    ::unsetenv("NOCTALIA_STATE_HOME");
+    ::unsetenv("NOCTALIA_DATA_HOME");
+    std::filesystem::remove_all(root);
+  }
+
+} // namespace
+
+int main() {
+  checkConfigSurvivesFirstSidecarWrite();
+  checkSidecarPathOutranksConfigFilePath();
+
+  if (g_failures == 0) {
+    std::println("config_wallpaper_precedence_test: all checks passed");
+  }
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

If `state/noctalia/settings.toml` doesn't exist on startup, a wallpaper path declared in `config.toml` is discarded.

A new sidecar has no `config_version` and `storedConfigVersion()` returns `0` instead of `nullopt` when the key is absent. So `loadAll()` treats it as a pending migration and that branch ended with `extractWallpaperFromOverrides()`.

This PR removes that call and two other instances of it which are already followed by `loadAll()`.

## Motivation

<!-- What problem does this solve? -->

This gets annoying when using a system that has some sort of impermanence, `settings.toml` is wiped at each boot and a wallpaper declared in `config.toml` doesn't show.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

Closes #4044

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

```shell
just lint
just format # with clang-format 22.1.8
just test   # 105 pass
just build
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

I tested the build result on my system in the following cases:
| `config.toml` | `settings.toml` | Result |
|--------|--------|--------|
| Wallpaper declared | File does not exist | Loads wallpaper from `config.toml` |
| Wallpaper declared | No wallpaper declared | Loads wallpaper from `config.toml` |
| Wallpaper declared | Another wallpaper declared | Loads wallpaper from `settings.toml` |
| No wallpaper declared | Wallpaper declared | Loads wallpaper from `settings.toml` |

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
