### PR TITLE
fix(desktop): rescale cx/cy in rebaseForCurrentOutputs on output size change

### DIFF
--- a/src/shell/desktop/desktop_widget_layout.h
+++ b/src/shell/desktop/desktop_widget_layout.h
@@ -114,8 +114,15 @@ namespace desktop_widgets {
         if (output == nullptr) {
           continue;
         }
-        widget.placementWidth = outputLogicalWidth(*output);
-        widget.placementHeight = outputLogicalHeight(*output);
+        const float width = outputLogicalWidth(*output);
+        const float height = outputLogicalHeight(*output);
+        if (widget.placementWidth > 0.0F && widget.placementHeight > 0.0F
+            && (widget.placementWidth != width || widget.placementHeight != height)) {
+          widget.cx *= width / widget.placementWidth;
+          widget.cy *= height / widget.placementHeight;
+        }
+        widget.placementWidth = width;
+        widget.placementHeight = height;
       }
     }
   };


### PR DESCRIPTION
## Bug Description

`rebaseForCurrentOutputs` only backfilled `placementWidth`/`placementHeight`. After `exitEdit`, a widget centered on a 1366-wide output could be stored behind `placement_width=1920`, so `remapForOutputChange` skipped rescale.

Related to #4123 (placement backfill / stale coordinates). Does not address `settings.toml` shadowing hand-authored `config.toml` keys (see #4124).

## Root Cause

`rebaseForCurrentOutputs` wrote the current output size onto the widget without first rescaling `cx`/`cy` from the recorded placement size. Later remaps treated the new size as already matching the output and left coordinates unscaled.

## Fix

Mirror `remapForOutputChange`: when recorded placement size differs from the current output, rescale `cx`/`cy`, then write the current size. Matching size leaves coordinates. Legacy `placementWidth==0` records size without inventing a rescale.

One function in `src/shell/desktop/desktop_widget_layout.h`. Config merge / UI scale unchanged.

## How to Verify

1. Place a widget centered on a 1366-wide output, then rebase onto 1920.
2. `cx` must become 1920-scaled (1366-center → 1920-center), not stay locked at 1366.
3. Same-size rebase leaves `cx`/`cy`.
4. Legacy `placementWidth==0` records size without a rescale.

## Test Plan

- [x] Fail on baseline replica: `cx` stays 1366 after 1920 backfill
- [x] Pass on this head: rescale then write size; same-size and zero-placement paths unchanged
- [ ] Maintainer: live multi-resolution desktop widgets

## Risk Assessment

Low — one layout helper. Arithmetic matches existing `remapForOutputChange`. No config, compositor, or widget-store changes.

Candidate: `a14172fcb227716ce7ca308669f5e8ff95c1df2e` on `a1a0e0ffc841af1f77901bc7ebc81c104ed8d56e`.