### PR TITLE
fix(launcher): resolve window provider icons via desktop entry

### DIFF
--- a/src/launcher/window_provider.cpp
+++ b/src/launcher/window_provider.cpp
@@ -2,6 +2,9 @@
 
 #include "compositors/compositor_platform.h"
 #include "i18n/i18n.h"
+#include "system/app_identity.h"
+#include "system/desktop_entry.h"
+#include "system/internal_app_metadata.h"
 #include "util/fuzzy_match.h"
 #include "util/string_utils.h"
 
@@ -21,6 +24,28 @@ namespace {
     std::string title;
     std::string searchable;
   };
+
+  // Mirror the taskbar / dock / active window / window switcher icon lookup: a
+  // Wayland app id (e.g. "dev.zed.Zed") is rarely a valid icon theme name, so
+  // resolve it to a desktop entry and use its Icon key, then fall back to the
+  // raw app id. Without this the launcher shows the generic window glyph for
+  // apps whose app id and icon name differ.
+  void assignWindowIcon(LauncherResult& result, const std::string& appId) {
+    if (appId.empty()) {
+      return;
+    }
+    if (const auto internal = internal_apps::metadataForAppId(appId);
+        internal.has_value() && !internal->iconPath.empty()) {
+      result.iconPath = internal->iconPath;
+      return;
+    }
+    if (const auto entry = app_identity::findDesktopEntry(appId, desktopEntries());
+        entry.has_value() && !entry->icon.empty()) {
+      result.iconName = entry->icon;
+      return;
+    }
+    result.iconName = appId;
+  }
 
   [[nodiscard]] std::vector<WindowCandidate> collectWindows(const CompositorPlatform* platform) {
     std::vector<WindowCandidate> candidates;
@@ -65,7 +90,7 @@ std::vector<LauncherResult> WindowProvider::query(std::string_view text) const {
     result.id = candidate.window.windowId;
     result.title = candidate.title;
     result.subtitle = candidate.window.appId;
-    result.iconName = candidate.window.appId;
+    assignWindowIcon(result, candidate.window.appId);
     result.glyphName = "app-window";
     result.score = score;
     return result;


### PR DESCRIPTION
## Summary

The launcher's window provider (`/win`) passes the raw Wayland app id straight into the icon theme lookup. When an app's app id doesn't match its icon name, that lookup misses and the result falls back to the generic window glyph. `makeResult()` now resolves the app id to a desktop entry via `app_identity::findDesktopEntry()` and uses its `Icon=` key, with an internal apps branch and a raw app id fallback so the rest of the provider is untouched.

## Motivation

I ran into this with Zed: its window shows the default icon in the launcher's window list, but the correct icon everywhere else (taskbar, dock, app launcher). `dev.zed.Zed.desktop` has `Icon=zed`, the Wayland app id is `dev.zed.Zed`, and the icon on disk is `zed.png`, so `resolve("dev.zed.Zed")` finds nothing.

Going through past issues and PRs, this is the same class of bug as #2337 (inconsistent missing icons in dock / active window vs app launcher), which was fixed by routing app id to desktop entry resolution through `app_identity`. The taskbar, dock, active window widget and window switcher all go through that path already; the window provider was added later (#2884) and never got wired up to it. This applies the existing approach in the one place it was still missing.

## Type of Change

- [x] Bug fix

## Related Issue

Related to #2337.

## Testing

`just format` (clang-format v22) clean. Built with `meson setup --buildtype=debug` + `ninja`: 0 warnings, all 796 targets link. `meson test`: 111/111 pass (no dedicated test exists for the window provider). Ran the built binary in place of my installed shell and confirmed Zed now shows its real icon in `/win` where it previously showed the generic glyph.

## Manual Coverage

- [x] Tested on Niri

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

