### PR TITLE
build(nix): disable building tests in the package

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -123,6 +123,8 @@ lib.warnIf cudaSupport
 
   mesonBuildType = "release";
 
+  mesonFlags = [ "-Dtests=disabled" ];
+
   ninjaFlags = [ "-v" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

This PR disables building tests in the nix package

## Motivation

Building tests increases unnecessary compilation time for a `-git` package

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`nix-build .` followed by running `./result/bin/noctalia`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
