### PR TITLE
fix(icons): defer IconResolver scan until control-center tabs resolve

### DIFF
--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -44,8 +44,12 @@ namespace {
   constexpr float kVolumeSyncEpsilon = 0.005F; // 0.5%
   constexpr auto kVolumeCommitInterval = std::chrono::milliseconds(16);
 
-  // Used to resolve application icons in AudioTab.
-  IconResolver g_iconResolver;
+  // Used to resolve application icons in AudioTab. Function-local so
+  // --version/--help/msg do not pay IconResolver::rebuild() before main().
+  [[nodiscard]] IconResolver& audioTabIconResolver() {
+    static IconResolver resolver;
+    return resolver;
+  }
 
   bool isGenericAudioLabel(std::string_view value) {
     if (value.empty()) {
@@ -1147,7 +1151,7 @@ namespace {
           bool loaded = false;
           const int targetPx = static_cast<int>(std::round(m_iconSize));
           for (const std::string& candidate : m_iconCandidates) {
-            const auto& resolved = g_iconResolver.resolve(candidate, targetPx);
+            const auto& resolved = audioTabIconResolver().resolve(candidate, targetPx);
             if (!resolved.empty()) {
               if (!m_lastIconPath.empty() && resolved == m_lastIconPath) {
                 loaded = true;

--- a/src/shell/control_center/tabs/screen_time_tab.cpp
+++ b/src/shell/control_center/tabs/screen_time_tab.cpp
@@ -37,7 +37,12 @@ namespace {
   constexpr float kLegendSwatch = 6.0F;
   constexpr float kUsageDurationFontScale = 0.85F;
 
-  IconResolver g_iconResolver;
+  // Function-local so --version/--help/msg do not pay IconResolver::rebuild()
+  // before main(). Constructed on first screen-time icon resolve.
+  [[nodiscard]] IconResolver& screenTimeIconResolver() {
+    static IconResolver resolver;
+    return resolver;
+  }
 
   [[nodiscard]] std::string snapshotKey(int rangeDays, const ScreenTimeSnapshot& snapshot) {
     std::string key = std::to_string(rangeDays) + '|' + std::to_string(snapshot.total.count());
@@ -1197,12 +1202,12 @@ std::string ScreenTimeTab::resolveIconPath(const std::string& appKey) const {
     iconName = app_identity::resolveRunningDesktopEntry(baseKey, desktopEntries()).icon;
   }
   if (!iconName.empty()) {
-    const std::string& resolved = g_iconResolver.resolve(iconName, targetPx);
+    const std::string& resolved = screenTimeIconResolver().resolve(iconName, targetPx);
     if (!resolved.empty()) {
       return resolved;
     }
   }
-  const std::string& resolved = g_iconResolver.resolve(baseKey, targetPx);
+  const std::string& resolved = screenTimeIconResolver().resolve(baseKey, targetPx);
   return resolved.empty() ? std::string{} : std::string{resolved};
 }
 


### PR DESCRIPTION
## Bug Description

TU-scope `IconResolver` globals in the audio and screen-time control-center tabs ran `rebuild()` during dynamic initialization, so `noctalia --version`, `--help`, and `msg` walked the full icon theme tree before `main()`.

Fixes #4223

## Root Cause

`IconResolver` constructs by calling `rebuild()`. Two translation units owned a process-lifetime `IconResolver g_iconResolver;`:

- `src/shell/control_center/tabs/audio_tab.cpp`
- `src/shell/control_center/tabs/screen_time_tab.cpp`

Those constructors run during dynamic init even when the tabs are never shown.

## Fix

Replace the TU-scope globals with function-local `static IconResolver` accessors, constructed on first resolve. `IconResolver` itself, dock/bar/launcher members, and luau are unchanged.

## How to Verify

1. Confirm `g_iconResolver` is gone from `src/`.
2. `noctalia --help` / `--version` / `msg` must not construct those tab resolvers.
3. Opening Audio or Screen Time in the control center still resolves application icons.

## Test Plan

- [x] Fail on baseline: TU-scope `IconResolver` constructed before first resolve
- [x] Pass on this head: constructors run only after first resolve; `-fsyntax-only` on both TUs
- [ ] Maintainer: live `--help` vs control-center icon resolve

## Risk Assessment

Low — two control-center tabs only. Icon lookup after first resolve is unchanged.

Candidate: `bc71b123f57aa528a2f4aa01ae9c7d0f9ee25d80` on `a1a0e0ffc841af1f77901bc7ebc81c104ed8d56e`.