### PR TITLE
fix(plugins): pin origin remote so plugin fetch survives clone.defaultRemoteName

### DIFF
--- a/src/scripting/plugin_git.cpp
+++ b/src/scripting/plugin_git.cpp
@@ -106,8 +106,11 @@ namespace scripting::plugin_git {
     // Blobless but NOT shallow: full commit/tree history (still tiny — no file
     // blobs until needed), so later fetches can inspect history normally. A `--depth 1`
     // shallow clone grafts fetched commits as disjoint roots ("unrelated histories").
+    // Pin the remote name: clone.defaultRemoteName (and checkout.defaultRemote) otherwise
+    // name it something other than origin, and fetch/set-url origin fail (#4122).
     return run(
-        {"git", "clone", "--filter=blob:none", "--no-checkout", url, dest.string()}, kNetworkTimeout, kProgressCap
+        {"git", "clone", "--filter=blob:none", "--no-checkout", "-o", "origin", url, dest.string()}, kNetworkTimeout,
+        kProgressCap
     );
   }
 
@@ -145,8 +148,15 @@ namespace scripting::plugin_git {
   }
 
   GitResult setOrigin(const std::filesystem::path& dest, std::string_view sourceLocation) {
+    auto updated =
+        run({"git", "-C", dest.string(), "remote", "set-url", "origin", std::string(sourceLocation)}, kLocalTimeout,
+            kProgressCap);
+    if (updated) {
+      return updated;
+    }
+    // Existing caches cloned under clone.defaultRemoteName≠origin have no `origin` remote.
     return run(
-        {"git", "-C", dest.string(), "remote", "set-url", "origin", std::string(sourceLocation)}, kLocalTimeout,
+        {"git", "-C", dest.string(), "remote", "add", "origin", std::string(sourceLocation)}, kLocalTimeout,
         kProgressCap
     );
   }

--- a/tests/plugin_git_export_test.cpp
+++ b/tests/plugin_git_export_test.cpp
@@ -194,6 +194,36 @@ int main() {
        )
       && ok;
 
+  // clone.defaultRemoteName≠origin must still create/fetch `origin` (#4122).
+  ::setenv("GIT_CONFIG_COUNT", "1", 1);
+  ::setenv("GIT_CONFIG_KEY_0", "clone.defaultRemoteName", 1);
+  ::setenv("GIT_CONFIG_VALUE_0", "up", 1);
+  const auto destUp = root / "repo-up";
+  const auto clonedUp = scripting::plugin_git::cloneBlobless(source.string(), destUp);
+  ok = expect(static_cast<bool>(clonedUp), "cloneBlobless with defaultRemoteName=up failed") && ok;
+  const auto remoteUp = process::runSync({"git", "-C", destUp.string(), "remote"});
+  ok = expect(static_cast<bool>(remoteUp), "git remote failed on defaultRemoteName clone") && ok;
+  ok = expect(remoteUp.out == "origin\n" || remoteUp.out == "origin", "cloneBlobless did not pin remote name origin")
+      && ok;
+  ok = expect(
+           static_cast<bool>(scripting::plugin_git::fetch(destUp, source.string())),
+           "fetch failed after defaultRemoteName=up clone"
+       )
+      && ok;
+
+  const auto destLegacy = root / "repo-legacy-up";
+  ok = runGit({"git", "clone", "--filter=blob:none", "--no-checkout", source.string(), destLegacy.string()}) && ok;
+  const auto remoteLegacy = process::runSync({"git", "-C", destLegacy.string(), "remote"});
+  ok = expect(remoteLegacy.out == "up\n" || remoteLegacy.out == "up", "legacy clone remote was not up") && ok;
+  ok = expect(
+           static_cast<bool>(scripting::plugin_git::fetch(destLegacy, source.string())),
+           "fetch did not recover a non-origin remote"
+       )
+      && ok;
+  ::unsetenv("GIT_CONFIG_COUNT");
+  ::unsetenv("GIT_CONFIG_KEY_0");
+  ::unsetenv("GIT_CONFIG_VALUE_0");
+
   std::error_code ec;
   std::filesystem::remove_all(root, ec);
   return ok ? 0 : 1;


### PR DESCRIPTION
## Bug Description

Plugin source updates fail and the plugin list goes empty when `clone.defaultRemoteName` is not `origin` (for example `up`).

Fixes #4122

## Root Cause

`cloneBlobless` cloned without `-o origin`. `fetch` always ran `git fetch origin`. With `clone.defaultRemoteName=up` the remote is named `up`, so fetch exits 128 (`'origin' does not appear to be a git repository`) and `remote set-url origin` also fails.

## Fix

- Pass `-o origin` on blobless clone so the remote name is stable under a non-origin `clone.defaultRemoteName`.
- If `remote set-url origin` cannot find that remote, `git remote add origin` then fetch.

## How to Verify

1. Set `clone.defaultRemoteName=up`.
2. Clone a plugin source without pinning: remote is `up`; `git fetch origin` fails.
3. With this change: clone remote is `origin`, fetch exits 0.
4. A legacy repo that already has remote `up` gets `origin` added, then fetch exits 0.

## Test Plan

- [x] Added `tests/plugin_git_export_test.cpp` coverage for pinned clone + legacy remote recovery
- [x] Fail on baseline: clone does not pin `origin`; fetch after `defaultRemoteName=up` fails
- [x] Pass on this head: `git clone -o origin` under `defaultRemoteName=up`; legacy `up` recovered via `remote add origin`
- [ ] Maintainer: plugin list refresh with a non-origin default remote

## Risk Assessment

Low — plugin git wrapper only. URL refresh still uses `set-url` on `origin`. No plugin UI or store changes.

Candidate: `bbb756569e384d7348be41912806d7ddb0d098c8` on `a1a0e0ffc841af1f77901bc7ebc81c104ed8d56e`.