### PR TITLE
fix(dock): keep shared-class pin origins distinct

### DIFF
--- a/src/shell/dock/dock_model.cpp
+++ b/src/shell/dock/dock_model.cpp
@@ -128,6 +128,9 @@ namespace shell::dock {
         dockItem.windowLookupIdLower = dockItem.idLower;
         dockItem.windowLookupWmClassLower = taskbarStyleWmClassLower(entry.startupWmClass, dockItem.idLower);
       }
+      if (app_identity::startupWmClassShared(entry, desktopEntries())) {
+        dockItem.windowLookupWmClassLower.clear();
+      }
 
       dockItem.active = !snapshot.activeAppIdLower.empty() && snapshot.activeAppIdLower == dockItem.idLower;
       if (deps.config.showDots || deps.config.showInstanceCount) {

--- a/src/system/app_identity.cpp
+++ b/src/system/app_identity.cpp
@@ -131,6 +131,26 @@ namespace app_identity {
     );
   }
 
+  bool startupWmClassShared(const DesktopEntry& entry, std::span<const DesktopEntry> allEntries) {
+    const std::string wm = StringUtils::toLower(entry.startupWmClass);
+    if (wm.empty()) {
+      return false;
+    }
+    const std::string idLower = StringUtils::toLower(entry.id);
+    for (const auto& other : allEntries) {
+      if (other.hidden || other.noDisplay) {
+        continue;
+      }
+      if (StringUtils::toLower(other.id) == idLower) {
+        continue;
+      }
+      if (StringUtils::toLower(other.startupWmClass) == wm) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   std::optional<DesktopEntry> findDesktopEntry(
       std::string_view appKey, std::span<const DesktopEntry> allEntries, std::span<const DesktopEntry> priorityEntries
   ) {
@@ -139,6 +159,20 @@ namespace app_identity {
     }
 
     const std::string appLower = StringUtils::toLower(std::string(appKey));
+
+    // Exact desktop id wins over pinned fuzzy matching. A pinned Flatpak/AppImage
+    // must not claim a running distro window that has its own desktop file.
+    for (const auto& entry : allEntries) {
+      if (StringUtils::toLower(entry.id) == appLower) {
+        return entry;
+      }
+    }
+    for (const auto& entry : priorityEntries) {
+      if (StringUtils::toLower(entry.id) == appLower) {
+        return entry;
+      }
+    }
+
     for (const auto& entry : priorityEntries) {
       if (desktopEntryMatchesLower(entry, appLower)) {
         return entry;

--- a/src/system/app_identity.h
+++ b/src/system/app_identity.h
@@ -23,6 +23,10 @@ namespace app_identity {
 
   [[nodiscard]] bool desktopEntryMatchesLower(const DesktopEntry& entry, std::string_view valueLower);
 
+  // True when another non-hidden desktop entry uses the same StartupWMClass.
+  // Dock window lookup must not use a shared class. That steals focus across origins.
+  [[nodiscard]] bool startupWmClassShared(const DesktopEntry& entry, std::span<const DesktopEntry> allEntries);
+
   // Best-effort lookup by app id / StartupWMClass. Operates on the parsed desktop-entry list,
   // which already excludes hidden/NoDisplay/wrong-desktop entries.
   [[nodiscard]] std::optional<DesktopEntry> findDesktopEntry(

--- a/tests/app_identity_test.cpp
+++ b/tests/app_identity_test.cpp
@@ -274,6 +274,67 @@ int main() {
   TEST_CHECK(kdeResolved.name == "Easy Effects");
   TEST_CHECK(kdeResolved.icon == "easyeffects");
 
+  DesktopEntry braveFlatpak;
+  braveFlatpak.id = "com.brave.Browser";
+  braveFlatpak.origin = DesktopEntryOrigin::Flatpak;
+  braveFlatpak.name = "Brave";
+  braveFlatpak.nameLower = "brave";
+  braveFlatpak.startupWmClass = "brave-browser";
+  braveFlatpak.startupWmClassLower = "brave-browser";
+  braveFlatpak.exec = "flatpak run com.brave.Browser";
+  braveFlatpak.icon = "com.brave.Browser";
+
+  DesktopEntry braveDistro;
+  braveDistro.id = "brave-browser";
+  braveDistro.origin = DesktopEntryOrigin::System;
+  braveDistro.name = "Brave";
+  braveDistro.nameLower = "brave";
+  braveDistro.startupWmClass = "brave-browser";
+  braveDistro.startupWmClassLower = "brave-browser";
+  braveDistro.exec = "/usr/bin/brave-browser";
+  braveDistro.icon = "brave-browser";
+
+  const std::vector<DesktopEntry> braveOrigins = {braveFlatpak, braveDistro};
+  const auto pinnedFlatpakSteals =
+      app_identity::findDesktopEntry("brave-browser", braveOrigins, std::array<DesktopEntry, 1>{braveFlatpak});
+  TEST_CHECK(pinnedFlatpakSteals.has_value());
+  TEST_CHECK(pinnedFlatpakSteals->id == "brave-browser");
+  TEST_CHECK(pinnedFlatpakSteals->origin == DesktopEntryOrigin::System);
+
+  const auto pinnedDistroKeeps =
+      app_identity::findDesktopEntry("brave-browser", braveOrigins, std::array<DesktopEntry, 1>{braveDistro});
+  TEST_CHECK(pinnedDistroKeeps.has_value());
+  TEST_CHECK(pinnedDistroKeeps->id == "brave-browser");
+
+  const auto pinnedFlatpakOwnId =
+      app_identity::findDesktopEntry("com.brave.Browser", braveOrigins, std::array<DesktopEntry, 1>{braveFlatpak});
+  TEST_CHECK(pinnedFlatpakOwnId.has_value());
+  TEST_CHECK(pinnedFlatpakOwnId->id == "com.brave.Browser");
+
+  const auto braveRunning = app_identity::resolveRunningApps(
+      std::array<std::string, 1>{"brave-browser"}, braveOrigins, std::array<DesktopEntry, 1>{braveFlatpak}
+  );
+  TEST_CHECK(braveRunning.size() == 1);
+  TEST_CHECK(braveRunning[0].entry.id == "brave-browser");
+
+  const auto braveBothRunning = app_identity::resolveRunningApps(
+      std::array<std::string, 2>{"brave-browser", "com.brave.Browser"}, braveOrigins,
+      std::array<DesktopEntry, 1>{braveFlatpak}
+  );
+  TEST_CHECK(braveBothRunning.size() == 2);
+  TEST_CHECK(braveBothRunning[0].entry.id == "brave-browser");
+  TEST_CHECK(braveBothRunning[1].entry.id == "com.brave.Browser");
+
+  TEST_CHECK(app_identity::startupWmClassShared(braveFlatpak, braveOrigins));
+  TEST_CHECK(app_identity::startupWmClassShared(braveDistro, braveOrigins));
+  TEST_CHECK(!app_identity::startupWmClassShared(easyEffects, std::array<DesktopEntry, 1>{easyEffects}));
+
+  const auto easyEffectsPinned = app_identity::findDesktopEntry(
+      "org.kde.easyeffects", std::array<DesktopEntry, 1>{easyEffects}, std::array<DesktopEntry, 1>{easyEffects}
+  );
+  TEST_CHECK(easyEffectsPinned.has_value());
+  TEST_CHECK(easyEffectsPinned->id == "com.github.wwmm.easyeffects");
+
   const std::vector<DesktopEntry> ambiguousTail = {
       duplicateTailEntry("com.foo.easyeffects", "foo-easyeffects"),
       duplicateTailEntry("com.bar.easyeffects", "bar-easyeffects"),


### PR DESCRIPTION
## Summary

Prefer exact desktop-id matches in `findDesktopEntry` before fuzzy WM-class matching, and clear shared `StartupWMClass` window lookup when another non-hidden entry shares that class so a dock pin focuses only its own origin (or launches when no exact window exists).

## Motivation

Origin issue #4179: pinning Flatpak Brave while distro Brave is open focused the distro window because pin-biased fuzzy matching collapsed shared `StartupWMClass` origins.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4179

## Testing

- Fail-then-pass `pin_origin_test`: baseline fails `distroRunning->id == "brave-browser"` (exit 1); candidate exit 0.
- pinned `com.brave.Browser` does not resolve running `brave-browser`; exact compositor id still maps to distro desktop file; both origins stay distinct in `resolveRunningApps`.
- Easy Effects unique-class resolve still works (`startupWmClassShared` false alone).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Prior PR #4233 was closed for an incomplete template body. Same candidate SHA `8d461ce7be01836fe1e26b064732dfeff99a4eee`.
