### PR TITLE
feat(settings): add search for installed plugins

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1523,6 +1523,8 @@
         "incompatible-plugin-api": "incompatible plugin API",
         "remove": "Remove plugin",
         "requires": "Requires: {dependencies}",
+        "search-empty": "No plugins match \"{query}\".",
+        "search-placeholder": "Search installed plugins",
         "title": "Plugins",
         "update-all": "Update all ({count})",
         "update-available": "update available",

--- a/src/shell/settings/settings_content_plugins.cpp
+++ b/src/shell/settings/settings_content_plugins.cpp
@@ -849,7 +849,25 @@ namespace settings {
             .scrollToTop = ctx.scrollContentToTop,
         }
     );
-
+    // Collect before the header so the update badge counts the visible rows.
+    std::vector<scripting::PluginStatus> plugins;
+    plugins.reserve(ctx.plugins.size());
+    for (const auto& plugin : ctx.plugins) {
+      if (plugin.materialized || plugin.enabled) {
+        plugins.push_back(plugin);
+      }
+    }
+    // In page search narrows the list and empty query keeps every plugin.
+    if (!ctx.searchQuery.empty()) {
+      std::erase_if(plugins, [&](const scripting::PluginStatus& plugin) {
+        return !(
+            StringUtils::containsInsensitive(pluginDisplayName(plugin), ctx.searchQuery)
+            || StringUtils::containsInsensitive(plugin.id, ctx.searchQuery)
+            || StringUtils::containsInsensitive(plugin.description, ctx.searchQuery)
+            || StringUtils::containsInsensitive(plugin.source, ctx.searchQuery)
+        );
+      });
+    }
     Flex* pluginsHeader = nullptr;
     auto pluginsHeaderNode = ui::row({
         .out = &pluginsHeader,
@@ -865,10 +883,29 @@ namespace settings {
           })
       );
     }
