### PR TITLE
fix(network): prompt for VPN secrets

### DIFF
--- a/src/dbus/network/network_secret_agent.cpp
+++ b/src/dbus/network/network_secret_agent.cpp
@@ -35,7 +35,20 @@ namespace {
 
   constexpr auto kWirelessSettingName = "802-11-wireless";
   constexpr auto kWirelessSecuritySettingName = "802-11-wireless-security";
+  constexpr auto kVpnSettingName = "vpn";
+  constexpr auto kVpnSecretsSettingName = "vpn-secrets";
+  constexpr auto kConnectionSettingName = "connection";
   constexpr auto kPskKey = "psk";
+  constexpr auto kPasswordKey = "password";
+  constexpr auto kVpnFallbackLabel = "VPN";
+
+  bool isVpnSecretSetting(const std::string& settingName) {
+    return settingName == kVpnSettingName || settingName == kVpnSecretsSettingName;
+  }
+
+  bool isSupportedSecretSetting(const std::string& settingName) {
+    return settingName == kWirelessSecuritySettingName || isVpnSecretSetting(settingName);
+  }
 
   std::string extractSsid(const SecretsDict& connection) {
     auto wifiIt = connection.find(kWirelessSettingName);
@@ -54,6 +67,34 @@ namespace {
     }
   }
 
+  std::string extractConnectionId(const SecretsDict& connection) {
+    auto connIt = connection.find(kConnectionSettingName);
+    if (connIt == connection.end()) {
+      return {};
+    }
+    auto idIt = connIt->second.find("id");
+    if (idIt == connIt->second.end()) {
+      return {};
+    }
+    try {
+      return idIt->second.get<std::string>();
+    } catch (const sdbus::Error&) {
+      return {};
+    }
+  }
+
+  std::string secretKeyFor(const std::string& settingName, const std::vector<std::string>& hints) {
+    if (settingName == kWirelessSecuritySettingName) {
+      return kPskKey;
+    }
+    for (const auto& hint : hints) {
+      if (!hint.empty()) {
+        return hint;
+      }
+    }
+    return kPasswordKey;
+  }
+
 } // namespace
 
 struct NetworkSecretAgent::Impl {
@@ -62,12 +103,13 @@ struct NetworkSecretAgent::Impl {
   RequestCallback requestCallback;
   std::optional<sdbus::Result<SecretsDict>> pendingResult;
   std::string pendingSettingName;
+  std::string pendingSecretKey;
 
   explicit Impl(SystemBus& b) : bus(b) {}
 
   void onGetSecrets(
       sdbus::Result<SecretsDict>&& result, SecretsDict connection, sdbus::ObjectPath connectionPath,
-      std::string settingName, std::vector<std::string> /*hints*/, std::uint32_t flags
+      std::string settingName, std::vector<std::string> hints, std::uint32_t flags
   ) {
     if ((flags & kNmSecretAgentGetSecretsFlagAllowInteraction) == 0U) {
       kLog.debug("GetSecrets without ALLOW_INTERACTION -> NoSecrets");
@@ -79,7 +121,7 @@ struct NetworkSecretAgent::Impl {
       );
       return;
     }
-    if (settingName != kWirelessSecuritySettingName) {
+    if (!isSupportedSecretSetting(settingName)) {
       kLog.debug("GetSecrets for unsupported setting \"{}\" -> NoSecrets", settingName);
       result.returnError(
           sdbus::Error{
@@ -100,12 +142,22 @@ struct NetworkSecretAgent::Impl {
     }
 
     SecretRequest request;
-    request.ssid = extractSsid(connection);
+    if (isVpnSecretSetting(settingName)) {
+      request.ssid = extractConnectionId(connection);
+      if (request.ssid.empty()) {
+        request.ssid = kVpnFallbackLabel;
+      }
+    } else {
+      request.ssid = extractSsid(connection);
+    }
     request.settingName = settingName;
-    kLog.info("GetSecrets prompt ssid=\"{}\" path={}", request.ssid, std::string(connectionPath));
+    kLog.info(
+        "GetSecrets prompt label=\"{}\" setting={} path={}", request.ssid, settingName, std::string(connectionPath)
+    );
 
     pendingResult = std::move(result);
     pendingSettingName = settingName;
+    pendingSecretKey = secretKeyFor(settingName, hints);
 
     if (requestCallback) {
       requestCallback(request);
@@ -124,6 +176,7 @@ struct NetworkSecretAgent::Impl {
     );
     pendingResult.reset();
     pendingSettingName.clear();
+    pendingSecretKey.clear();
   }
 
   void submitPending(const std::string& psk) {
@@ -131,10 +184,12 @@ struct NetworkSecretAgent::Impl {
       return;
     }
     SecretsDict secrets;
-    secrets[pendingSettingName][kPskKey] = sdbus::Variant{psk};
+    const std::string key = pendingSecretKey.empty() ? std::string(kPskKey) : pendingSecretKey;
+    secrets[pendingSettingName][key] = sdbus::Variant{psk};
     pendingResult->returnResults(secrets);
     pendingResult.reset();
     pendingSettingName.clear();
+    pendingSecretKey.clear();
   }
 };
 

--- a/src/dbus/network/network_secret_agent.h
+++ b/src/dbus/network/network_secret_agent.h
@@ -7,7 +7,7 @@
 class SystemBus;
 
 // NetworkManager secret agent. Registers with org.freedesktop.NetworkManager.AgentManager
-// on the system bus and answers GetSecrets requests for new Wi-Fi PSK connections.
+// on the system bus and answers GetSecrets for Wi-Fi PSK and interactive VPN secrets.
 //
 // The agent is single-slot: one in-flight prompt at a time. Additional GetSecrets
 // calls while a prompt is open are rejected with NoSecrets, letting NM fall back
@@ -20,8 +20,8 @@ class SystemBus;
 class NetworkSecretAgent {
 public:
   struct SecretRequest {
-    std::string ssid;
-    std::string settingName; // e.g. "802-11-wireless-security"
+    std::string ssid;        // Wi-Fi SSID, or VPN connection.id for the prompt label
+    std::string settingName; // e.g. "802-11-wireless-security" or "vpn"
   };
 
   using RequestCallback = std::function<void(const SecretRequest&)>;


### PR DESCRIPTION
## Summary

Accept NetworkManager `vpn` / `vpn-secrets` GetSecrets requests when `ALLOW_INTERACTION` is set. Label VPN prompts with `connection.connection.id` (fallback `VPN`). Reply with the first non-empty hint, else `password`. Leave Wi-Fi `802-11-wireless-security` / `psk` unchanged.

## Motivation

Origin issue #4051: `NetworkSecretAgent::onGetSecrets` returned `NoSecrets` unless the setting was `802-11-wireless-security`, so VPN plugins requesting setting `vpn` never got a password prompt.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4051

## Testing

- Fail-then-pass replica: baseline fails `vpn GetSecrets with ALLOW_INTERACTION must prompt` (exit 1); candidate passes vpn/vpn-secrets prompts, still NoSecrets without ALLOW_INTERACTION, Wi-Fi PSK still `psk`, exit 0.
- `g++ -std=c++20 -fsyntax-only -I src` of `network_secret_agent.cpp`: exit 0.
- Diff limited to `network_secret_agent.cpp` + header comment.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Prior PR #4238 was closed for an incomplete template body. Same candidate SHA `0a71f23f8431b99a3f28020d764e1bf4833f08d1`.
