### PR TITLE
fix(plugins): pin clone remote origin for plugin git fetch

### DIFF
--- a/src/scripting/plugin_git.cpp
+++ b/src/scripting/plugin_git.cpp
@@ -106,8 +106,11 @@ namespace scripting::plugin_git {
     // Blobless but NOT shallow: full commit/tree history (still tiny — no file
     // blobs until needed), so later fetches can inspect history normally. A `--depth 1`
     // shallow clone grafts fetched commits as disjoint roots ("unrelated histories").
+    // Pin the remote name: clone.defaultRemoteName (and checkout.defaultRemote) otherwise
+    // name it something other than origin, and fetch/set-url origin fail (#4122).
     return run(
-        {"git", "clone", "--filter=blob:none", "--no-checkout", url, dest.string()}, kNetworkTimeout, kProgressCap
+        {"git", "clone", "--filter=blob:none", "--no-checkout", "-o", "origin", url, dest.string()}, kNetworkTimeout,
+        kProgressCap
     );
   }
 
@@ -145,8 +148,15 @@ namespace scripting::plugin_git {
   }
 
   GitResult setOrigin(const std::filesystem::path& dest, std::string_view sourceLocation) {
+    auto updated =
+        run({"git", "-C", dest.string(), "remote", "set-url", "origin", std::string(sourceLocation)}, kLocalTimeout,
+            kProgressCap);
+    if (updated) {
+      return updated;
+    }
+    // Existing caches cloned under clone.defaultRemoteName≠origin have no `origin` remote.
     return run(
-        {"git", "-C", dest.string(), "remote", "set-url", "origin", std::string(sourceLocation)}, kLocalTimeout,
+        {"git", "-C", dest.string(), "remote", "add", "origin", std::string(sourceLocation)}, kLocalTimeout,
         kProgressCap
     );
   }

--- a/tests/plugin_git_export_test.cpp
+++ b/tests/plugin_git_export_test.cpp
@@ -194,6 +194,36 @@ int main() {
        )
       && ok;
 
+  // clone.defaultRemoteName≠origin must still create/fetch `origin` (#4122).
+  ::setenv("GIT_CONFIG_COUNT", "1", 1);
+  ::setenv("GIT_CONFIG_KEY_0", "clone.defaultRemoteName", 1);
+  ::setenv("GIT_CONFIG_VALUE_0", "up", 1);
+  const auto destUp = root / "repo-up";
+  const auto clonedUp = scripting::plugin_git::cloneBlobless(source.string(), destUp);
+  ok = expect(static_cast<bool>(clonedUp), "cloneBlobless with defaultRemoteName=up failed") && ok;
+  const auto remoteUp = process::runSync({"git", "-C", destUp.string(), "remote"});
+  ok = expect(static_cast<bool>(remoteUp), "git remote failed on defaultRemoteName clone") && ok;
+  ok = expect(remoteUp.out == "origin\n" || remoteUp.out == "origin", "cloneBlobless did not pin remote name origin")
+      && ok;
+  ok = expect(
+           static_cast<bool>(scripting::plugin_git::fetch(destUp, source.string())),
+           "fetch failed after defaultRemoteName=up clone"
+       )
+      && ok;
+
+  const auto destLegacy = root / "repo-legacy-up";
+  ok = runGit({"git", "clone", "--filter=blob:none", "--no-checkout", source.string(), destLegacy.string()}) && ok;
+  const auto remoteLegacy = process::runSync({"git", "-C", destLegacy.string(), "remote"});
+  ok = expect(remoteLegacy.out == "up\n" || remoteLegacy.out == "up", "legacy clone remote was not up") && ok;
+  ok = expect(
+           static_cast<bool>(scripting::plugin_git::fetch(destLegacy, source.string())),
+           "fetch did not recover a non-origin remote"
+       )
+      && ok;
+  ::unsetenv("GIT_CONFIG_COUNT");
+  ::unsetenv("GIT_CONFIG_KEY_0");
+  ::unsetenv("GIT_CONFIG_VALUE_0");
+
   std::error_code ec;
   std::filesystem::remove_all(root, ec);
   return ok ? 0 : 1;


### PR DESCRIPTION
## Summary

Pin `git clone` to remote name `origin` (`-o origin`) and make plugin fetch recover a missing `origin` remote (for example after `clone.defaultRemoteName=up`) before `git fetch origin`.

## Motivation

Origin issue #4122: with `clone.defaultRemoteName` set to a non-`origin` name, plugin clones never create an `origin` remote, so `git fetch origin` fails and the plugin list goes empty.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4122

## Testing

- Fail-then-pass with `plugin_git_export_test` linked against baseline `plugin_git.cpp`: exit 1 (`cloneBlobless did not pin remote name origin`, fetch fails under `defaultRemoteName=up`).
- Candidate SHA `bbb756569e384d7348be41912806d7ddb0d098c8`: standalone test exit 0 — `git clone -o origin` under `defaultRemoteName=up` yields remote `origin` and fetch exit 0; legacy remote `up` recovers via `remote add origin` then fetch exit 0.
- Git CLI equivalent: without `-o origin`, `git fetch origin` exit 128.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Prior PR #4234 was closed for an incomplete template body. Same candidate SHA.
