### PR TITLE
fix(process): run string commands in non-login shell

### DIFF
--- a/src/core/process/process.cpp
+++ b/src/core/process/process.cpp
@@ -834,14 +834,14 @@ namespace process {
     if (command.empty()) {
       return false;
     }
-    return runAsync(std::vector<std::string>{"/bin/sh", "-lc", command});
+    return runAsync(std::vector<std::string>{"/bin/sh", "-c", command});
   }
 
   bool runAsync(const std::string& command, RunCallbacks callbacks, RunOptions options) {
     if (command.empty()) {
       return false;
     }
-    return runAsync(std::vector<std::string>{"/bin/sh", "-lc", command}, std::move(callbacks), options);
+    return runAsync(std::vector<std::string>{"/bin/sh", "-c", command}, std::move(callbacks), options);
   }
 
   std::optional<int> launchDetachedTracked(const std::vector<std::string>& args) {
@@ -954,7 +954,7 @@ namespace process {
   RunResult runSync(const std::string& command) {
     if (command.empty())
       return {-1, {}, {}};
-    return runSync(std::vector<std::string>{"/bin/sh", "-lc", command});
+    return runSync(std::vector<std::string>{"/bin/sh", "-c", command});
   }
 
   bool launchFirstAvailable(std::initializer_list<std::initializer_list<const char*>> commandVariants) {


### PR DESCRIPTION
## Summary

Run string-command process helpers through `/bin/sh -c`.

## Motivation

Using `/bin/sh -lc` starts a login shell, which can source profile initialization and unexpectedly alter command behavior.

## Type of Change

- [x] Bug fix

## Testing

- `just test debug noctalia:process` (1/1 passed)
- `nix develop -c just format` (no changes)
- `git diff --check`

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
