### PR TITLE
feat(widgets/media): add "Rotate Album Art" option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -4208,6 +4208,10 @@
           "description": "Reverse the low-to-high frequency order of the bars",
           "label": "Reversed"
         },
+        "rotate-album-art": {
+          "description": "Rotate the circular album artwork while media is playing",
+          "label": "Rotate Album Art"
+        },
         "scale": {
           "description": "Scale this widget relative to the bar content scale",
           "label": "Scale"

--- a/docs/user/bar/widgets/media.mdx
+++ b/docs/user/bar/widgets/media.mdx
@@ -12,6 +12,7 @@ Left-click opens the Media tab in the control center; right-click toggles play/p
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `album_art_only` | bool | `false` | Show only circular album artwork (horizontal bars; hidden in Settings on vertical bars) |
+| `rotate_album_art` | bool | `false` | Rotate the circular album artwork while media is playing (hidden when `hide_album_art` is enabled) |
 | `hide_album_art` | bool | `false` | Hide the album artwork (horizontal bars). Also hides the fallback icon |
 | `hide_artist` | bool | `false` | Hide the artist and show only the track title (horizontal bars; ignored when `album_art_only` is enabled) |
 | `artist_first` | bool | `false` | Show `Artist - Title` instead of `Title - Artist` (horizontal bars; ignored when `hide_artist` or `album_art_only` is enabled) |

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <numbers>
 #include <wayland-client-protocol.h>
 
 using namespace mpris;
@@ -28,8 +29,9 @@ MediaWidget::MediaWidget(MprisService* mpris, HttpClient* httpClient, wl_output*
     : m_mpris(mpris), m_httpClient(httpClient), m_maxWidth(static_cast<float>(options.maxWidth)),
       m_minWidth(static_cast<float>(options.minWidth)), m_artSize(static_cast<float>(options.artSize)),
       m_titleScrollMode(options.titleScrollMode), m_hideWhenNoMedia(options.hideWhenNoMedia),
-      m_albumArtOnly(options.albumArtOnly), m_hideAlbumArt(options.hideAlbumArt), m_hideArtist(options.hideArtist),
-      m_artistFirst(options.artistFirst), m_showProgress(options.showProgress) {}
+      m_rotateAlbumArt(options.rotateAlbumArt), m_albumArtOnly(options.albumArtOnly),
+      m_hideAlbumArt(options.hideAlbumArt), m_hideArtist(options.hideArtist), m_artistFirst(options.artistFirst),
+      m_showProgress(options.showProgress) {}
 
 void MediaWidget::create() {
   auto area = ui::inputArea({});
@@ -213,6 +215,28 @@ void MediaWidget::doUpdate(Renderer& renderer) {
   syncProgress(active);
 }
 
+bool MediaWidget::needsFrameTick() const {
+  return m_rotateAlbumArt
+      && m_lastPlaybackStatus == "Playing"
+      && m_art != nullptr
+      && m_art->hasImage()
+      && m_art->visible();
+}
+
+void MediaWidget::onFrameTick(float deltaMs) {
+  constexpr float kRotationsPerSecond = 0.1F;
+  constexpr float kTwoPi = 2.0F * std::numbers::pi_v<float>;
+
+  m_artRotation += (kTwoPi * kRotationsPerSecond) * (deltaMs / 1000.0F);
+  if (m_artRotation >= kTwoPi) {
+    m_artRotation -= kTwoPi;
+  }
+  if (m_art != nullptr) {
+    m_art->setRotation(m_artRotation);
+    requestRedraw();
+  }
+}
+
 void MediaWidget::applyTitleScrollMode(bool titleVisible) {
   if (m_label == nullptr) {
     return;
@@ -309,6 +333,9 @@ void MediaWidget::syncState(Renderer& renderer, const std::optional<MprisPlayerI
         m_lastPlaybackStatus == "Playing" ? widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))
                                           : colorSpecFromRole(ColorRole::OnSurfaceVariant)
     );
+    if (needsFrameTick()) {
+      requestFrameTick();
+    }
     requestRedraw();
     return;
   }
@@ -327,6 +354,8 @@ void MediaWidget::syncState(Renderer& renderer, const std::optional<MprisPlayerI
 
   const int artDecodePx = static_cast<int>(std::round(64.0F * m_contentScale));
   if (artChanged) {
+    m_artRotation = 0.0F;
+    m_art->setRotation(0.0F);
     if (m_hideAlbumArt) {
       m_art->clear(renderer);
     } else {
@@ -354,6 +383,10 @@ void MediaWidget::syncState(Renderer& renderer, const std::optional<MprisPlayerI
         requestRedraw();
       }
     }
+  }
+
+  if (needsFrameTick()) {
+    requestFrameTick();
   }
 
   if (textChanged || artChanged) {

--- a/src/shell/bar/widgets/media_widget.h
+++ b/src/shell/bar/widgets/media_widget.h
@@ -34,6 +34,7 @@ public:
     int artSize = 16;
     MediaTitleScrollMode titleScrollMode = MediaTitleScrollMode::None;
     bool hideWhenNoMedia = false;
+    bool rotateAlbumArt = false;
     bool albumArtOnly = false;
     bool hideAlbumArt = false;
     bool hideArtist = false;
@@ -44,6 +45,8 @@ public:
   MediaWidget(MprisService* mpris, HttpClient* httpClient, wl_output* output, Options options);
 
   void create() override;
+  [[nodiscard]] bool needsFrameTick() const override;
+  void onFrameTick(float deltaMs) override;
 
 private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
@@ -65,6 +68,7 @@ private:
   float m_artSize = 16.0F;
   MediaTitleScrollMode m_titleScrollMode = MediaTitleScrollMode::None;
   bool m_hideWhenNoMedia = false;
+  bool m_rotateAlbumArt = false;
   bool m_albumArtOnly = false;
   bool m_hideAlbumArt = false;
   bool m_hideArtist = false;
@@ -73,6 +77,7 @@ private:
   // Cached from the last doLayout(); the update phase has no container extents of its own.
   bool m_isVertical = false;
   bool m_progressFillVisible = false;
+  float m_artRotation = 0.0F;
   InputArea* m_area = nullptr;
   Image* m_art = nullptr;
   Glyph* m_emptyGlyph = nullptr;

--- a/src/shell/bar/widgets/media_widget_definition.cpp
+++ b/src/shell/bar/widgets/media_widget_definition.cpp
@@ -18,6 +18,13 @@ const noctalia::bar::WidgetDefinition<MediaWidget::Options>& mediaWidgetDefiniti
                       .horizontalBarOnly = true,
                   },
           }),
+          field<&Options::rotateAlbumArt>({
+              .key = "rotate_album_art",
+              .presentation =
+                  settings::WidgetSettingPresentation{
+                      .visibleWhen = notHideAlbumArt,
+                  },
+          }),
           field<&Options::hideAlbumArt>({
               .key = "hide_album_art",
               .presentation =


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add an optional "Rotate Album Art" setting to the Media bar widget. When enabled, the circular album artwork continuously rotates while media playback is "Playing".

## Motivation

Allows users to have an animated vinyl/record-style spinning album art effect in the bar when music is actively playing, adding visual feedback and flair to the desktop.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

- Ran `ninja -C build-debug test`: 110/110 tests passed.
- Ran `python3 tools/i18n-check.py`: OK (catalog valid).
- Live manual testing on Wayland with active MPRIS player (testing play, pause, track changes, and option toggle).

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/73351c70-a267-44dd-aaac-b352ca34424a


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Frame tick animation runs at 0.1 rotations/second.
- Only ticks when media is actively playing and artwork is visible.
- Angle smoothly wraps around 2*pi and resets to 0 when album artwork changes.
