### PR TITLE
fix(ui): scale segmented controls once

### DIFF
--- a/src/shell/control_center/tabs/notifications_tab.cpp
+++ b/src/shell/control_center/tabs/notifications_tab.cpp
@@ -665,7 +665,7 @@ std::unique_ptr<Flex> NotificationsTab::create() {
                   {.label = i18n::tr("control-center.notifications.filter.older")},
               },
           .selectedIndex = m_filterIndex,
-          .fontSize = Style::fontSizeCaption * scale,
+          .fontSize = Style::fontSizeCaption,
           .scale = scale,
           .surfaceOpacity = panelCardOpacity(),
           .equalSegmentWidths = true,

--- a/src/shell/control_center/tabs/power_tab.cpp
+++ b/src/shell/control_center/tabs/power_tab.cpp
@@ -298,7 +298,7 @@ void PowerTab::buildProfilesCard(Flex& root, float scale) {
       ui::segmented({
           .out = &m_profiles,
           .options = std::move(options),
-          .fontSize = Style::fontSizeCaption * scale,
+          .fontSize = Style::fontSizeCaption,
           .scale = scale,
           .surfaceOpacity = panelCardOpacity(),
           .surfaceRole = ColorRole::Surface,

--- a/src/shell/control_center/tabs/screen_time_tab.cpp
+++ b/src/shell/control_center/tabs/screen_time_tab.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<Flex> ScreenTimeTab::create() {
                   {.label = i18n::tr("control-center.screen-time.range.14-days")},
               },
           .selectedIndex = 0,
-          .fontSize = Style::fontSizeCaption * scale,
+          .fontSize = Style::fontSizeCaption,
           .scale = scale,
           .surfaceOpacity = panelCardOpacity(),
           .equalSegmentWidths = true,

--- a/src/shell/control_center/tabs/weather_tab.cpp
+++ b/src/shell/control_center/tabs/weather_tab.cpp
@@ -286,7 +286,7 @@ std::unique_ptr<Flex> WeatherTab::create() {
                   {.label = i18n::tr("control-center.weather.forecast-view.hourly")},
               },
           .selectedIndex = static_cast<std::size_t>(m_forecastView),
-          .fontSize = Style::fontSizeCaption * scale,
+          .fontSize = Style::fontSizeCaption,
           .scale = scale,
           .compact = true,
           .surfaceOpacity = panelCardOpacity(),

--- a/src/shell/settings/plugin_store_content.cpp
+++ b/src/shell/settings/plugin_store_content.cpp
@@ -453,7 +453,8 @@ namespace settings {
           ui::segmented({
               .options = allSources,
               .selectedIndex = selectedSourceIndex,
-              .fontSize = Style::fontSizeCaption * scale,
+              .fontSize = Style::fontSizeCaption,
+              .scale = scale,
               .compact = true,
               .onChange = [this](std::size_t i) {
                 m_selectedSource = i == 0 ? std::string{} : m_sources[i - 1];


### PR DESCRIPTION
## Summary

Pass the base caption font size and control scale separately to the affected segmented controls.

## Motivation

`ui::segmented` applies its scale internally, so pre-scaling `fontSize` made these controls scale twice. The plugin source selector also omitted the control scale.

## Type of Change

- [x] Bug fix

## Testing

- Audited all 20 `ui::segmented` call sites; no double-scaled `fontSize` remains
- `just format`
- `git diff --check`
- Directly compiled `src/shell/control_center/tabs/power_tab.cpp.o`
- Full suite not run: the cold build was interrupted before completion

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
