### PR TITLE
fix(pipewire): mute route-less virtual sources

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -1925,9 +1925,9 @@ void PipeWireService::setNodeMuted(std::uint32_t id, bool muted) {
     return;
   }
 
-  // Device nodes go through WirePlumber's mixer-api to keep pipewire-pulse / pavucontrol in sync. The
-  // committed mute echoes back through onMixerVolumeChanged; swMute is set optimistically for
-  // immediate UI feedback.
+  // Device nodes with a hardware route go through WirePlumber's mixer-api to keep pipewire-pulse /
+  // pavucontrol in sync. Route-less virtual sources also need the direct SPA node mute below: the mixer
+  // write can update the optimistic UI state without stopping capture in the virtual filter graph.
   const bool isDeviceNode = nd.mediaClass == "Audio/Sink" || nd.mediaClass == "Audio/Source";
   if (isDeviceNode && m_wpMixer != nullptr) {
     m_wpMixer->setMuted(id, muted);
@@ -1942,7 +1942,9 @@ void PipeWireService::setNodeMuted(std::uint32_t id, bool muted) {
       }
       rebuildState();
     }
-    return;
+    if (nd.hasRoute) {
+      return;
+    }
   }
 
   // Program streams, and device nodes for immediate local/UI consistency.


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item. -->

## Summary

Mute route-less virtual audio sources (EasyEffects virtual microphones) by continuing past mixer-api to the existing SPA `PROP_mute` node write. Hardware sources that already have a DeviceRoute stay mixer-api-only.

`Audio/Source/Virtual` is collapsed to `Audio/Source` after #3846, so panel mute currently writes mixer-api, sets optimistic `swMute` for the icon, and returns before SPA mute. That stops capture on routed hardware mics but leaves EasyEffects filter-graph capture live.

## Motivation

https://github.com/noctalia-dev/noctalia/issues/4226 — muting the selected EasyEffects virtual microphone flips the muted icon while capture still passes. Hardware "Kreo Sonic Analog Stereo" mutes correctly. Virtual recognition (#3846) listed these sources; it did not make mute stop capture.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4226

## Testing

- `clang-format` 22.1.8 `--dry-run --Werror` on `src/pipewire/pipewire_service.cpp`: exit 0
- `git diff --check`: exit 0
- Standalone control-flow contract `virtual_source_mute_test.cpp`:
  - baseline (`-DBASELINE`): exit 1 — `route-less virtual source must receive a direct SPA node mute`
  - candidate `1736d19f75c37e177e18d2b2f9d3f6897842ef13`: exit 0 — PASS
  - cases: route-less source gets SPA mute; routed hardware source stays mixer-only; program stream retains SPA mute; device source without mixer retains SPA mute
- Full Meson/Ninja suite was not run; this host has no EasyEffects capture graph. The change is the early-return gate in `PipeWireService::setNodeMuted` only.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

No live EasyEffects session was available on the verification host.

## Screenshots / Videos

N/A — mute control-flow, no UI layout change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Candidate SHA `1736d19f75c37e177e18d2b2f9d3f6897842ef13` on baseline `a1a0e0ffc841af1f77901bc7ebc81c104ed8d56e`. Does not implement #3274 (visual mute desync). Does not change default-device selection.
