### PR TITLE
fix(icons): defer IconResolver scan until control-center tabs resolve

### DIFF
--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -44,8 +44,8 @@ namespace {
   constexpr float kVolumeSyncEpsilon = 0.005F; // 0.5%
   constexpr auto kVolumeCommitInterval = std::chrono::milliseconds(16);
 
-  // Used to resolve application icons in AudioTab. Function-local so
-  // --version/--help/msg do not pay IconResolver::rebuild() before main().
+  // Application icons for AudioTab rows. Must stay function-local: at TU scope
+  // its icon-theme walk runs before main(), on every CLI invocation.
   [[nodiscard]] IconResolver& audioTabIconResolver() {
     static IconResolver resolver;
     return resolver;

--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -44,8 +44,12 @@ namespace {
   constexpr float kVolumeSyncEpsilon = 0.005F; // 0.5%
   constexpr auto kVolumeCommitInterval = std::chrono::milliseconds(16);
 
-  // Used to resolve application icons in AudioTab.
-  IconResolver g_iconResolver;
+  // Used to resolve application icons in AudioTab. Function-local so
+  // --version/--help/msg do not pay IconResolver::rebuild() before main().
+  [[nodiscard]] IconResolver& audioTabIconResolver() {
+    static IconResolver resolver;
+    return resolver;
+  }
 
   bool isGenericAudioLabel(std::string_view value) {
     if (value.empty()) {
@@ -1147,7 +1151,7 @@ namespace {
           bool loaded = false;
           const int targetPx = static_cast<int>(std::round(m_iconSize));
           for (const std::string& candidate : m_iconCandidates) {
-            const auto& resolved = g_iconResolver.resolve(candidate, targetPx);
+            const auto& resolved = audioTabIconResolver().resolve(candidate, targetPx);
             if (!resolved.empty()) {
               if (!m_lastIconPath.empty() && resolved == m_lastIconPath) {
                 loaded = true;

--- a/src/shell/control_center/tabs/screen_time_tab.cpp
+++ b/src/shell/control_center/tabs/screen_time_tab.cpp
@@ -37,8 +37,8 @@ namespace {
   constexpr float kLegendSwatch = 6.0F;
   constexpr float kUsageDurationFontScale = 0.85F;
 
-  // Function-local so --version/--help/msg do not pay IconResolver::rebuild()
-  // before main(). Constructed on first screen-time icon resolve.
+  // App icons for the usage list. Must stay function-local: at TU scope its
+  // icon-theme walk runs before main(), on every CLI invocation.
   [[nodiscard]] IconResolver& screenTimeIconResolver() {
     static IconResolver resolver;
     return resolver;

--- a/src/shell/control_center/tabs/screen_time_tab.cpp
+++ b/src/shell/control_center/tabs/screen_time_tab.cpp
@@ -37,7 +37,12 @@ namespace {
   constexpr float kLegendSwatch = 6.0F;
   constexpr float kUsageDurationFontScale = 0.85F;
 
-  IconResolver g_iconResolver;
+  // Function-local so --version/--help/msg do not pay IconResolver::rebuild()
+  // before main(). Constructed on first screen-time icon resolve.
+  [[nodiscard]] IconResolver& screenTimeIconResolver() {
+    static IconResolver resolver;
+    return resolver;
+  }
 
   [[nodiscard]] std::string snapshotKey(int rangeDays, const ScreenTimeSnapshot& snapshot) {
     std::string key = std::to_string(rangeDays) + '|' + std::to_string(snapshot.total.count());
@@ -1197,12 +1202,12 @@ std::string ScreenTimeTab::resolveIconPath(const std::string& appKey) const {
     iconName = app_identity::resolveRunningDesktopEntry(baseKey, desktopEntries()).icon;
   }
   if (!iconName.empty()) {
-    const std::string& resolved = g_iconResolver.resolve(iconName, targetPx);
+    const std::string& resolved = screenTimeIconResolver().resolve(iconName, targetPx);
     if (!resolved.empty()) {
       return resolved;
     }
   }
-  const std::string& resolved = g_iconResolver.resolve(baseKey, targetPx);
+  const std::string& resolved = screenTimeIconResolver().resolve(baseKey, targetPx);
   return resolved.empty() ? std::string{} : std::string{resolved};
 }
 


### PR DESCRIPTION
## Summary

Defer `IconResolver` construction in the audio and screen-time control-center tabs until the first icon resolve. TU-scope globals previously ran `rebuild()` during dynamic init, so `noctalia --version`, `--help`, and `msg` paid a full icon-theme walk even when those tabs never appear.

## Motivation

Origin issue #4223: startup and CLI help paths should not scan icon themes for control-center tabs that are never shown.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4223

## Testing

- Fail-then-pass replica of TU-scope vs function-local static construction: baseline `baseline_ctors_before_use=1` exit 1; candidate `candidate_ctors_before_use=0`, `after_first_resolve=1`, exit 0.
- `git grep g_iconResolver HEAD -- src` → 0 hits on candidate.
- `g++ -fsyntax-only` of both changed TUs with existing noctalia compile flags: exit 0.
- Full meson/`ninja` not available on the factory host; scoped g++ + construction replica is the verifier evidence.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Prior PR #4235 was closed for an incomplete template body. Same candidate SHA `bc71b123f57aa528a2f4aa01ae9c7d0f9ee25d80`; only the description is corrected.
