### PR TITLE
fix(bluetooth): show DisplayPasskey pairing requests

### DIFF
--- a/src/dbus/bluetooth/bluetooth_agent.cpp
+++ b/src/dbus/bluetooth/bluetooth_agent.cpp
@@ -39,9 +39,7 @@ struct BluetoothAgent::Impl {
 
   explicit Impl(SystemBus& b) : bus(b) {}
 
-  [[nodiscard]] bool hasPending() const noexcept {
-    return pendingString.has_value() || pendingUint.has_value() || pendingVoid.has_value();
-  }
+  [[nodiscard]] bool hasPending() const noexcept { return pending.kind != BluetoothPairingKind::None; }
 
   void rejectIfBusy(auto& result, const char* what) {
     kLog.debug("{} while another request pending -> rejected", what);

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -448,6 +448,10 @@ std::unique_ptr<Flex> BluetoothTab::create() {
                     }
                   }
                   break;
+                case BluetoothPairingKind::DisplayPasskey:
+                  // Informational only: the code is typed on the device, and there is no
+                  // Agent1 reply to send. Do not fall through to the canceling default.
+                  break;
                 default:
                   m_agent->cancelPending();
                   break;
@@ -683,6 +687,11 @@ void BluetoothTab::syncPairingCard() {
   }
   if (m_pairingInputRow != nullptr) {
     m_pairingInputRow->setVisible(needsInput);
+  }
+  if (m_pairingAccept != nullptr) {
+    // DisplayPasskey has nothing to accept: the code is entered on the device and there
+    // is no Agent1 reply. Show only the Reject action so Accept cannot clear the card.
+    m_pairingAccept->setVisible(req.kind != BluetoothPairingKind::DisplayPasskey);
   }
 }
 


### PR DESCRIPTION
## Summary

Make Bluetooth `DisplayPasskey` requests visible in the pairing card.

## Motivation

BlueZ Agent1 `DisplayPasskey` is a fire-and-forget method without a reply result. The previous pending-state check only inspected reply contexts, so the UI treated these requests as inactive and hid the passkey.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4231

## Testing

- `nix develop --offline -c just format`
- `nix develop --offline -c just build debug`
- `nix develop --offline -c just lint debug` (572/572 source files, no diagnostics)
- `nix develop --offline -c just test debug --print-errorlogs` (109/110 passed; the unrelated `process` test reports `completion-only async command stdout was wrong`)
- Manual: Niri on NixOS with BlueZ and an HHKB Studio 2. Multiple pairing attempts displayed the pairing card and six-digit passkey while BlueZ waited for keyboard input.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

No layout or styling changes. The manual pairing validation covered the newly visible conditional state.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

`DisplayPasskey` has no D-Bus reply context by design, so this fix tracks pending state from the pairing request kind instead of requiring a reply holder.