### PR TITLE
fix(power): work around mac charge limit quirks

### DIFF
--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -128,13 +128,8 @@ namespace {
     }
   }
 
-  bool chargeLimitIsRestrictive(const UPowerChargeLimitState& state) {
-    return (state.effectiveStart.has_value() && (*state.effectiveStart > 0U && *state.effectiveStart < 100U))
-        || (state.effectiveEnd.has_value() && *state.effectiveEnd < 100U);
-  }
-
   bool chargeLimitIsExternallyManaged(const UPowerChargeLimitState& state) {
-    return state.enabledAvailable && !state.enabled && chargeLimitIsRestrictive(state);
+    return state.enabledAvailable && !state.enabled && state.hasRestrictiveThreshold();
   }
 
   bool sameDeviceInfoExceptChargeLimit(const UPowerDeviceInfo& lhs, const UPowerDeviceInfo& rhs) {
@@ -259,6 +254,11 @@ std::optional<double> UPowerDeviceInfo::healthPercent() const {
     return std::nullopt;
   }
   return std::clamp(energyFull / energyFullDesign * 100.0, 0.0, 100.0);
+}
+
+bool UPowerChargeLimitState::hasRestrictiveThreshold() const {
+  return (effectiveStart.has_value() && *effectiveStart > 0U && *effectiveStart < 100U)
+      || (effectiveEnd.has_value() && *effectiveEnd < 100U);
 }
 
 bool UPowerDeviceInfo::sameCatalogEntry(const UPowerDeviceInfo& other) const {

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -129,7 +129,7 @@ namespace {
   }
 
   bool chargeLimitIsRestrictive(const UPowerChargeLimitState& state) {
-    return (state.effectiveStart.has_value() && *state.effectiveStart > 0U)
+    return (state.effectiveStart.has_value() && (*state.effectiveStart > 0U && *state.effectiveStart < 100U))
         || (state.effectiveEnd.has_value() && *state.effectiveEnd < 100U);
   }
 

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -79,6 +79,11 @@ struct UPowerChargeLimitState {
   std::optional<bool> requestedEnabled;
   ChargeLimitOperationError operationError = ChargeLimitOperationError::None;
 
+  // True when the effective thresholds actually hold charge below full: a start
+  // threshold that delays resuming below full (0 < start < 100), or an end
+  // threshold that caps below full (end < 100). A start of 0 or 100 is not a limit.
+  [[nodiscard]] bool hasRestrictiveThreshold() const;
+
   bool operator==(const UPowerChargeLimitState&) const = default;
 };
 

--- a/src/shell/control_center/tabs/power_tab.cpp
+++ b/src/shell/control_center/tabs/power_tab.cpp
@@ -61,7 +61,7 @@ namespace {
   }
 
   bool hasRestrictiveThreshold(const UPowerChargeLimitState& state) {
-    return (state.effectiveStart.has_value() && *state.effectiveStart > 0U)
+    return (state.effectiveStart.has_value() && (*state.effectiveStart > 0U && *state.effectiveStart < 100U))
         || (state.effectiveEnd.has_value() && *state.effectiveEnd < 100U);
   }
 

--- a/src/shell/control_center/tabs/power_tab.cpp
+++ b/src/shell/control_center/tabs/power_tab.cpp
@@ -60,15 +60,10 @@ namespace {
     return state.configuredStart == state.effectiveStart && state.configuredEnd == state.effectiveEnd;
   }
 
-  bool hasRestrictiveThreshold(const UPowerChargeLimitState& state) {
-    return (state.effectiveStart.has_value() && (*state.effectiveStart > 0U && *state.effectiveStart < 100U))
-        || (state.effectiveEnd.has_value() && *state.effectiveEnd < 100U);
-  }
-
 } // namespace
 
 PowerTab::ChargeLimitMode PowerTab::classifyChargeLimit(const UPowerChargeLimitState& state) noexcept {
-  if (!state.requestPending && state.enabledAvailable && !state.enabled && hasRestrictiveThreshold(state)) {
+  if (!state.requestPending && state.enabledAvailable && !state.enabled && state.hasRestrictiveThreshold()) {
     return ChargeLimitMode::ExternallyManaged;
   }
 
@@ -562,7 +557,7 @@ void PowerTab::rebuildChargeLimits() {
     const auto& state = batteries[i].chargeLimit;
     auto& row = m_chargeLimitRows[i];
     const ChargeLimitMode mode = classifyChargeLimit(state);
-    const bool permitsFullCharge = (state.enabledAvailable && !state.enabled && !hasRestrictiveThreshold(state))
+    const bool permitsFullCharge = (state.enabledAvailable && !state.enabled && !state.hasRestrictiveThreshold())
         || (state.effectiveEnd == 100U && (!state.effectiveStart.has_value() || state.effectiveStart == 0U));
     if (row.nameLabel != nullptr) {
       row.nameLabel->setText(deviceDisplayName(batteries[i]));

--- a/tests/upower_charge_limit_test.cpp
+++ b/tests/upower_charge_limit_test.cpp
@@ -172,6 +172,14 @@ int main() {
   assert(PowerTabTestAccess::mode(state) == Mode::UPowerDisabled);
   assert(PowerTabTestAccess::control(state) == std::tuple(true, false, false));
 
+  // Apple Silicon reports an unrestricted charge limit as 100/100; that is not a
+  // restriction and must not be classified as externally managed.
+  state = supportedState(false);
+  state.effectiveStart = 100U;
+  state.effectiveEnd = 100U;
+  assert(!state.hasRestrictiveThreshold());
+  assert(PowerTabTestAccess::mode(state) == Mode::UPowerDisabled);
+
   state = supportedState(true);
   state.supportedSettings = 4U;
   assert(PowerTabTestAccess::mode(state) == Mode::FirmwareManaged);


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Adapts the external charge limit management check to work on Apple Silicon Macbooks.

## Motivation

The `macsmc_power` driver only [supports values of 75/80 or 100/100](https://linrunner.de/tlp/settings/bc-vendors.html#apple-macbooks) for charge limit. The existing check assumes the default start value is always 0, preventing the feature from working on these machines. Been running it locally for about two weeks and it works fine on my M2 Air.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

The bar widget now allows toggling the charge limit, changes work as expected when verified against `upower --battery`. Built using the nix flake.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
