### PR TITLE
fix(template): umbriel template is missing some color keys

### DIFF
--- a/assets/templates/umbriel/umbriel.toml
+++ b/assets/templates/umbriel/umbriel.toml
@@ -18,3 +18,5 @@ outer = "#{{colors.terminal_background.default.hex_stripped}}FF"
 
 [colors.overview]
 background_tint = "#{{colors.surface.default.hex_stripped}}88"
+badge = "#{{colors.primary.default.hex_stripped}}FF"
+workspace_bacground = "#{{colors.surface.default.hex_stripped}}FF"


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Add the following keys to the `umbriel` template for support of all themeable colors:
- `colors.shadow`
- `colors.overview.badge`
- `colors.overview.workspace_background`

## Motivation

Originally I missed the badges to be themed, but while opening this PR I decided it might be nice to add the other two missing as well.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

none of my knowledge, but the topic was mentioned on discord

## Testing

Ran
```sh
noctalia theme -r assets/templates/umbriel/umbriel.toml:test.toml \
 --theme-json ~/.cache/noctalia/predefined-scheme.json
```
which produces
```toml
[colors]
background = "#11112dFF"
text_primary = "#f3edf7FF"
text_muted = "#7c80b4FF"
accent_primary = "#fff59bFF"
accent_secondary = "#a9aefeFF"
warning = "#9bfeceFF"
error = "#fd4663FF"
insert_hint = "#9bfece80"
backdrop = "#11112dFF"
shadow = "##070722FF"

[colors.border]
focused = "#fff59bFF"
unfocused = "#11112dFF"
scratchpad_focused = "#9bfeceFF"
scratchpad_unfocused = "#02e577FF"
outer = "#070722FF"

[colors.overview]
background_tint = "#07072288"
badge = "#fff59bFF"
workspace_bacground = "#070722FF"
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
