### PR TITLE
fix(bluetooth): show DisplayPasskey pairing code

### DIFF
--- a/src/dbus/bluetooth/bluetooth_agent.cpp
+++ b/src/dbus/bluetooth/bluetooth_agent.cpp
@@ -40,7 +40,9 @@ struct BluetoothAgent::Impl {
   explicit Impl(SystemBus& b) : bus(b) {}
 
   [[nodiscard]] bool hasPending() const noexcept {
-    return pendingString.has_value() || pendingUint.has_value() || pendingVoid.has_value();
+    // DisplayPasskey is fire-and-forget (no Result holder). Gate on kind so the
+    // pairing card can show the six-digit code until Cancel / BlueZ Cancel.
+    return pending.kind != BluetoothPairingKind::None;
   }
 
   void rejectIfBusy(auto& result, const char* what) {

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -448,6 +448,9 @@ std::unique_ptr<Flex> BluetoothTab::create() {
                     }
                   }
                   break;
+                case BluetoothPairingKind::DisplayPasskey:
+                  // Informational only: no Agent1 reply to send. Do not cancel.
+                  break;
                 default:
                   m_agent->cancelPending();
                   break;


### PR DESCRIPTION
## Summary
- treat a pending `DisplayPasskey` request as visible even though it has no D-Bus result holder
- keep the six-digit pairing code visible when the UI Accept action is pressed
- preserve existing submit behavior for PIN and confirmation requests

Fixes #4231.

## Verification
- baseline replica fails because `DisplayPasskey` is not pending without result holders
- candidate replica passes: DisplayPasskey is pending, Accept is a no-op, PIN and confirmation still submit
- `bluetooth_agent.cpp` passes focused `g++ -std=c++20 -fsyntax-only -I src`

Full Meson/Ninja compilation was not run on the constrained verification host.