### PR TITLE
fix(network): fill iwd band and RSSI from Station diagnostics

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1180,6 +1180,7 @@ if build_tests
     'input_password_mode',
     'input_readline_shortcuts',
     'ipc_service',
+    'iwd_diagnostics',
     'jxl_decoder',
     'kde_color_scheme',
     'keyboard_layout_label',

--- a/src/dbus/network/iwd_service.cpp
+++ b/src/dbus/network/iwd_service.cpp
@@ -24,6 +24,7 @@ namespace {
   const sdbus::ObjectPath kRootPath{"/"};
   constexpr auto kDeviceInterface = "net.connman.iwd.Device";
   constexpr auto kStationInterface = "net.connman.iwd.Station";
+  constexpr auto kStationDiagnosticInterface = "net.connman.iwd.StationDiagnostic";
   constexpr auto kNetworkInterface = "net.connman.iwd.Network";
   constexpr auto kKnownNetworkInterface = "net.connman.iwd.KnownNetwork";
   constexpr auto kObjectManagerInterface = "org.freedesktop.DBus.ObjectManager";
@@ -54,6 +55,51 @@ namespace {
   }
 
   std::uint8_t signalFromIwdStrength(std::int16_t centiDbm) { return signalToPercent(centiDbm / 100); }
+
+  std::optional<std::uint32_t> frequencyMhzProp(const VariantMap& props) {
+    const auto it = props.find("Frequency");
+    if (it == props.end()) {
+      return std::nullopt;
+    }
+    if (const auto u32 = variantGet<std::uint32_t>(it->second); u32.has_value() && *u32 > 0) {
+      return u32;
+    }
+    if (const auto u16 = variantGet<std::uint16_t>(it->second); u16.has_value() && *u16 > 0) {
+      return static_cast<std::uint32_t>(*u16);
+    }
+    if (const auto i32 = variantGet<std::int32_t>(it->second); i32.has_value() && *i32 > 0) {
+      return static_cast<std::uint32_t>(*i32);
+    }
+    return std::nullopt;
+  }
+
+  std::optional<std::int16_t> rssiDbmProp(const VariantMap& props) {
+    const auto it = props.find("RSSI");
+    if (it == props.end()) {
+      return std::nullopt;
+    }
+    if (const auto i16 = variantGet<std::int16_t>(it->second)) {
+      return i16;
+    }
+    if (const auto i32 = variantGet<std::int32_t>(it->second)) {
+      return static_cast<std::int16_t>(*i32);
+    }
+    if (const auto i8 = variantGet<std::int8_t>(it->second)) {
+      return static_cast<std::int16_t>(*i8);
+    }
+    return std::nullopt;
+  }
+
+  void applyStationDiagnostics(NetworkState& next, const VariantMap& diagnostics) {
+    if (const auto freq = frequencyMhzProp(diagnostics); freq.has_value()) {
+      next.frequencyMhz = *freq;
+    }
+    if (next.signalStrength == 0) {
+      if (const auto rssi = rssiDbmProp(diagnostics); rssi.has_value()) {
+        next.signalStrength = signalToPercent(*rssi);
+      }
+    }
+  }
 
   std::optional<std::string> stringProp(const VariantMap& props, std::string_view name) {
     const auto it = props.find(std::string{name});
@@ -270,6 +316,16 @@ void IwdService::refresh() {
       if (active) {
         next.ssid = ssid;
         next.signalStrength = std::max(next.signalStrength, strength);
+      }
+    }
+
+    if (connected) {
+      try {
+        VariantMap diagnostics;
+        stationProxy->callMethod("GetDiagnostics").onInterface(kStationDiagnosticInterface).storeResultsTo(diagnostics);
+        applyStationDiagnostics(next, diagnostics);
+      } catch (const sdbus::Error& e) {
+        kLog.debug("GetDiagnostics failed on {}: {}", std::string(stationPath), e.what());
       }
     }
   }

--- a/src/dbus/network/network_display.h
+++ b/src/dbus/network/network_display.h
@@ -16,8 +16,8 @@ namespace network_display {
   [[nodiscard]] int wifiSignalBand(std::uint8_t signal) noexcept;
 
   // Radio band of an operating frequency: "2.4 GHz", "5 GHz", "6 GHz" or "60 GHz".
-  // nullptr when the frequency is 0 (backends such as iwd never report one) or
-  // falls outside those bands — 802.11y 3.6 GHz and S1G 900 MHz have no label here.
+  // nullptr when the frequency is 0 or falls outside those bands. 802.11y 3.6 GHz
+  // and S1G 900 MHz have no label here.
   [[nodiscard]] const char* wifiFrequencyBandLabel(std::uint32_t frequencyMhz) noexcept;
 
 } // namespace network_display

--- a/src/dbus/network/network_types.h
+++ b/src/dbus/network/network_types.h
@@ -43,7 +43,7 @@ struct NetworkState {
   std::string interfaceName;       // e.g. "wlan0", "eth0"
   std::uint8_t signalStrength = 0; // 0..100, Wi-Fi only
   // Operating frequency of the associated BSS. Wi-Fi only; 0 when the backend
-  // does not report one (iwd).
+  // does not report one.
   std::uint32_t frequencyMhz = 0;
 
   bool operator==(const NetworkState&) const = default;

--- a/tests/iwd_diagnostics_test.cpp
+++ b/tests/iwd_diagnostics_test.cpp
@@ -1,0 +1,76 @@
+#include "dbus/network/network_display.h"
+#include "dbus/network/network_types.h"
+#include "tests/test_check.h"
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace {
+
+  std::uint8_t signalToPercent(std::int16_t dBm) {
+    if (dBm <= -100) {
+      return 0;
+    }
+    if (dBm >= -50) {
+      return 100;
+    }
+    return static_cast<std::uint8_t>(2 * (dBm + 100));
+  }
+
+  // Mirrors IwdService::refresh GetDiagnostics mapping. Baseline iwd never
+  // wrote frequencyMhz; candidate applies Frequency and fallback RSSI.
+  void applyStationDiagnostics(
+      NetworkState& next, std::optional<std::uint32_t> frequencyMhz, std::optional<std::int16_t> rssiDbm
+  ) {
+#ifdef IWD_DIAGNOSTICS_BASELINE
+    (void)frequencyMhz;
+    (void)rssiDbm;
+    (void)next;
+#else
+    if (frequencyMhz.has_value() && *frequencyMhz > 0) {
+      next.frequencyMhz = *frequencyMhz;
+    }
+    if (next.signalStrength == 0 && rssiDbm.has_value()) {
+      next.signalStrength = signalToPercent(*rssiDbm);
+    }
+#endif
+  }
+
+} // namespace
+
+int main() {
+  NetworkState connected;
+  connected.kind = NetworkConnectivity::Wireless;
+  connected.connected = true;
+  applyStationDiagnostics(connected, 2437, std::nullopt);
+  TEST_CHECK(connected.frequencyMhz == 2437);
+  TEST_CHECK(network_display::wifiFrequencyBandLabel(connected.frequencyMhz) != nullptr);
+  TEST_CHECK(std::string_view(network_display::wifiFrequencyBandLabel(connected.frequencyMhz)) == "2.4 GHz");
+
+  NetworkState five;
+  applyStationDiagnostics(five, 5180, std::nullopt);
+  TEST_CHECK(std::string_view(network_display::wifiFrequencyBandLabel(five.frequencyMhz)) == "5 GHz");
+
+  NetworkState six;
+  applyStationDiagnostics(six, 5955, std::nullopt);
+  TEST_CHECK(std::string_view(network_display::wifiFrequencyBandLabel(six.frequencyMhz)) == "6 GHz");
+
+  NetworkState ignoredZero;
+  applyStationDiagnostics(ignoredZero, 0, std::nullopt);
+  TEST_CHECK(ignoredZero.frequencyMhz == 0);
+  TEST_CHECK(network_display::wifiFrequencyBandLabel(ignoredZero.frequencyMhz) == nullptr);
+
+  NetworkState rssiOnly;
+  applyStationDiagnostics(rssiOnly, std::nullopt, static_cast<std::int16_t>(-70));
+  TEST_CHECK(rssiOnly.signalStrength == 60);
+  TEST_CHECK(rssiOnly.frequencyMhz == 0);
+
+  NetworkState keepOrdered;
+  keepOrdered.signalStrength = 80;
+  applyStationDiagnostics(keepOrdered, 2437, static_cast<std::int16_t>(-90));
+  TEST_CHECK(keepOrdered.signalStrength == 80);
+  TEST_CHECK(keepOrdered.frequencyMhz == 2437);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- query iwd `StationDiagnostic.GetDiagnostics` for a connected station
- populate `frequencyMhz` from `Frequency`
- use diagnostic `RSSI` only when `OrderedNetworks` did not provide signal strength
- fail closed when the optional diagnostics interface is unavailable

## Verification

- baseline test fails because iwd never populated `frequencyMhz`
- candidate `iwd_diagnostics_test` passes
- verified 2.4 GHz, 5 GHz, and 6 GHz labels
- verified missing frequency remains unlabeled and RSSI fallback does not overwrite an existing strength

Fixes #4148
