### PR TITLE
fix(niri): preserve user noctalia.kdl on theme undo

### DIFF
--- a/assets/templates/niri/apply.sh
+++ b/assets/templates/niri/apply.sh
@@ -19,11 +19,11 @@ resolve_config_home() {
 
 config_dir="$(resolve_config_home)/niri"
 config_file="$config_dir/config.kdl"
-output_file="$config_dir/noctalia.kdl"
-include_line='include "noctalia.kdl"'
+output_file="$config_dir/noctalia-theme.kdl"
+include_line='include "noctalia-theme.kdl"'
 
 has_noctalia_include() {
-    grep -Eq '^[[:space:]]*include([[:space:]].*)?"([^"]*/)?noctalia\.kdl"([[:space:]]|$)' "$config_file"
+    grep -Eq '^[[:space:]]*include([[:space:]].*)?"([^"]*/)?noctalia-theme\.kdl"([[:space:]]|$)' "$config_file"
 }
 
 apply_include() {

--- a/assets/templates/niri/undo.sh
+++ b/assets/templates/niri/undo.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/niri"
 config_file="$config_dir/config.kdl"
-theme_file="$config_dir/noctalia.kdl"
+theme_file="$config_dir/noctalia-theme.kdl"
 
 if [ -f "$config_file" ]; then
     tmp_file="$(mktemp "${config_file}.tmp.XXXXXX")"
     trap 'rm -f "$tmp_file"' EXIT
-    awk '!/^[[:space:]]*include([[:space:]].*)?"([^"]*\/)?noctalia\.kdl"/' "$config_file" >"$tmp_file"
+    awk '!/^[[:space:]]*include([[:space:]].*)?"([^"]*\/)?noctalia-theme\.kdl"/' "$config_file" >"$tmp_file"
     if ! cmp -s "$config_file" "$tmp_file"; then
         cat "$tmp_file" >"$config_file"
     fi


### PR DESCRIPTION
## Summary

Write Noctalia's generated niri theme to `noctalia-theme.kdl` and include/remove only that generated filename. Preserve a user's existing `noctalia.kdl` (and its include) during undo.

## Motivation

Origin issue #4084: niri template undo deleted the user's `noctalia.kdl` keybind file because generated colors shared that name.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4084

## Testing

- Scripted fail-then-pass: origin/main scripts exit 1 (`FAIL: user noctalia.kdl was deleted`); candidate exit 0 (`PASS` — user `noctalia.kdl` + `include "noctalia.kdl"` survive; generated `noctalia-theme.kdl` and its include are removed).
- Files touched: only `assets/templates/niri/apply.sh` and `assets/templates/niri/undo.sh`.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Prior PR #4237 was closed for an incomplete template body. Same candidate SHA `31e4a7d5f3148cdf56003c349d12dd8a026992f2`.
