### PR TITLE
fix(auth): submit password only once per PAM conversation

### DIFF
--- a/src/auth/pam_authenticator.cpp
+++ b/src/auth/pam_authenticator.cpp
@@ -32,6 +32,7 @@ namespace {
 
   struct PamConversationData {
     const char* password = nullptr;
+    bool passwordSent = false;
   };
 
   struct PamHandle {
@@ -68,7 +69,17 @@ namespace {
 
       switch (msg[i]->msg_style) {
       case PAM_PROMPT_ECHO_OFF:
+        if (data->passwordSent) {
+          for (int j = 0; j < i; ++j) {
+            if (replies[j].resp != nullptr) {
+              std::free(replies[j].resp);
+            }
+          }
+          std::free(replies);
+          return PAM_CONV_ERR;
+        }
         replies[i].resp = ::strdup(data->password != nullptr ? data->password : "");
+        data->passwordSent = true;
         break;
       case PAM_PROMPT_ECHO_ON:
         replies[i].resp = ::strdup("");


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Only submit the user's password once per PAM conversation in `pam_authenticator.cpp`. If PAM prompts for authentication again within the same conversation session (e.g. retry loops), return `PAM_CONV_ERR` immediately instead of re-supplying the cached password.

## Motivation

When authenticating against `systemd-homed` encrypted homes, `pam_systemd_home` implements an internal retry loop (up to 5 attempts) on authentication failure. 
Because Noctalia was answering all `PAM_PROMPT_ECHO_OFF` queries with the cached password, failed attempts caused `systemd-homed` to run 5 sequential cryptographic verifications , resulting in a ~15-second freeze on the lock screen. 
Aborting the conversation on subsequent prompts aligns with the PAM conversation specification and matches the approach used by other Wayland lockers (e.g. swaylock), reducing the lockout delay to a single attempt (~3.0 seconds).

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

Close #4283 

## Testing
Manual testing on Arch Linux (systemd 261, systemd-homed with btrfs/LUKS):
- Locked session via Noctalia under Niri.
- Entered incorrect password:
  - Before: Looped through 5 `systemd-homework` attempts for ~15 seconds before failing.
  - After: Aborted after 1 attempt (~3 seconds). Journal logs confirm `pam_systemd_home` returned `Conversation error` on attempt 2 and terminated cleanly.
- Entered correct password: Unlocked immediately.

Didn't test on non systemd-homed session.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

