### PR TITLE
fix(desktop): rescale cx/cy in rebaseForCurrentOutputs on output size change

### DIFF
--- a/src/shell/desktop/desktop_widget_layout.h
+++ b/src/shell/desktop/desktop_widget_layout.h
@@ -114,8 +114,15 @@ namespace desktop_widgets {
         if (output == nullptr) {
           continue;
         }
-        widget.placementWidth = outputLogicalWidth(*output);
-        widget.placementHeight = outputLogicalHeight(*output);
+        const float width = outputLogicalWidth(*output);
+        const float height = outputLogicalHeight(*output);
+        if (widget.placementWidth > 0.0F && widget.placementHeight > 0.0F
+            && (widget.placementWidth != width || widget.placementHeight != height)) {
+          widget.cx *= width / widget.placementWidth;
+          widget.cy *= height / widget.placementHeight;
+        }
+        widget.placementWidth = width;
+        widget.placementHeight = height;
       }
     }
   };

--- a/src/shell/desktop/desktop_widget_layout.h
+++ b/src/shell/desktop/desktop_widget_layout.h
@@ -116,7 +116,8 @@ namespace desktop_widgets {
         }
         const float width = outputLogicalWidth(*output);
         const float height = outputLogicalHeight(*output);
-        if (widget.placementWidth > 0.0F && widget.placementHeight > 0.0F
+        if (widget.placementWidth > 0.0F
+            && widget.placementHeight > 0.0F
             && (widget.placementWidth != width || widget.placementHeight != height)) {
           widget.cx *= width / widget.placementWidth;
           widget.cy *= height / widget.placementHeight;


### PR DESCRIPTION
## Summary

Make `rebaseForCurrentOutputs` rescale widget `cx`/`cy` when placement size differs from the current output size, then write the new placement size — same arithmetic as `remapForOutputChange`.

## Motivation

Origin issue #4123: after `exitEdit`, a widget centered on a 1366-wide output could be stored behind `placement_width=1920`, locking the old center forever because rebase only backfilled size without rescaling coordinates.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Related to #4123

## Testing

- Replica of the function body (`rebase_placement_test.cpp`): baseline assignment-only fails `cx must rescale 1366 -> 1920` (exit 1); candidate rescale then write size passes (exit 0).
- Matching output size leaves cx/cy; legacy `placementWidth==0` records size without inventing a rescale.
- Diff limited to `src/shell/desktop/desktop_widget_layout.h` (`rebaseForCurrentOutputs` only). Does not touch settings.toml shadowing (open #4124).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Prior PR #4236 was closed for an incomplete template body. Same candidate SHA `a14172fcb227716ce7ca308669f5e8ff95c1df2e`.
