### PR TITLE
feat(lockscreen): add the ability to hide session actions

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3214,6 +3214,7 @@
       "label-field": "Label",
       "label-placeholder": "Optional button text",
       "shortcut-label": "Shortcut",
+      "hide-on-lock-screen-label": "Hide on Lock Screen",
       "variant": {
         "default": "Default",
         "destructive": "Destructive",

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -521,6 +521,7 @@ namespace {
               if (item.shortcut.has_value()) {
                 row.insert_or_assign("shortcut", keyChordToString(*item.shortcut));
               }
+              row.insert_or_assign("hide_on_lock_screen", *item.hideOnLockScreen);
               row.insert_or_assign("countdown_seconds", item.countdownSeconds);
               array.push_back(std::move(row));
             }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -224,6 +224,7 @@ struct SessionPanelActionConfig {
   std::optional<std::string> glyph = std::nullopt;
   SessionActionButtonVariant variant = SessionActionButtonVariant::Default;
   std::optional<KeyChord> shortcut = std::nullopt;
+  std::optional<bool> hideOnLockScreen = std::nullopt;
   /// When > 0, the action arms a countdown (seconds) before running; activate again to confirm immediately.
   double countdownSeconds = 0.0;
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1491,6 +1491,7 @@ namespace noctalia::config::schema {
               }
           ),
           field(&SessionPanelActionConfig::countdownSeconds, "countdown_seconds"),
+          optionalBoolField(&SessionPanelActionConfig::hideOnLockScreen, "hide_on_lock_screen"),
       };
       return s;
     }

--- a/src/launcher/session_provider.cpp
+++ b/src/launcher/session_provider.cpp
@@ -100,7 +100,7 @@ namespace {
       if (row.action == "command" && (!row.command.has_value() || StringUtils::trim(*row.command).empty())) {
         continue;
       }
-      if ((row.action == "lock" || row.action == "lock_and_suspend")
+      if ((row.action == "lock" || row.action == "lock_and_suspend" || row.hideOnLockScreen)
           && config != nullptr
           && !config->isLockScreenEnabled()) {
         continue;

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -34,6 +34,7 @@
 #include <ctime>
 #include <format>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <tuple>
 #include <wayland-client-core.h>
@@ -1313,6 +1314,9 @@ std::vector<SessionPanelActionConfig> LockSurface::resolveSessionActions() const
       continue;
     }
     if (row.action == "lock" || row.action == "lock_and_suspend") {
+      continue;
+    }
+    if (row.hideOnLockScreen.value_or(false)) {
       continue;
     }
     if (row.action == "command" && (!row.command.has_value() || StringUtils::trim(*row.command).empty())) {

--- a/src/shell/settings/settings_content_session_action.cpp
+++ b/src/shell/settings/settings_content_session_action.cpp
@@ -302,6 +302,29 @@ namespace settings {
     variantBlock->addChild(std::move(variantSelect));
     fields->addChild(std::move(variantBlock));
 
+    auto hideOnLockScreenBlock = ui::row(
+        {.align = FlexAlign::Center, .gap = Style::spaceXs * scale, .flexGrow = 1.0F},
+        makeLabel(
+            i18n::tr("settings.session-actions.hide-on-lock-screen-label"), Style::fontSizeCaption * scale,
+            colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal
+        )
+    );
+
+    auto hideOnLockScreenToggle = ui::toggle({
+        .checked = row.hideOnLockScreen,
+        .scale = scale,
+        .onChange = [&row, variantOptions, persist](bool value) {
+          row.hideOnLockScreen = value;
+          persist();
+        },
+    });
+
+    hideOnLockScreenBlock->addChild(std::move(hideOnLockScreenToggle));
+
+    if (row.action != "lock" && row.action != "lock_and_suspend") {
+      fields->addChild(std::move(hideOnLockScreenBlock));
+    }
+
     auto shortcutBlock = ui::row(
         {.align = FlexAlign::Center, .gap = Style::spaceXs * scale, .flexGrow = 1.0F},
         makeLabel(


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Adds a boolean option `shell.session.actions.hide_on_lock_screen` for session actions that determine whether it is hidden in the "Session Buttons" row of the Login Box widget on the lock screen.

## Motivation

I'd like to be able to have one or two different session actions visible, but have the rest hidden. For example, I like having the ability to quickly suspend my computer after it being locked for a long period of time, but would like to omit my shutdown, reboot, and log out actions from that row.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

Automated:
- No new tests, all existing tests pass

Manual (on top of the manual coverage below):
- [X] Tested custom actions
- [X] Tested that `lock` and `lock_and_suspend` behaviors are still excluded, regardless of the value of `hide_on_lock_screen`
- [X] Tested that custom actions work
- [X] Tested that the default actions still appear if all other applicable session actions are hidden

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
Coming soon

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [ ] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
N/A