### PR TITLE
feat(notifications): make dismissed history retention configurable

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2272,6 +2272,10 @@
           "description": "Automatically remove notification history entries older than the specified number of hours (0 to keep forever)",
           "label": "Retention Period"
         },
+        "keep-dismissed-in-history": {
+          "description": "Keep notifications in history after their toasts are dismissed",
+          "label": "Keep Dismissed Notifications"
+        },
         "layer": {
           "description": "Use Overlay to show notification toasts above fullscreen apps",
           "label": "Wayland Layer"

--- a/docs/user/services/notifications.mdx
+++ b/docs/user/services/notifications.mdx
@@ -19,6 +19,7 @@ offset_x                 = 20          # absolute horizontal margin from the scr
 offset_y                 = 8           # absolute vertical margin from the screen edge
 monitors                 = []          # empty = all monitors; otherwise connector/description selectors (e.g. ["eDP-1", "DP-1"])
 collapse_on_dismiss      = true        # slide remaining toasts to close gaps when one is dismissed
+keep_dismissed_in_history = true       # keep history entries when their toasts are dismissed
 max_visible              = 0           # maximum on-screen toasts; 0 = fill available space (all visible)
 history_retention_hours  = 0           # delete stored history older than this; 0 keeps it indefinitely
 
@@ -43,7 +44,7 @@ play_sound      = true
 - If none of the configured monitors are currently connected (e.g. an external display was undocked), Noctalia falls back to showing toasts on all available monitors so notifications never disappear silently. Targeting is restored automatically when a configured monitor reconnects.
 - Selector matching follows monitor override rules: exact connector name (`eDP-1`) or a word-boundary token in the monitor description.
 - Internal Noctalia notifications (shell and plugins) are toast-only and are never stored in notification history.
-- Dismissing a toast (right-click, close button, or `noctalia msg notification-clear-active`) only hides it. The entry stays in control-center history and still counts as unread until the notifications tab is opened. History entries are removed only by the per-entry delete button, **Clear all**, `noctalia msg notification-clear-history`, or `history_retention_hours`.
+- By default, dismissing a toast (right-click, close button, or `noctalia msg notification-clear-active`) only hides it. The entry stays in control-center history and still counts as unread until the notifications tab is opened. Set `keep_dismissed_in_history = false` to remove the history entry when its toast is dismissed. Timed-out notifications remain in history.
 - `history_retention_hours` removes stored external notifications older than the configured number of hours. The default
   `0` retains history indefinitely; accepted values are `0`–`8760`.
 - `collapse_on_dismiss = true` (default) causes remaining toasts to slide into a compact stack when one is dismissed. Set to `false` for stable-slot behavior where toasts keep their original positions.

--- a/example.toml
+++ b/example.toml
@@ -169,6 +169,7 @@ tint_intensity         = 0.3        # 0.0 = no tint, 1.0 = opaque
 enable_daemon      = true
 show_app_name      = true
 show_actions       = true           # show action buttons; when false, clicking a toast triggers its default action
+keep_dismissed_in_history = true    # set false to remove history entries when their toasts are dismissed
 layer              = "top"          # top | overlay
 scale              = 1.0            # notification size multiplier applied on top of accessibility.ui_scale
 background_opacity = 0.97

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -715,6 +715,11 @@ void Application::initNotificationAndOsd() {
   auto applyHistoryRetention = [this]() {
     m_notificationManager.setHistoryRetentionHours(m_configService.config().notification.historyRetentionHours);
   };
+  auto applyDismissedHistory = [this]() {
+    m_notificationManager.setKeepDismissedInHistory(m_configService.config().notification.keepDismissedInHistory);
+  };
+  applyDismissedHistory();
+  m_configService.addReloadCallback(applyDismissedHistory);
   applyHistoryRetention();
   m_configService.addReloadCallback(applyHistoryRetention);
   applyNotificationFilterConfig();

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -753,6 +753,7 @@ struct NotificationConfig {
   int offsetY = 8;                 // absolute vertical margin from the screen edge
   std::vector<std::string> monitors;
   bool collapseOnDismiss = true;
+  bool keepDismissedInHistory = true;
   int historyRetentionHours = 0;
   int maxVisible = 0; // 0 = unlimited (space-based only)
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -257,6 +257,7 @@ namespace noctalia::config::schema {
         field(&NotificationConfig::offsetY, "offset_y"),
         field(&NotificationConfig::monitors, "monitors"),
         field(&NotificationConfig::collapseOnDismiss, "collapse_on_dismiss"),
+        field(&NotificationConfig::keepDismissedInHistory, "keep_dismissed_in_history"),
         field(&NotificationConfig::historyRetentionHours, "history_retention_hours", Range<std::int64_t>{0, 8760}),
         field(&NotificationConfig::maxVisible, "max_visible", Range<std::int64_t>{0, 20}),
         custom<NotificationConfig>(

--- a/src/notification/notification_manager.cpp
+++ b/src/notification/notification_manager.cpp
@@ -555,7 +555,11 @@ bool NotificationManager::close(uint32_t id, CloseReason reason) {
   if (it == m_idToIndex.end()) {
     if (m_pendingDBusClose.contains(id)) {
       emitPendingDBusClose(id, reason);
-      markHistoryClosed(id, reason);
+      if (reason == CloseReason::Dismissed && !m_keepDismissedInHistory) {
+        removeHistoryEntry(id);
+      } else {
+        markHistoryClosed(id, reason);
+      }
       return true;
     }
     return false;
@@ -564,12 +568,17 @@ bool NotificationManager::close(uint32_t id, CloseReason reason) {
   const size_t index = it->second;
   const Notification closed = m_notifications[index];
   const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
+  const bool saveHistory = shouldSaveNotificationToHistory(m_filters, closed);
+  const bool removeDismissedHistory = reason == CloseReason::Dismissed && !m_keepDismissedInHistory;
+  const bool historyHandledUnreadChange = saveHistory && removeDismissedHistory && m_historyIndex.contains(id);
   const char* reasonStr = (reason == CloseReason::Expired) ? "expired"
       : (reason == CloseReason::Dismissed)                 ? "dismissed"
                                                            : "closed";
   kLog.debug("notification {} #{}", reasonStr, id);
-  if (shouldSaveNotificationToHistory(m_filters, closed)) {
-    if (m_historyIndex.contains(id)) {
+  if (saveHistory) {
+    if (removeDismissedHistory) {
+      removeHistoryEntry(id, reason);
+    } else if (m_historyIndex.contains(id)) {
       markHistoryClosed(id, reason);
     } else {
       upsertHistory(closed, false, reason);
@@ -594,7 +603,9 @@ bool NotificationManager::close(uint32_t id, CloseReason reason) {
     m_closeCallback(id, reason);
   }
 
-  notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
+  if (!historyHandledUnreadChange) {
+    notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
+  }
 
   return true;
 }
@@ -669,6 +680,8 @@ void NotificationManager::processExpired() {
     close(id, CloseReason::Expired);
   }
 }
+
+void NotificationManager::setKeepDismissedInHistory(bool keep) { m_keepDismissedInHistory = keep; }
 
 void NotificationManager::pauseExpiry(uint32_t id) {
   const auto it = m_idToIndex.find(id);

--- a/src/notification/notification_manager.h
+++ b/src/notification/notification_manager.h
@@ -131,6 +131,7 @@ public:
   void clearHistory();
   void setFilters(std::vector<NotificationFilterConfig> filters);
   [[nodiscard]] const std::vector<NotificationFilterConfig>& filters() const noexcept;
+  void setKeepDismissedInHistory(bool keep);
   void setHistoryRetentionHours(int hours);
   void setDoNotDisturb(bool enabled);
   [[nodiscard]] bool doNotDisturb() const noexcept;
@@ -174,6 +175,7 @@ private:
   uint32_t suppressExternal(std::string_view appName, Urgency urgency);
 
   int m_historyRetentionHours = 0;
+  bool m_keepDismissedInHistory = true;
   bool m_persistScheduled = false;
   Timer m_historyRetentionTimer;
 

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2932,6 +2932,12 @@ namespace settings {
         "monitor output display screen"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Notifications, "history", tr("settings.schema.notifications.keep-dismissed-in-history.label"),
+        tr("settings.schema.notifications.keep-dismissed-in-history.description"),
+        {"notification", "keep_dismissed_in_history"}, ToggleSetting{cfg.notification.keepDismissedInHistory},
+        "history dismissed toast remove keep"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Notifications, "history", tr("settings.schema.notifications.history-retention-hours.label"),
         tr("settings.schema.notifications.history-retention-hours.description"),
         {"notification", "history_retention_hours"},

--- a/tests/notification_history_dismiss_test.cpp
+++ b/tests/notification_history_dismiss_test.cpp
@@ -86,5 +86,32 @@ int main() {
   TEST_CHECK(manager.close(filteredId, CloseReason::Dismissed));
   TEST_CHECK(manager.history().empty());
 
+  // Opting out removes dismissed notifications, including their unread state, but does not affect expirations.
+  NotificationManager discardManager;
+  std::vector<std::pair<uint32_t, CloseReason>> discardCloses;
+  int unreadStateChanges = 0;
+  discardManager.setKeepDismissedInHistory(false);
+  discardManager.setCloseCallback([&discardCloses](uint32_t id, CloseReason reason) {
+    discardCloses.emplace_back(id, reason);
+  });
+  discardManager.setStateCallback([&unreadStateChanges]() { ++unreadStateChanges; });
+
+  const uint32_t discardedId = addExternal(discardManager, "discarded");
+  TEST_CHECK(discardManager.history().size() == 1);
+  TEST_CHECK(discardManager.hasUnreadNotificationHistory());
+  TEST_CHECK(discardManager.close(discardedId, CloseReason::Dismissed));
+  TEST_CHECK(discardManager.all().empty());
+  TEST_CHECK(discardManager.history().empty());
+  TEST_CHECK(!discardManager.hasUnreadNotificationHistory());
+  TEST_CHECK(discardCloses.size() == 1);
+  TEST_CHECK(discardCloses.front().first == discardedId);
+  TEST_CHECK(discardCloses.front().second == CloseReason::Dismissed);
+  TEST_CHECK(unreadStateChanges == 2);
+
+  const uint32_t expiredId = addExternal(discardManager, "expired");
+  TEST_CHECK(discardManager.close(expiredId, CloseReason::Expired));
+  TEST_CHECK(discardManager.history().size() == 1);
+  TEST_CHECK(findEntry(discardManager, expiredId) != nullptr);
+  TEST_CHECK(findEntry(discardManager, expiredId)->closeReason == CloseReason::Expired);
   return 0;
 }


### PR DESCRIPTION
## Summary

Add keep_dismissed_in_history, defaulting to true to preserve the existing behavior while allowing dismissed toasts to be removed from history.

## Motivation

I don't really want to store the full history, but I'd like to have a list of notifications I missed.

## Type of Change
- [x] New feature

## Related Issue

See #3842 for context.

## Testing

I did test it.

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.