### PR TITLE
fix(desktop-calendar): honor calendar event date/time formats

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2569,11 +2569,11 @@
           "description-reconnect": "Google authorization is missing; reconnect this account"
         },
         "calendar-event-date-format": {
-          "description": "The date format shown in the event card for the selected date",
+          "description": "The date format shown above the event list in calendar views",
           "label": "Event Date Format"
         },
         "calendar-event-time-format": {
-          "description": "The time format shown for calendar events",
+          "description": "The time format shown for calendar events in calendar views",
           "label": "Event Time Format"
         },
         "calendar-refresh-interval": {

--- a/docs/user/control-center/index.mdx
+++ b/docs/user/control-center/index.mdx
@@ -123,24 +123,21 @@ The Calendar tab shows the month view and events from configured calendar accoun
 Right-click a day to launch the application registered for the `text/calendar` MIME type. The Calendar panel closes
 after a successful launch.
 
-`[control_center.calendar]` holds how the tab is drawn; `[calendar]` holds whether events are synced at all.
+`[control_center.calendar]` holds how the tab is drawn; `[calendar]` holds whether events are synced and the shared event date and time formats.
 
 ```toml
 [control_center.calendar]
 show_events_card  = true
 show_week_numbers = false       # ISO 8601 week numbers in the month grid
-event_date_format = "%A %e %B"  # date heading above the event list
-event_time_format = "%H:%M"     # per-event start time
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `show_events_card` | bool | `true` | Show the event list beside the month grid. Also toggled from the calendar button in the tab header. |
 | `show_week_numbers` | bool | `false` | Show a column of ISO 8601 week numbers to the left of the month grid, separated from it by a divider. Each row is numbered by the week its Thursday falls in. |
-| `event_date_format` | string | `"%A %e %B"` | strftime format for the date heading above the event list. |
-| `event_time_format` | string | `"%H:%M"` | strftime format for each event's start time. All-day events show an "All day" label instead. |
 
-Week numbers are a decoration of the month grid, so they work with `[calendar].enabled = false` and no accounts configured. The other three options only have visible effect once events are syncing.
+The shared `event_date_format` and `event_time_format` options are documented under [Calendar](/noctalia/services/calendar/).
+Week numbers are a decoration of the month grid, so they work with `[calendar].enabled = false` and no accounts configured.
 
 ## Notifications
 

--- a/docs/user/desktop/widgets.mdx
+++ b/docs/user/desktop/widgets.mdx
@@ -223,8 +223,8 @@ font_family       = ""
 | `show_week_numbers` | bool | `false` | Show ISO week numbers beside the month grid |
 | `font_family` | string | `""` | Typeface for calendar text; empty inherits the global shell font |
 
-The event list uses the `event_date_format` and `event_time_format` from [`[control_center.calendar]`](/noctalia/control-center/#calendar),
-shared with the control center Calendar tab.
+The event list uses the shared `event_date_format` and `event_time_format` from [`[calendar]`](/noctalia/services/calendar/),
+so the desktop widget and control center use the same event formatting.
 
 Use the arrow buttons or vertical scrolling to change months. Select a day to update the event list; selecting a day
 from the preceding or following month also navigates to that month. Select the date or month heading to return to today.

--- a/docs/user/desktop/widgets.mdx
+++ b/docs/user/desktop/widgets.mdx
@@ -223,6 +223,9 @@ font_family       = ""
 | `show_week_numbers` | bool | `false` | Show ISO week numbers beside the month grid |
 | `font_family` | string | `""` | Typeface for calendar text; empty inherits the global shell font |
 
+The event list uses the `event_date_format` and `event_time_format` from [`[control_center.calendar]`](/noctalia/control-center/#calendar),
+shared with the control center Calendar tab.
+
 Use the arrow buttons or vertical scrolling to change months. Select a day to update the event list; selecting a day
 from the preceding or following month also navigates to that month. Select the date or month heading to return to today.
 

--- a/docs/user/services/calendar.mdx
+++ b/docs/user/services/calendar.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 The calendar service syncs events from your online accounts and shows them in the control center calendar. CalDAV providers (Nextcloud, iCloud, Fastmail, Radicale, mailbox.org, …) are talked to directly; Google Calendar is connected through a browser authorization flow. Events are read-only.
 
-`[calendar]` covers accounts and sync only. How the Calendar tab is drawn, including event date and time formats and the ISO week number column, lives under [`[control_center.calendar]`](/noctalia/control-center/#calendar).
+`[calendar]` covers account sync and shared event date and time formats. Calendar-tab-only presentation options, such as the events card and ISO week number column, live under [`[control_center.calendar]`](/noctalia/control-center/#calendar).
 
 ## Settings setup
 
@@ -31,8 +31,10 @@ Existing accounts can be edited from **Settings → Services → Calendar**. Goo
 
 ```toml
 [calendar]
-enabled         = true
-refresh_minutes = 15
+enabled             = true
+refresh_minutes     = 15
+event_date_format   = "%A %e %B"
+event_time_format   = "%H:%M"
 
 # iCloud CalDAV. The table name is the local account id.
 [calendar.account.personal_icloud]

--- a/example.toml
+++ b/example.toml
@@ -241,14 +241,14 @@ disk_poll_seconds = 10.0            # disk usage and swap usage; graph widgets u
 [calendar]
 enabled                     = false
 refresh_minutes             = 15
+event_date_format           = "%A %e %B"    # date format used for events
+event_time_format           = "%H:%M"       # time format used for events
 
 # Calendar tab of the control center.
 
 [control_center.calendar]
 show_events_card            = true
 show_week_numbers           = false         # ISO 8601 week numbers in the month grid
-event_date_format           = "%A %e %B"    # date format used for events
-event_time_format           = "%H:%M"       # time format used for events
 
 # ── Weather ───────────────────────────────────────────────────────────────────
 

--- a/src/config/config_migrations.cpp
+++ b/src/config/config_migrations.cpp
@@ -26,6 +26,7 @@ namespace noctalia::config {
     constexpr int kWorkspacesDisplayMigrationVersion = 11;
     constexpr int kKeyboardLayoutCustomLabelsMigrationVersion = 12;
     constexpr int kPluginAutoUpdateModeMigrationVersion = 13;
+    constexpr int kCalendarEventFormatsMigrationVersion = 14;
     constexpr std::int64_t kMaxBarRadius = 500;
     constexpr std::array<std::string_view, 5> kBarRadiusKeys = {
         "radius", "radius_top_left", "radius_top_right", "radius_bottom_left", "radius_bottom_right",
@@ -643,6 +644,54 @@ namespace noctalia::config {
       });
     }
 
+    template <typename OnChanged> void migrateCalendarEventFormats(toml::table& root, OnChanged&& onChanged) {
+      auto* controlCenter = root["control_center"].as_table();
+      if (controlCenter == nullptr) {
+        return;
+      }
+      auto* calendarTab = (*controlCenter)["calendar"].as_table();
+      if (calendarTab == nullptr) {
+        return;
+      }
+
+      toml::table* calendar = root["calendar"].as_table();
+      if (calendar == nullptr) {
+        if (root.contains("calendar")) {
+          return;
+        }
+        root.insert("calendar", toml::table{});
+        calendar = root["calendar"].as_table();
+      }
+      if (calendar == nullptr) {
+        return;
+      }
+
+      constexpr std::array<std::string_view, 2> kFormatKeys{"event_date_format", "event_time_format"};
+      for (const std::string_view key : kFormatKeys) {
+        toml::node* oldNode = calendarTab->get(key);
+        if (oldNode == nullptr) {
+          continue;
+        }
+        const std::string path = "control_center.calendar." + std::string(key);
+        const bool keptCanonical = calendar->contains(key);
+        if (!keptCanonical) {
+          calendar->insert_or_assign(key, *oldNode);
+        }
+        calendarTab->erase(key);
+        onChanged(path, keptCanonical);
+      }
+    }
+
+    void migrateCalendarEventFormatsSidecar(toml::table& root, schema::Diagnostics& diag) {
+      migrateCalendarEventFormats(root, [&diag](const std::string& path, bool keptCanonical) {
+        diag.warn(
+            path,
+            keptCanonical ? "moved event format to calendar configuration; kept the existing canonical value"
+                          : "moved event format to calendar configuration"
+        );
+      });
+    }
+
     template <typename OnChanged> void migratePluginAutoUpdateMode(toml::table& root, OnChanged&& onChanged) {
       auto* plugins = root["plugins"].as_table();
       if (plugins == nullptr) {
@@ -766,6 +815,11 @@ namespace noctalia::config {
             .toVersion = kPluginAutoUpdateModeMigrationVersion,
             .summary = "plugins: migrate boolean auto-update to source scope",
             .apply = migratePluginAutoUpdateModeSidecar,
+        },
+        {
+            .toVersion = kCalendarEventFormatsMigrationVersion,
+            .summary = "calendar: move event formats to calendar configuration",
+            .apply = migrateCalendarEventFormatsSidecar,
         },
     };
     return migrations;
@@ -911,6 +965,15 @@ namespace noctalia::config {
           .migrationVersion = kPluginAutoUpdateModeMigrationVersion,
           .path = path,
           .message = "boolean plugin auto-update is deprecated; use \"" + std::string(mode) + "\"",
+      });
+    });
+    migrateCalendarEventFormats(root, [&issues](const std::string& path, bool keptCanonical) {
+      issues.push_back({
+          .migrationVersion = kCalendarEventFormatsMigrationVersion,
+          .path = path,
+          .message = keptCanonical
+              ? "event format is deprecated; move it to [calendar] and keep the existing canonical value"
+              : "event format is deprecated; move it to [calendar]",
       });
     });
   }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -137,7 +137,7 @@ struct BarConfig {
 
   [[nodiscard]] constexpr bool isAutoHideEnabled() const noexcept { return autoHide || smartAutoHide; }
   bool reserveSpace = true;  // reserve compositor exclusive zone; applies with or without auto_hide
-  std::string layer = "top"; // top | overlay — attached panels use the same layer
+  std::string layer = "top"; // top | overlay; attached panels use the same layer
   std::int32_t thickness = Style::barThicknessDefault;
   float backgroundOpacity = 1.0F;
   // Inside outline for the bar background; attached panels inherit the resolved values.
@@ -1168,6 +1168,8 @@ struct CalendarConfig {
 
   bool enabled = false;
   std::int32_t refreshMinutes = 15;
+  std::string eventDateFormat = "%A %e %B";
+  std::string eventTimeFormat = "%H:%M";
   std::vector<Account> accounts;
 
   bool operator==(const CalendarConfig&) const = default;
@@ -1536,8 +1538,6 @@ struct ControlCenterConfig {
   struct CalendarTabConfig {
     bool showEventsCard = true;
     bool showWeekNumbers = false;
-    std::string eventDateFormat = "%A %e %B";
-    std::string eventTimeFormat = "%H:%M";
     bool operator==(const CalendarTabConfig&) const = default;
   };
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -104,7 +104,7 @@ namespace noctalia::config::schema {
 
   namespace {
     // Poll-second floats are stored verbatim here; the [1,120]/disabled clamping
-    // happens at consumption, not at parse time — so no Range is attached.
+    // happens at consumption, not at parse time; so no Range is attached.
     const Schema<SystemConfig::MonitorConfig>& systemMonitorSchema() {
       static const Schema<SystemConfig::MonitorConfig> s = {
           field(&SystemConfig::MonitorConfig::enabled, "enabled"),
@@ -474,8 +474,6 @@ namespace noctalia::config::schema {
       static const Schema<ControlCenterConfig::CalendarTabConfig> s = {
           field(&ControlCenterConfig::CalendarTabConfig::showEventsCard, "show_events_card"),
           field(&ControlCenterConfig::CalendarTabConfig::showWeekNumbers, "show_week_numbers"),
-          field(&ControlCenterConfig::CalendarTabConfig::eventDateFormat, "event_date_format"),
-          field(&ControlCenterConfig::CalendarTabConfig::eventTimeFormat, "event_time_format"),
       };
       return s;
     }
@@ -1657,6 +1655,8 @@ namespace noctalia::config::schema {
     static const Schema<CalendarConfig> s = {
         field(&CalendarConfig::enabled, "enabled"),
         field(&CalendarConfig::refreshMinutes, "refresh_minutes", kRefreshMinutesRange),
+        field(&CalendarConfig::eventDateFormat, "event_date_format"),
+        field(&CalendarConfig::eventTimeFormat, "event_time_format"),
         namedMap<CalendarConfig, CalendarConfig::Account>(
             &CalendarConfig::accounts, "account", calendarAccountSchema(),
             [](CalendarConfig::Account& a, std::string_view id) { a.id = std::string(id); },
@@ -1792,7 +1792,7 @@ namespace noctalia::config::schema {
       return true;
     }
 
-    // [plugin_settings."author/plugin"].<key> — open schema; keys validate against
+    // [plugin_settings."author/plugin"].<key>, open schema; keys validate against
     // the manifest in config_validate's validatePluginSettings, not here.
     if (section == "plugin_settings") {
       return path.size() <= 3;
@@ -1810,7 +1810,7 @@ namespace noctalia::config::schema {
 
   namespace {
     // Clamp ranges shared by the concrete BarConfig fields and the parallel
-    // optional BarMonitorOverride fields — declared once so the two schemas can't
+    // optional BarMonitorOverride fields, declared once so the two schemas can't
     // drift apart.
     constexpr Range<std::int64_t> kBarThicknessRange{10, 300};
     constexpr Range<std::int64_t> kBarRadiusRange{0, 500};
@@ -1922,7 +1922,7 @@ namespace noctalia::config::schema {
 
   namespace {
     // optional<ColorSpec>, emitted only when set, read when present. Unlike
-    // colorSpecField it does NOT treat an empty string as nullopt — it matches the
+    // colorSpecField it does NOT treat an empty string as nullopt; it matches the
     // legacy bar/capsule_group reads (which parse whatever string is present).
     template <typename Struct>
     Field<Struct> optionalColorField(std::optional<ColorSpec> Struct::* member, std::string_view key) {

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -23,7 +23,6 @@
 #include <chrono>
 #include <cmath>
 #include <memory>
-#include <string_view>
 #include <wayland-client-protocol.h>
 
 namespace {
@@ -597,23 +596,18 @@ void CalendarTab::rebuild() {
 }
 
 void CalendarTab::rebuildEventList(float scale) {
-  if (m_eventsScroll == nullptr) {
+  if (m_eventsScroll == nullptr || m_config == nullptr) {
     return;
   }
-  std::string_view eventDateFormat = "%A %e %B";
-  std::string_view eventTimeFormat = "%H:%M";
-  if (m_config != nullptr) {
-    eventDateFormat = m_config->config().controlCenter.calendarTab.eventDateFormat;
-    eventTimeFormat = m_config->config().controlCenter.calendarTab.eventTimeFormat;
-  }
+  const auto& calendarConfig = m_config->config().calendar;
   calendar_view::rebuildEventList({
       .scroll = *m_eventsScroll,
       .title = m_eventsTitle,
       .snapshot = m_calendar != nullptr ? &m_calendar->snapshot() : nullptr,
       .selected = {.year = m_selectedYear, .month = m_selectedMonth, .day = m_selectedDay},
       .scale = scale,
-      .dateFormat = eventDateFormat,
-      .timeFormat = eventTimeFormat,
+      .dateFormat = calendarConfig.eventDateFormat,
+      .timeFormat = calendarConfig.eventTimeFormat,
       .state = &m_eventListState,
       .requestRedraw = []() { PanelManager::instance().requestRedraw(); },
   });

--- a/src/shell/desktop/desktop_widgets_controller.cpp
+++ b/src/shell/desktop/desktop_widgets_controller.cpp
@@ -474,16 +474,22 @@ void DesktopWidgetsController::handleConfigReload() {
   }
   pruneWallpaperMasks();
 
+  const bool calendarChanged = m_config != nullptr && m_config->lastChange().calendar;
   if (!isEditing()) {
     loadSnapshotFromConfig();
     if (m_host != nullptr) {
       m_host->rebuild(m_snapshot);
+      if (calendarChanged) {
+        m_host->requestLayout();
+      }
       // Plugin-level settings live in [plugin_settings], outside the widget snapshot, so
       // the host's instance diff cannot see them change.
       if (m_config != nullptr && m_config->lastChange().plugins) {
         m_host->reloadPluginWidgets();
       }
     }
+  } else if (calendarChanged && m_editor != nullptr) {
+    m_editor->requestLayout();
   }
   applyVisibility();
 }

--- a/src/shell/desktop/widgets/desktop_calendar_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_calendar_widget.cpp
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <wayland-client-protocol.h>
 
@@ -35,8 +34,6 @@ namespace {
   constexpr float kDayButtonSize = 34.0F;
   constexpr float kDotDiameter = 4.0F;
   constexpr float kWeekColumnWidth = 24.0F;
-  constexpr std::string_view kEventDateFormat = "%A %e %B";
-  constexpr std::string_view kEventTimeFormat = "%H:%M";
 
 } // namespace
 
@@ -358,15 +355,10 @@ void DesktopCalendarWidget::rebuildCalendar() {
 }
 
 void DesktopCalendarWidget::rebuildEventList() {
-  if (m_eventsScroll == nullptr) {
+  if (m_eventsScroll == nullptr || m_config == nullptr) {
     return;
   }
-  std::string_view eventDateFormat = kEventDateFormat;
-  std::string_view eventTimeFormat = kEventTimeFormat;
-  if (m_config != nullptr) {
-    eventDateFormat = m_config->config().controlCenter.calendarTab.eventDateFormat;
-    eventTimeFormat = m_config->config().controlCenter.calendarTab.eventTimeFormat;
-  }
+  const auto& calendarConfig = m_config->config().calendar;
   calendar_view::rebuildEventList({
       .scroll = *m_eventsScroll,
       .reserveScrollbarGutter = true,
@@ -374,8 +366,8 @@ void DesktopCalendarWidget::rebuildEventList() {
       .snapshot = m_calendar != nullptr ? &m_calendar->snapshot() : nullptr,
       .selected = {.year = m_selectedYear, .month = m_selectedMonth, .day = m_selectedDay},
       .scale = contentScale(),
-      .dateFormat = eventDateFormat,
-      .timeFormat = eventTimeFormat,
+      .dateFormat = calendarConfig.eventDateFormat,
+      .timeFormat = calendarConfig.eventTimeFormat,
       .fontFamily = m_fontFamily,
       .state = &m_eventListState,
       .requestRedraw = [this]() { requestRedraw(); },

--- a/src/shell/desktop/widgets/desktop_calendar_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_calendar_widget.cpp
@@ -361,6 +361,12 @@ void DesktopCalendarWidget::rebuildEventList() {
   if (m_eventsScroll == nullptr) {
     return;
   }
+  std::string_view eventDateFormat = kEventDateFormat;
+  std::string_view eventTimeFormat = kEventTimeFormat;
+  if (m_config != nullptr) {
+    eventDateFormat = m_config->config().controlCenter.calendarTab.eventDateFormat;
+    eventTimeFormat = m_config->config().controlCenter.calendarTab.eventTimeFormat;
+  }
   calendar_view::rebuildEventList({
       .scroll = *m_eventsScroll,
       .reserveScrollbarGutter = true,
@@ -368,8 +374,8 @@ void DesktopCalendarWidget::rebuildEventList() {
       .snapshot = m_calendar != nullptr ? &m_calendar->snapshot() : nullptr,
       .selected = {.year = m_selectedYear, .month = m_selectedMonth, .day = m_selectedDay},
       .scale = contentScale(),
-      .dateFormat = kEventDateFormat,
-      .timeFormat = kEventTimeFormat,
+      .dateFormat = eventDateFormat,
+      .timeFormat = eventTimeFormat,
       .fontFamily = m_fontFamily,
       .state = &m_eventListState,
       .requestRedraw = [this]() { requestRedraw(); },

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -97,8 +97,8 @@ namespace settings {
       return *it;
     }
 
-    // Builds a slider whose bounds come from the shared schema Range — the same
-    // constant the parser clamps with — so the UI range and the config clamp are
+    // Builds a slider whose bounds come from the shared schema Range, the same
+    // constant the parser clamps with. This keeps the UI range and the config clamp
     // one source. `integerValue` (write as int64) stays explicit: it is a UI/write
     // choice, not implied by the range's numeric type (e.g. transition_duration).
     template <typename V, typename T>
@@ -2387,7 +2387,7 @@ namespace settings {
       );
     }
 
-    // Location — single source of "where am I"; shared by weather, night light, and theme auto mode.
+    // Location: single source of "where am I"; shared by weather, night light, and theme auto mode.
     entries.push_back(makeEntry(
         SettingsSection::Location, "location", tr("settings.schema.services.location-auto-locate.label"),
         tr("settings.schema.services.location-auto-locate.description"), {"location", "auto_locate"},
@@ -2434,7 +2434,7 @@ namespace settings {
       entries.push_back(std::move(e));
     }
 
-    // Custom scheduling — explicit sunrise/sunset times for night light and theme auto mode.
+    // Custom scheduling: explicit sunrise/sunset times for night light and theme auto mode.
     {
       auto e = makeEntry(
           SettingsSection::Location, "location", tr("settings.schema.services.custom-schedule.label"),
@@ -2463,7 +2463,7 @@ namespace settings {
       entries.push_back(std::move(e));
     }
 
-    // Weather — consumes the resolved location.
+    // Weather: consumes the resolved location.
     entries.push_back(makeEntry(
         SettingsSection::Location, "weather", tr("settings.schema.services.weather.label"),
         tr("settings.schema.services.weather.description"), {"weather", "enabled"}, ToggleSetting{cfg.weather.enabled},
@@ -2618,13 +2618,8 @@ namespace settings {
     {
       auto e = makeEntry(
           SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-date-format.label"),
-          tr("settings.schema.services.calendar-event-date-format.description"),
-          {"control_center", "calendar", "event_date_format"},
-          TextSetting{
-              .value = cfg.controlCenter.calendarTab.eventDateFormat,
-              .placeholder = "%A %e %B",
-              .browseFileExtensions = {}
-          },
+          tr("settings.schema.services.calendar-event-date-format.description"), {"calendar", "event_date_format"},
+          TextSetting{.value = cfg.calendar.eventDateFormat, .placeholder = "%A %e %B", .browseFileExtensions = {}},
           "calendar date format strftime chrono"
       );
       e.visibleWhen = calendarOn;
@@ -2633,11 +2628,8 @@ namespace settings {
     {
       auto e = makeEntry(
           SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-time-format.label"),
-          tr("settings.schema.services.calendar-event-time-format.description"),
-          {"control_center", "calendar", "event_time_format"},
-          TextSetting{
-              .value = cfg.controlCenter.calendarTab.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}
-          },
+          tr("settings.schema.services.calendar-event-time-format.description"), {"calendar", "event_time_format"},
+          TextSetting{.value = cfg.calendar.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}},
           "calendar time format strftime chrono"
       );
       e.visibleWhen = calendarOn;
@@ -2980,7 +2972,7 @@ namespace settings {
         "urgency"
     ));
 
-    // Bar — register every configured bar so global search can surface settings from all of them.
+    // Bar: register every configured bar so global search can surface settings from all of them.
     for (const auto& bar : cfg.bars) {
       constexpr SettingsSection section = SettingsSection::Bar;
       const std::vector<std::string> root = {"bar", bar.name};

--- a/src/ui/controls/calendar_view.h
+++ b/src/ui/controls/calendar_view.h
@@ -75,8 +75,8 @@ namespace calendar_view {
     const CalendarSnapshot* snapshot = nullptr;
     Date selected;
     float scale = 1.0F;
-    std::string_view dateFormat = "%A %e %B";
-    std::string_view timeFormat = "%H:%M";
+    std::string_view dateFormat;
+    std::string_view timeFormat;
     std::string fontFamily;
     EventListState* state = nullptr;
     std::function<void()> requestRedraw;

--- a/tests/config_migration_test.cpp
+++ b/tests/config_migration_test.cpp
@@ -779,6 +779,73 @@ German = "Clock"
     );
   }
 
+  void checkCalendarEventFormatsMigration() {
+    toml::table sidecar = toml::parse(R"(
+config_version = 13
+[control_center.calendar]
+event_date_format = "%Y-%m-%d"
+event_time_format = "%I:%M %p"
+)");
+    noctalia::config::schema::Diagnostics diagnostics;
+    const int applied = noctalia::config::applyPendingConfigMigrations(sidecar, 13, diagnostics);
+    expect(applied == noctalia::config::currentConfigVersion(), "calendar event format migration was not applied");
+    expect(
+        sidecar["calendar"]["event_date_format"].value<std::string_view>()
+            == std::optional<std::string_view>{"%Y-%m-%d"},
+        "calendar event date format was not moved"
+    );
+    expect(
+        sidecar["calendar"]["event_time_format"].value<std::string_view>()
+            == std::optional<std::string_view>{"%I:%M %p"},
+        "calendar event time format was not moved"
+    );
+    const auto* legacyCalendar = sidecar["control_center"]["calendar"].as_table();
+    expect(
+        legacyCalendar != nullptr
+            && legacyCalendar->get("event_date_format") == nullptr
+            && legacyCalendar->get("event_time_format") == nullptr,
+        "legacy calendar event formats were not removed"
+    );
+
+    toml::table legacyConfig = toml::parse(R"(
+[control_center.calendar]
+event_date_format = "%d.%m.%Y"
+event_time_format = "%H:%M"
+)");
+    noctalia::config::LegacyConfigIssues issues;
+    noctalia::config::normalizeLegacyConfig(legacyConfig, issues);
+    expect(
+        legacyConfig["calendar"]["event_date_format"].value<std::string_view>()
+            == std::optional<std::string_view>{"%d.%m.%Y"},
+        "hand-written calendar event date format was not normalized"
+    );
+    expect(
+        issues.size() == 2
+            && hasIssuePath(issues, "control_center.calendar.event_date_format")
+            && hasIssuePath(issues, "control_center.calendar.event_time_format"),
+        "hand-written calendar event formats did not produce migration issues"
+    );
+
+    toml::table conflict = toml::parse(R"(
+config_version = 13
+[calendar]
+event_date_format = "%d"
+[control_center.calendar]
+event_date_format = "%A"
+event_time_format = "%H:%M"
+)");
+    noctalia::config::schema::Diagnostics conflictDiagnostics;
+    (void)noctalia::config::applyPendingConfigMigrations(conflict, 13, conflictDiagnostics);
+    expect(
+        conflict["calendar"]["event_date_format"].value<std::string_view>() == std::optional<std::string_view>{"%d"},
+        "calendar event format migration overwrote the canonical date format"
+    );
+    expect(
+        conflict["calendar"]["event_time_format"].value<std::string_view>() == std::optional<std::string_view>{"%H:%M"},
+        "calendar event format migration did not move a non-conflicting value"
+    );
+  }
+
   void checkVersionGating() {
     toml::table legacy = toml::parse(R"(
 [bar.main]
@@ -924,6 +991,7 @@ int main() {
   checkRemainingWidgetGesturesMigration();
   checkCustomButtonCommandsMigration();
   checkDeadZoneActionsMigration();
+  checkCalendarEventFormatsMigration();
   checkSysmonPresentationMigration();
   checkKeyboardLayoutShowGlyphMigration();
   checkKeyboardLayoutCustomLabelsMigration();

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -3,12 +3,12 @@
 // The schema is now the single source for both serialize (config_export::serialize →
 // writeTable) and parse (parseConfigTable → readInto), so there is no legacy code
 // to compare against. What still earns its keep:
-//   - read inverse — readInto(writeTable(x)) == x for every section: the schema's
+//   - read inverse: readInto(writeTable(x)) == x for every section: the schema's
 //                    read and write are mutual inverses (catches a field whose read
 //                    key != write key, or a lossy codec).
-//   - bar golden   — config_export::serialize(probe)["bar"] stays byte-identical to a captured
+//   - bar golden: config_export::serialize(probe)["bar"] stays byte-identical to a captured
 //                    reference (locks the resolve-and-flatten monitor-override emit).
-//   - clamp goldens — pin parse-time range behavior.
+//   - clamp goldens: pin parse-time range behavior.
 
 #include "config/config_export.h"
 #include "config/config_types.h"
@@ -417,11 +417,11 @@ location = "https://example.invalid/bad"
     c.controlCenter.sidebarSectionMode = ControlCenterSidebarMode::None;
     c.controlCenter.calendarTab.showEventsCard = false;
     c.controlCenter.calendarTab.showWeekNumbers = true;
-    c.controlCenter.calendarTab.eventDateFormat = "%Y-%m-%d";
-    c.controlCenter.calendarTab.eventTimeFormat = "%I:%M %p";
     c.controlCenter.shortcuts = {{"wifi"}, {"bluetooth"}};
     c.calendar.enabled = true;
     c.calendar.refreshMinutes = 30;
+    c.calendar.eventDateFormat = "%Y-%m-%d";
+    c.calendar.eventTimeFormat = "%I:%M %p";
     c.calendar.accounts = {
         {"acc1", "google", "Work", "#ff0000", "", "", "", {}},
         {"acc2",
@@ -1176,7 +1176,7 @@ widget_spacing = 8
 
   // Every schema-backed section must round-trip, AND the probe must actually populate
   // it. Iterating the section registry rather than a hand-written list means a new
-  // section is covered the moment it is declared — and fails here until its probe
+  // section is covered the moment it is declared, and fails here until its probe
   // values are filled in.
   {
     const Config defaults;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
The desktop calendar widget currently hardcodes its date formatting, this makes it re-use the formatting setting already used in the control center calendar widget which has the same layout.

## Motivation

<!-- What problem does this solve? -->
I use the calendar desktop widget and want to have it formatted in 12-hour time, like I do the control center.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #4218

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
I built and ran locally, worked as expected.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