-    pluginsHeader->addChild(ui::spacer());
-    const int updatesAvailable = static_cast<int>(
-        std::ranges::count_if(ctx.plugins, [](const scripting::PluginStatus& p) { return p.updateAvailable; })
+    // Only shows the installed plugins.
+    Input* pluginSearchInput = nullptr;
+    pluginsHeader->addChild(
+        ui::input({
+            .out = &pluginSearchInput,
+            .value = std::string(ctx.searchQuery),
+            .placeholder = i18n::tr("settings.plugins.plugins.search-placeholder"),
+            .fontSize = Style::fontSizeBody * scale,
+            .controlHeight = Style::controlHeight * scale,
+            .horizontalPadding = Style::spaceSm * scale,
+            .clearButtonEnabled = true,
+            .width = 300.0F * scale,
+            .onChange = [cb = ctx.setSearchQuery](const std::string& text) {
+              if (cb) {
+                cb(text);
+              }
+            },
+        })
     );
+    pluginSearchInput->inputArea()->setTabFocusKey("settings.plugins.search");
+    pluginsHeader->addChild(ui::spacer());
+    const int updatesAvailable =
+        static_cast<int>(std::ranges::count_if(plugins, &scripting::PluginStatus::updateAvailable));
     if (updatesAvailable > 0 && ctx.updateAll) {
       pluginsHeader->addChild(
           ui::button({
@@ -907,13 +944,6 @@ namespace settings {
           i18n::tr("settings.plugins.plugins.empty"), Style::fontSizeCaption * scale, ColorRole::OnSurfaceVariant
       ));
     }
-    std::vector<scripting::PluginStatus> plugins;
-    plugins.reserve(ctx.plugins.size());
-    for (const auto& plugin : ctx.plugins) {
-      if (plugin.materialized || plugin.enabled) {
-        plugins.push_back(plugin);
-      }
-    }
     std::ranges::sort(plugins, [&](const auto& a, const auto& b) {
       const std::string_view aName = pluginDisplayName(a);
       const std::string_view bName = pluginDisplayName(b);
@@ -930,6 +960,12 @@ namespace settings {
       if (!ctx.pendingDeletePluginId.empty() && ctx.pendingDeletePluginId == plugin.id) {
         pluginsBody->addChild(pluginDeleteConfirmPanel(plugin, ctx, scale));
       }
+    }
+    if (!ctx.pluginsLoading && !ctx.plugins.empty() && plugins.empty() && !ctx.searchQuery.empty()) {
+      pluginsBody->addChild(makeLabel(
+          i18n::tr("settings.plugins.plugins.search-empty", "query", ctx.searchQuery), Style::fontSizeCaption * scale,
+          ColorRole::OnSurfaceVariant
+      ));
     }
   }
 

--- a/src/shell/settings/settings_content_plugins.cpp
+++ b/src/shell/settings/settings_content_plugins.cpp
@@ -849,7 +849,6 @@ namespace settings {
             .scrollToTop = ctx.scrollContentToTop,
         }
     );
-    // Collect before the header so the update badge counts the visible rows.
     std::vector<scripting::PluginStatus> plugins;
     plugins.reserve(ctx.plugins.size());
     for (const auto& plugin : ctx.plugins) {
@@ -857,6 +856,10 @@ namespace settings {
         plugins.push_back(plugin);
       }
     }
+    // The update action covers every installed plugin, so count the badge before filtering.
+    const int updatesAvailable =
+        static_cast<int>(std::ranges::count_if(plugins, &scripting::PluginStatus::updateAvailable));
+    const bool hasInstalledPlugins = !plugins.empty();
     // In page search narrows the list and empty query keeps every plugin.
     if (!ctx.searchQuery.empty()) {
       std::erase_if(plugins, [&](const scripting::PluginStatus& plugin) {
@@ -888,7 +891,7 @@ namespace settings {
     pluginsHeader->addChild(
         ui::input({
             .out = &pluginSearchInput,
-            .value = std::string(ctx.searchQuery),
+            .value = ctx.searchQuery,
             .placeholder = i18n::tr("settings.plugins.plugins.search-placeholder"),
             .fontSize = Style::fontSizeBody * scale,
             .controlHeight = Style::controlHeight * scale,
@@ -902,10 +905,10 @@ namespace settings {
             },
         })
     );
-    pluginSearchInput->inputArea()->setTabFocusKey("settings.plugins.search");
+    if (pluginSearchInput != nullptr && pluginSearchInput->inputArea() != nullptr) {
+      pluginSearchInput->inputArea()->setTabFocusKey("settings.plugins.search");
+    }
     pluginsHeader->addChild(ui::spacer());
-    const int updatesAvailable =
-        static_cast<int>(std::ranges::count_if(plugins, &scripting::PluginStatus::updateAvailable));
     if (updatesAvailable > 0 && ctx.updateAll) {
       pluginsHeader->addChild(
           ui::button({
@@ -947,8 +950,10 @@ namespace settings {
     std::ranges::sort(plugins, [&](const auto& a, const auto& b) {
       const std::string_view aName = pluginDisplayName(a);
       const std::string_view bName = pluginDisplayName(b);
-      if (aName != bName) {
-        return aName < bName;
+      if (!StringUtils::equalsInsensitive(aName, bName)) {
+        return std::ranges::lexicographical_compare(aName, bName, [](char x, char y) {
+          return std::tolower(static_cast<unsigned char>(x)) < std::tolower(static_cast<unsigned char>(y));
+        });
       }
       if (a.source != b.source) {
         return pluginSourceLess(a.source, b.source);
@@ -961,8 +966,8 @@ namespace settings {
         pluginsBody->addChild(pluginDeleteConfirmPanel(plugin, ctx, scale));
       }
     }
-    if (!ctx.pluginsLoading && !ctx.plugins.empty() && plugins.empty() && !ctx.searchQuery.empty()) {
-      pluginsBody->addChild(makeLabel(
+    if (!ctx.pluginsLoading && hasInstalledPlugins && plugins.empty() && !ctx.searchQuery.empty()) {
+      section->addChild(makeLabel(
           i18n::tr("settings.plugins.plugins.search-empty", "query", ctx.searchQuery), Style::fontSizeCaption * scale,
           ColorRole::OnSurfaceVariant
       ));

--- a/src/shell/settings/settings_content_plugins.h
+++ b/src/shell/settings/settings_content_plugins.h
@@ -26,8 +26,9 @@ namespace settings {
   struct SettingsPluginsContext {
     float scale = 1.0F;
     std::string_view selectedSection;
-    // In page search query and empty means no filtering.
-    std::string_view searchQuery;
+    // In page search query and empty means no filtering. Owned copy so the context
+    // never views a string that a debounced rebuild could observe mid mutation.
+    std::string searchQuery;
     std::function<void(std::string)> setSearchQuery;
     std::vector<scripting::PluginStatus> plugins;
     std::vector<PluginSourceConfig> sources;

--- a/src/shell/settings/settings_content_plugins.h
+++ b/src/shell/settings/settings_content_plugins.h
@@ -26,6 +26,9 @@ namespace settings {
   struct SettingsPluginsContext {
     float scale = 1.0F;
     std::string_view selectedSection;
+    // In page search query and empty means no filtering.
+    std::string_view searchQuery;
+    std::function<void(std::string)> setSearchQuery;
     std::vector<scripting::PluginStatus> plugins;
     std::vector<PluginSourceConfig> sources;
     bool searchActive = false;

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -492,6 +492,7 @@ void SettingsWindow::openToBarWidget(std::string barName, std::string widgetName
   clearTransientSettingsState();
   clearStatusMessage();
   m_searchQuery.clear();
+  m_pluginSearchQuery.clear();
   m_selectedSection = "bar";
   m_selectedBarName = std::move(barName);
   m_selectedMonitorOverride.clear();
@@ -515,6 +516,7 @@ bool SettingsWindow::openToPlugin(std::string pluginId) {
   clearTransientSettingsState();
   clearStatusMessage();
   m_searchQuery.clear();
+  m_pluginSearchQuery.clear();
   m_selectedSection = "plugins";
   m_pendingOpenPluginSettingsId = std::move(pluginId);
   m_contentScrollState.offset = 0.0F;
@@ -624,6 +626,8 @@ void SettingsWindow::destroyWindow() {
   m_pendingResetPageScope.clear();
   m_pendingResetSettingPaths.clear();
   m_searchQuery.clear();
+  m_pluginSearchQuery.clear();
+  m_pluginSearchDebounceTimer.stop();
   m_selectedSection.clear();
   m_selectedBarName.clear();
   m_selectedMonitorOverride.clear();

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -310,7 +310,9 @@ private:
   bool m_deferFocusScrollToLayout = false;
   Node* m_pendingContentScrollTarget = nullptr;
   std::string m_searchQuery;
+  std::string m_pluginSearchQuery;
   Timer m_searchDebounceTimer;
+  Timer m_pluginSearchDebounceTimer;
   // Set by openToBarWidget (e.g. middle-click on a bar widget) / openToPlugin and consumed after
   // the Settings scene is available so the requested editor can be mounted into it.
   std::string m_pendingOpenWidgetInspectorName;

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -1074,6 +1074,14 @@ void SettingsWindow::rebuildSettingsContent() {
         settings::SettingsPluginsContext{
             .scale = scale,
             .selectedSection = m_selectedSection,
+            .searchQuery = m_pluginSearchQuery,
+            .setSearchQuery =
+                [this](std::string query) {
+                  m_pluginSearchQuery = std::move(query);
+                  m_contentScrollState.offset = 0.0F;
+                  m_pendingDeletePluginId.clear();
+                  m_pluginSearchDebounceTimer.start(kSearchDebounceInterval, [this]() { requestContentRebuild(); });
+                },
             .plugins = m_pluginList,
             .sources = cfg.plugins.sources,
             .searchActive = !m_searchQuery.empty(),
@@ -1403,7 +1411,11 @@ std::unique_ptr<Flex> SettingsWindow::buildBody(
     this->createMonitorOverride(std::move(barName), std::move(match));
   };
   const auto clearTransientSettingsState = [this]() { this->clearTransientSettingsState(); };
-  const auto clearSearchQuery = [this]() { m_searchQuery.clear(); };
+  const auto clearSearchQuery = [this]() {
+    m_searchQuery.clear();
+    m_pluginSearchQuery.clear();
+    m_pluginSearchDebounceTimer.stop();
+  };
 
   auto body = ui::row({
       .align = FlexAlign::Stretch,


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

This PR adds an in-page search field to Plugins section that filters installed plugins by name, id, description, and source (case-insensitive). The query is debounced, resets scroll on change, clears on section navigation, and shows a "No plugins match" with the query message when nothing matches. The "Update all (N)" badge counts every installed plugin with an update regardless of the active search filter, so the count stays stable while typing. Installed plugins are also sorted case-insensitively now.

## Motivation

Good to have search to find plugins easily and better for the people with many plugins installed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4191 

## Testing

- `just format && just test debug && just lint && python3 tools/i18n-check.py`  all ran with no issue

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/db17df68-cf4a-44b9-94d9-e387dc9ccf6c

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.