### PR TITLE
fix(niri): preserve user noctalia.kdl on theme undo

### DIFF
--- a/assets/templates/niri/apply.sh
+++ b/assets/templates/niri/apply.sh
@@ -19,11 +19,11 @@ resolve_config_home() {
 
 config_dir="$(resolve_config_home)/niri"
 config_file="$config_dir/config.kdl"
-output_file="$config_dir/noctalia.kdl"
-include_line='include "noctalia.kdl"'
+output_file="$config_dir/noctalia-theme.kdl"
+include_line='include "noctalia-theme.kdl"'
 
 has_noctalia_include() {
-    grep -Eq '^[[:space:]]*include([[:space:]].*)?"([^"]*/)?noctalia\.kdl"([[:space:]]|$)' "$config_file"
+    grep -Eq '^[[:space:]]*include([[:space:]].*)?"([^"]*/)?noctalia-theme\.kdl"([[:space:]]|$)' "$config_file"
 }
 
 apply_include() {

--- a/assets/templates/niri/undo.sh
+++ b/assets/templates/niri/undo.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/niri"
 config_file="$config_dir/config.kdl"
-theme_file="$config_dir/noctalia.kdl"
+theme_file="$config_dir/noctalia-theme.kdl"
 
 if [ -f "$config_file" ]; then
     tmp_file="$(mktemp "${config_file}.tmp.XXXXXX")"
     trap 'rm -f "$tmp_file"' EXIT
-    awk '!/^[[:space:]]*include([[:space:]].*)?"([^"]*\/)?noctalia\.kdl"/' "$config_file" >"$tmp_file"
+    awk '!/^[[:space:]]*include([[:space:]].*)?"([^"]*\/)?noctalia-theme\.kdl"/' "$config_file" >"$tmp_file"
     if ! cmp -s "$config_file" "$tmp_file"; then
         cat "$tmp_file" >"$config_file"
     fi


### PR DESCRIPTION
## Summary

- write Noctalia's generated niri theme to `noctalia-theme.kdl`
- include and remove only that generated filename
- preserve a user's existing `noctalia.kdl` and its include during undo

Fixes #4084

## Verification

- baseline: undo deletes the user's `noctalia.kdl` (`FAIL`)
- candidate: user `noctalia.kdl` and include survive; generated `noctalia-theme.kdl` and include are removed (`PASS`)
- scope: `assets/templates/niri/apply.sh` and `assets/templates/niri/undo.sh` only
