### PR TITLE
fix(dock): keep pinned origins distinct when WM class is shared

### DIFF
--- a/src/shell/dock/dock_model.cpp
+++ b/src/shell/dock/dock_model.cpp
@@ -128,6 +128,9 @@ namespace shell::dock {
         dockItem.windowLookupIdLower = dockItem.idLower;
         dockItem.windowLookupWmClassLower = taskbarStyleWmClassLower(entry.startupWmClass, dockItem.idLower);
       }
+      if (app_identity::startupWmClassShared(entry, desktopEntries())) {
+        dockItem.windowLookupWmClassLower.clear();
+      }
 
       dockItem.active = !snapshot.activeAppIdLower.empty() && snapshot.activeAppIdLower == dockItem.idLower;
       if (deps.config.showDots || deps.config.showInstanceCount) {

--- a/src/system/app_identity.cpp
+++ b/src/system/app_identity.cpp
@@ -131,6 +131,26 @@ namespace app_identity {
     );
   }
 
+  bool startupWmClassShared(const DesktopEntry& entry, std::span<const DesktopEntry> allEntries) {
+    const std::string wm = StringUtils::toLower(entry.startupWmClass);
+    if (wm.empty()) {
+      return false;
+    }
+    const std::string idLower = StringUtils::toLower(entry.id);
+    for (const auto& other : allEntries) {
+      if (other.hidden || other.noDisplay) {
+        continue;
+      }
+      if (StringUtils::toLower(other.id) == idLower) {
+        continue;
+      }
+      if (StringUtils::toLower(other.startupWmClass) == wm) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   std::optional<DesktopEntry> findDesktopEntry(
       std::string_view appKey, std::span<const DesktopEntry> allEntries, std::span<const DesktopEntry> priorityEntries
   ) {
@@ -139,6 +159,20 @@ namespace app_identity {
     }
 
     const std::string appLower = StringUtils::toLower(std::string(appKey));
+
+    // Exact desktop id wins over pinned fuzzy matching. A pinned Flatpak/AppImage
+    // must not claim a running distro window that has its own desktop file.
+    for (const auto& entry : allEntries) {
+      if (StringUtils::toLower(entry.id) == appLower) {
+        return entry;
+      }
+    }
+    for (const auto& entry : priorityEntries) {
+      if (StringUtils::toLower(entry.id) == appLower) {
+        return entry;
+      }
+    }
+
     for (const auto& entry : priorityEntries) {
       if (desktopEntryMatchesLower(entry, appLower)) {
         return entry;

--- a/src/system/app_identity.h
+++ b/src/system/app_identity.h
@@ -23,6 +23,10 @@ namespace app_identity {
 
   [[nodiscard]] bool desktopEntryMatchesLower(const DesktopEntry& entry, std::string_view valueLower);
 
+  // True when another non-hidden desktop entry uses the same StartupWMClass.
+  // Dock window lookup must not use a shared class. That steals focus across origins.
+  [[nodiscard]] bool startupWmClassShared(const DesktopEntry& entry, std::span<const DesktopEntry> allEntries);
+
   // Best-effort lookup by app id / StartupWMClass. Operates on the parsed desktop-entry list,
   // which already excludes hidden/NoDisplay/wrong-desktop entries.
   [[nodiscard]] std::optional<DesktopEntry> findDesktopEntry(

--- a/tests/app_identity_test.cpp
+++ b/tests/app_identity_test.cpp
@@ -274,6 +274,67 @@ int main() {
   TEST_CHECK(kdeResolved.name == "Easy Effects");
   TEST_CHECK(kdeResolved.icon == "easyeffects");
 
+  DesktopEntry braveFlatpak;
+  braveFlatpak.id = "com.brave.Browser";
+  braveFlatpak.origin = DesktopEntryOrigin::Flatpak;
+  braveFlatpak.name = "Brave";
+  braveFlatpak.nameLower = "brave";
+  braveFlatpak.startupWmClass = "brave-browser";
+  braveFlatpak.startupWmClassLower = "brave-browser";
+  braveFlatpak.exec = "flatpak run com.brave.Browser";
+  braveFlatpak.icon = "com.brave.Browser";
+
+  DesktopEntry braveDistro;
+  braveDistro.id = "brave-browser";
+  braveDistro.origin = DesktopEntryOrigin::System;
+  braveDistro.name = "Brave";
+  braveDistro.nameLower = "brave";
+  braveDistro.startupWmClass = "brave-browser";
+  braveDistro.startupWmClassLower = "brave-browser";
+  braveDistro.exec = "/usr/bin/brave-browser";
+  braveDistro.icon = "brave-browser";
+
+  const std::vector<DesktopEntry> braveOrigins = {braveFlatpak, braveDistro};
+  const auto pinnedFlatpakSteals =
+      app_identity::findDesktopEntry("brave-browser", braveOrigins, std::array<DesktopEntry, 1>{braveFlatpak});
+  TEST_CHECK(pinnedFlatpakSteals.has_value());
+  TEST_CHECK(pinnedFlatpakSteals->id == "brave-browser");
+  TEST_CHECK(pinnedFlatpakSteals->origin == DesktopEntryOrigin::System);
+
+  const auto pinnedDistroKeeps =
+      app_identity::findDesktopEntry("brave-browser", braveOrigins, std::array<DesktopEntry, 1>{braveDistro});
+  TEST_CHECK(pinnedDistroKeeps.has_value());
+  TEST_CHECK(pinnedDistroKeeps->id == "brave-browser");
+
+  const auto pinnedFlatpakOwnId =
+      app_identity::findDesktopEntry("com.brave.Browser", braveOrigins, std::array<DesktopEntry, 1>{braveFlatpak});
+  TEST_CHECK(pinnedFlatpakOwnId.has_value());
+  TEST_CHECK(pinnedFlatpakOwnId->id == "com.brave.Browser");
+
+  const auto braveRunning = app_identity::resolveRunningApps(
+      std::array<std::string, 1>{"brave-browser"}, braveOrigins, std::array<DesktopEntry, 1>{braveFlatpak}
+  );
+  TEST_CHECK(braveRunning.size() == 1);
+  TEST_CHECK(braveRunning[0].entry.id == "brave-browser");
+
+  const auto braveBothRunning = app_identity::resolveRunningApps(
+      std::array<std::string, 2>{"brave-browser", "com.brave.Browser"}, braveOrigins,
+      std::array<DesktopEntry, 1>{braveFlatpak}
+  );
+  TEST_CHECK(braveBothRunning.size() == 2);
+  TEST_CHECK(braveBothRunning[0].entry.id == "brave-browser");
+  TEST_CHECK(braveBothRunning[1].entry.id == "com.brave.Browser");
+
+  TEST_CHECK(app_identity::startupWmClassShared(braveFlatpak, braveOrigins));
+  TEST_CHECK(app_identity::startupWmClassShared(braveDistro, braveOrigins));
+  TEST_CHECK(!app_identity::startupWmClassShared(easyEffects, std::array<DesktopEntry, 1>{easyEffects}));
+
+  const auto easyEffectsPinned = app_identity::findDesktopEntry(
+      "org.kde.easyeffects", std::array<DesktopEntry, 1>{easyEffects}, std::array<DesktopEntry, 1>{easyEffects}
+  );
+  TEST_CHECK(easyEffectsPinned.has_value());
+  TEST_CHECK(easyEffectsPinned->id == "com.github.wwmm.easyeffects");
+
   const std::vector<DesktopEntry> ambiguousTail = {
       duplicateTailEntry("com.foo.easyeffects", "foo-easyeffects"),
       duplicateTailEntry("com.bar.easyeffects", "bar-easyeffects"),


### PR DESCRIPTION
## Bug Description

Pinned Flatpak/AppImage desktop files were matching running distro windows via `StartupWMClass`, so a dock click focused the other origin.

Fixes #4179

## Root Cause

Pins are exact-id (`pinned_apps::matchesEntry`). Running-window attach is fuzzy and pin-biased: `findDesktopEntry` walked `priorityEntries` with `desktopEntryMatchesLower` (id or StartupWMClass or identityKey). Distro `brave-browser` matched pinned Flatpak `com.brave.Browser` via the shared WM class. Click used that collapsed set through `windowsForDockItem`, so a pinned Flatpak focused the distro window.

## Fix

- `findDesktopEntry`: exact desktop id in `allEntries` (then priority) wins before fuzzy matching.
- Dock window lookup: if another non-hidden entry shares `StartupWMClass`, clear `windowLookupWmClassLower` so click matches exact `app_id` only. Empty windows launch the pinned file.
- Unique-class matches (Easy Effects) unchanged.

## How to Verify

1. Pin Flatpak Brave (`com.brave.Browser`) while distro Brave is open.
2. The Flatpak pin must not show as running; click launches the Flatpak Exec.
3. Pinning `brave-browser` still focuses a window whose compositor `app_id` is exactly `brave-browser`.
4. Shared-class origins stay distinct dock items. Easy Effects unique-class resolve still works.

## Test Plan

- [x] Added regression coverage in `tests/app_identity_test.cpp` (Brave Flatpak vs distro, Easy Effects unique class)
- [x] Fail on baseline: pinned Flatpak claims running `brave-browser`
- [x] Pass on this head: exact id wins; shared class does not steal focus
- [ ] Maintainer: live dock click with both origins installed

## Risk Assessment

Low — identity lookup and dock window matching only. Unique-class paths unchanged. No compositor, pin-store, or launch-command changes.

Candidate: `8d461ce7be01836fe1e26b064732dfeff99a4eee` on `a1a0e0ffc841af1f77901bc7ebc81c104ed8d56e`.