### PR TITLE
fix(calendar): expand vdir paths before validation

### DIFF
--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -31,6 +31,7 @@
 #include "ui/controls/segmented.h"
 #include "ui/dialogs/file_dialog.h"
 #include "ui/popup_parent.h"
+#include "util/file_utils.h"
 #include "util/string_utils.h"
 #include "wayland/toplevel_surface.h"
 #include "wayland/wayland_connection.h"
@@ -1495,7 +1496,7 @@ void SettingsWindow::openCalendarAccountEditor(std::optional<std::string> accoun
       }
       if (vdir) {
         const std::filesystem::path checkPath =
-            draft->path.empty() ? calendar::defaultVdirPath() : std::filesystem::path(draft->path);
+            draft->path.empty() ? calendar::defaultVdirPath() : FileUtils::expandUserPath(draft->path);
         std::error_code ec;
         if (!std::filesystem::exists(checkPath, ec) || !std::filesystem::is_directory(checkPath, ec)) {
           draft->pathInvalid = true;


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->

Fix vdir account validation so paths beginning with `~/` are expanded before filesystem checks.

## Motivation

The **Settings → Services → Calendar → Local (vdir)** account editor suggests a tilde-based path in its placeholder:

<img width="1336" height="832" alt="Local vdir path placeholder"
 src="https://github.com/user-attachments/assets/a65ca517-5b7e-4df8-b4fe-4e992c3b39cc" />

However, the editor validates the raw input using `std::filesystem::path`. The standard filesystem API treats `~` literally and does not perform shell-style tilde expansion, so valid paths beginning with `~/` are rejected:

<img width="1860" height="1357" alt="Tilde-based vdir path rejected"
 src="https://github.com/user-attachments/assets/fe5c36e0-acec-47c5-ada4-c32f2f233344" />

This change uses the existing `FileUtils::expandUserPath()` helper before validating the directory, matching the documented behaviour and the existing configuration path handling.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

```bash
just format
NOSYSBASHLOGOUT=1 just test
just build
nix build
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple 

## Screenshots / Videos

No UI changes.

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

Note that the paths started with `~/` will still be converted to absolute path like `/home/username`, this is expected. 