### PR TITLE
Fix spelling behaviour->behavior

### DIFF
--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -231,7 +231,7 @@ void Application::initIpc() {
   });
 
   m_ipcService.bind(noctalia::cli::msg::notificationInvokeLatest, [this](const std::string&) -> std::string {
-    // Mirror the toast left-click behaviour for the most recent active notification:
+    // Mirror the toast left-click behavior for the most recent active notification:
     // invoke its "default" action so the source application raises/focuses its window.
     // all() stores notifications oldest-first (push_back), so iterate in reverse for newest.
     const auto& notifications = m_notificationManager.all();

--- a/src/shell/panel/plugin_panel.h
+++ b/src/shell/panel/plugin_panel.h
@@ -77,7 +77,7 @@ public:
   [[nodiscard]] bool dismissTransientUi() override;
 
   // Delivers a manifest-declared capture_keys chord to the script's onKey(chord, pressed) and
-  // reports it consumed. Declared chords only: everything else keeps its host behaviour, and a
+  // reports it consumed. Declared chords only: everything else keeps its host behavior, and a
   // focused text input still wins printable keys (PanelManager reserves those before calling).
   [[nodiscard]] bool handleGlobalKey(std::uint32_t sym, std::uint32_t modifiers, bool pressed, bool preedit) override;
 

--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -1278,7 +1278,7 @@ void SystemMonitorService::samplingLoop() {
     const bool historyEnabled = historyPollSeconds > 0.0F;
     // Per-core is opt-in via retainCpuCores() and runs on a fixed 1s cadence, deliberately
     // independent of cpu_poll_seconds (default 2s): consumers want per-second resolution, and
-    // pinning it here leaves aggregate CPU behaviour untouched whatever the user configures.
+    // pinning it here leaves aggregate CPU behavior untouched whatever the user configures.
     const bool cpuCoresEnabled = m_cpuCoreRefs.load(std::memory_order_relaxed) > 0;
     // Resuming after a pause: the previous sample predates the gap, so a delta against it would
     // cover the whole pause rather than one second. Drop it and seed afresh.

--- a/src/ui/controls/context_menu_popup.h
+++ b/src/ui/controls/context_menu_popup.h
@@ -51,7 +51,7 @@ struct ContextMenuPopupRequest {
   // pointer capture (scrollbar thumb drags leaving the popup). Defaults to parent.wlSurface.
   wl_surface* pointerParentSurface = nullptr;
   // Serial of the input event that requested this popup. When absent, legacy
-  // callers retain the previous last-input-serial behaviour.
+  // callers retain the previous last-input-serial behavior.
   std::optional<std::uint32_t> inputSerial = std::nullopt;
   std::optional<ContextMenuPopupPlacement> placement = std::nullopt;
 };

--- a/tests/ical_parser_test.cpp
+++ b/tests/ical_parser_test.cpp
@@ -494,7 +494,7 @@ int main() {
   // All-day (VALUE=DATE) MONTHLY on the 1st, over a one-year window, is exactly 12 - one per month.
   // The old code derived the day-of-month from floor<days> of the UTC instant, which for a zone east
   // of UTC rolls back to the previous civil day (the 31st of Dec), so months without a 31st were
-  // dropped. Correct behaviour is zone-independent. Window is padded ±half-month so each local-midnight
+  // dropped. Correct behavior is zone-independent. Window is padded ±half-month so each local-midnight
   // occurrence lands inside regardless of the running zone's UTC offset.
   {
     const std::string ics = "BEGIN:VEVENT\r\nUID:ad\r\nSUMMARY:s\r\nDTSTART;VALUE=DATE:20240101\r\n"

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -2316,7 +2316,7 @@ int main() {
   }
 
   // Graph: no pointer callback declared -> plain Graph, no InputArea wrapper
-  // (existing values/size behaviour is unaffected by the new capability).
+  // (existing values/size behavior is unaffected by the new capability).
   {
     ui::UiTreeReconciler reconciler;
     Flex host;

--- a/tests/widget_definition_test.cpp
+++ b/tests/widget_definition_test.cpp
@@ -46,7 +46,7 @@
 #include <string_view>
 
 // The battery definition's finalize hook reaches into the warning-threshold helper, which would drag
-// UPower, notifications and i18n into a test about definition well-formedness. Threshold behaviour is
+// UPower, notifications and i18n into a test about definition well-formedness. Threshold behavior is
 // not under test here, so stand the helper in rather than link that tree.
 int batteryWarningThresholdForSelector(
     const BatteryConfig& /*config*/, const UPowerService* /*upower*/, std::string_view /*selector*/


### PR DESCRIPTION
## Summary

Change spelling of "behaviour" to American and more frequent "behavior"

The occurrence in [`protocols/virtual-keyboard-unstable-v1.xml`](https://github.com/noctalia-dev/noctalia/blob/f90a587fccc7f1cda59d0d3c7721b6d66780de3b/protocols/virtual-keyboard-unstable-v1.xml#L32) was ignored

## Motivation

Consistency

```sh
$ grep -ir "behaviour" . | wc -l
8
$ grep -ir "behavior" . | wc -l
577
```

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

```sh
$ grep -ir "behaviour" . | wc -l
1 # the one in protocols
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
