### PR TITLE
feat(media): improve Media tab artwork and controlsMedia tab artwork

### DIFF
--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -586,13 +586,17 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       m_pendingPositionCandidateUs[busName] = normalizedUs;
       m_pendingPositionCandidateMatches[busName] = 0;
       m_pendingPositionCandidateAt[busName] = now;
+
       if (playerIt->second.playbackStatus == "Playing" && shouldRetryPropertiesRefresh(busName)) {
         schedulePositionRefreshRetry(busName, kPositionCandidateRetryInterval, false);
       }
+
       return;
     }
 
-    if (guardingRecentTrackChange && playerIt->second.playbackStatus == "Playing") {
+    if (guardingRecentTrackChange
+        && playerIt->second.playbackStatus == "Playing"
+        && elapsedSinceTrackChangeUs < 250'000) {
       int& matchCount = m_pendingPositionCandidateMatches[busName];
       ++matchCount;
       if (matchCount < 2) {
@@ -648,7 +652,14 @@ std::int64_t MprisService::projectedPositionUs(const MprisPlayerInfo& player) co
       m_hasAuthoritativePositionSample.contains(player.busName) && m_hasAuthoritativePositionSample.at(player.busName);
   std::int64_t projectedUs = std::max<std::int64_t>(0, player.positionUs);
   if (!hasAuthoritativeSample && player.playbackStatus == "Playing") {
-    projectedUs = 0;
+    if (const auto it = m_lastPositionSampleAt.find(player.busName); it != m_lastPositionSampleAt.end()) {
+      const auto elapsedUs =
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - it->second).count();
+
+      if (elapsedUs > 0) {
+        projectedUs += elapsedUs;
+      }
+    }
   }
 
   if (player.playbackStatus == "Playing" && hasAuthoritativeSample) {
@@ -656,7 +667,8 @@ std::int64_t MprisService::projectedPositionUs(const MprisPlayerInfo& player) co
       const auto trackChangeIt = m_lastLogicalTrackChangeAt.find(player.busName);
       const bool inInitialTrackWindow = trackChangeIt != m_lastLogicalTrackChangeAt.end()
           && std::chrono::steady_clock::now() - trackChangeIt->second <= kRecentTrackChangeGuardWindow;
-      const bool suppressInitialProjection = inInitialTrackWindow
+      const bool suppressInitialProjection = hasAuthoritativeSample
+          && inInitialTrackWindow
           && projectedUs <= kInitialPositionProjectionGraceCeilingUs
           && std::chrono::steady_clock::now() - it->second <= kInitialPositionProjectionGraceWindow;
       if (suppressInitialProjection) {
@@ -2105,13 +2117,11 @@ void MprisService::applyPlayerSnapshot(
         || previous_info.canSeek != merged.canSeek;
 
     if (trackChanged || previous_info.playbackStatus != merged.playbackStatus) {
-      const std::weak_ptr<void> aliveGuard = m_aliveGuard;
-      DeferredCall::callLater([this, aliveGuard, busName]() {
-        if (aliveGuard.expired()) {
-          return;
-        }
+      auto& timerId = m_positionResyncTimers[busName];
+      timerId = TimerManager::instance().start(timerId, kPositionCandidateRetryInterval, [this, busName]() {
         refreshPlayerPosition(busName, true);
       });
+
       if (shouldRetryPropertiesRefresh(busName)) {
         schedulePositionRefreshRetry(busName, kPositionRetryInterval, true);
       }

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -1,3 +1,4 @@
+#include "util/string_utils.h"
 #include "shell/control_center/tabs/home_tab.h"
 
 #include "config/config_service.h"
@@ -417,7 +418,7 @@ std::unique_ptr<Flex> HomeTab::create() {
           })
       ),
       ui::column(
-          {.out = &m_mediaText, .align = FlexAlign::Stretch, .gap = Style::spaceXs * 0.5F * scale, .flexGrow = 1.0F},
+          {.out = &m_mediaText, .align = FlexAlign::Stretch, .gap = Style::spaceXs * 0.5F * scale, .fillWidth = true, .flexGrow = 0.0F},
           ui::label({
               .out = &m_mediaTrack,
               .text = "...",
@@ -1510,10 +1511,21 @@ void HomeTab::sync(Renderer& renderer) {
         m_loadedMediaArtUrl.clear();
         PanelManager::instance().requestLayout();
       } else {
-        const std::string trackText =
-            active->title.empty() ? i18n::tr("control-center.home.media.unknown-track") : active->title;
         const std::string artists = mpris::joinArtists(active->artists);
-        const std::string artistText = artists.empty() ? i18n::tr("control-center.home.media.unknown-artist") : artists;
+        const auto truncateMediaText = [](const std::string& text) {
+          constexpr std::size_t kMaxChars = 20;
+          if (StringUtils::truncateUtf8CodePoints(text, kMaxChars).size() == text.size()) {
+            return text;
+          }
+          return StringUtils::truncateUtf8CodePoints(text, kMaxChars) + "...";
+        };
+
+        const std::string trackText = active->title.empty()
+            ? i18n::tr("control-center.home.media.unknown-track")
+            : truncateMediaText(active->title);
+        const std::string artistText = artists.empty()
+            ? i18n::tr("control-center.home.media.unknown-artist")
+            : truncateMediaText(artists);
         if (m_mediaTrack->text() != trackText || m_mediaArtist->text() != artistText) {
           m_mediaTrack->setText(trackText);
           m_mediaArtist->setText(artistText);
@@ -1594,24 +1606,13 @@ void HomeTab::sync(Renderer& renderer) {
             PanelManager::instance().requestLayout();
           }
         }
-        std::string statusText;
-        if (active->playbackStatus == "Playing") {
-          statusText = i18n::tr("control-center.home.media.playing");
-          m_mediaStatus->setColor(colorSpecFromRole(ColorRole::Primary));
-        } else if (active->playbackStatus == "Paused") {
-          statusText = i18n::tr("control-center.home.media.paused");
-          m_mediaStatus->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant));
-        } else {
-          statusText = active->playbackStatus;
-          m_mediaStatus->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant));
-        }
-        if (!progressText.empty()) {
-          statusText = std::format("{} · {}", statusText, progressText);
-        }
+        std::string statusText = progressText;
+        m_mediaStatus->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant));
         if (m_mediaStatus->text() != statusText) {
           m_mediaStatus->setText(statusText);
           PanelManager::instance().requestLayout();
         }
+        m_mediaStatus->setVisible(!progressText.empty());
       }
     }
   }

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -928,25 +928,33 @@ void MediaTab::refresh(Renderer& renderer) {
         loaded = true;
       }
 
+      // The foreground artwork changed, so force the blurred background
+      // to be regenerated from the new artwork texture.
+      if (loaded) {
+        m_artworkBlurCache.invalidate();
+      }
+
       // Only lock this URL once we actually have an image.
       // Otherwise keep retrying while metadata/download catches up.
-            if (loaded && m_artworkBackground != nullptr && m_renderContext != nullptr) {
+      if (loaded && m_artworkBackground != nullptr && m_renderContext != nullptr) {
         const auto artworkTexture = m_artwork->textureHandle();
 
         if (artworkTexture.valid()) {
           m_renderContext->backend().makeCurrentNoSurface();
 
-          const std::uint32_t blurWidth = static_cast<std::uint32_t>(artworkTexture.width);
-          const std::uint32_t blurHeight = static_cast<std::uint32_t>(artworkTexture.height);
+          const std::uint32_t blurWidth =
+             std::max(1U, static_cast<std::uint32_t>(artworkTexture.width / 2));
+          const std::uint32_t blurHeight =
+             std::max(1U, static_cast<std::uint32_t>(artworkTexture.height / 2));
 
-         const auto blurredTexture = m_artworkBlurCache.get(
-             m_renderContext->backend(),
-             artworkTexture,
-             blurWidth,
-             blurHeight,
-             8.0F,
-             1
-         );
+          const auto blurredTexture = m_artworkBlurCache.get(
+              m_renderContext->backend(),
+              artworkTexture,
+              blurWidth,
+              blurHeight,
+              8.0F,
+              1
+          );
 
           if (blurredTexture.valid()) {
             m_artworkBackground->setExternalTexture(renderer, blurredTexture);

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -26,7 +26,6 @@
 #include <string_view>
 #include <vector>
 
-
 using namespace control_center;
 using namespace mpris;
 
@@ -111,7 +110,7 @@ void MediaTab::openPlayerMenu() {
     );
   }
 
- Flex* anchor = m_playerMenuButton;
+  Flex* anchor = m_playerMenuButton;
   if (anchor == nullptr) {
     return;
   }
@@ -235,25 +234,26 @@ std::unique_ptr<Flex> MediaTab::create() {
   });
 
   auto artworkRow = ui::row(
-    {.out = &m_artworkRow, .align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = 0.0F, .flexGrow = 1.0F},
-ui::image({
-    .out = &m_artworkBackground,
-    .fit = ImageFit::Cover,
-    .participatesInLayout = false,
-    .configure = [](Image& image) {
-        image.setZIndex(-1);
-        image.setOpacity(0.80F);
-    },
-}),
-    ui::image({
-        .out = &m_artwork,
-        .fit = ImageFit::Cover,
-        .radius = Style::scaledRadiusXl(scale),
-        .width = kArtworkSize * scale,
-        .height = kArtworkSize * scale,
-        .configure = [](Image& image) { image.setZIndex(1); },
-    })
-);
+      {.out = &m_artworkRow, .align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = 0.0F, .flexGrow = 1.0F},
+      ui::image({
+          .out = &m_artworkBackground,
+          .fit = ImageFit::Cover,
+          .participatesInLayout = false,
+          .configure =
+              [](Image& image) {
+                image.setZIndex(-1);
+                image.setOpacity(0.80F);
+              },
+      }),
+      ui::image({
+          .out = &m_artwork,
+          .fit = ImageFit::Cover,
+          .radius = Style::scaledRadiusXl(scale),
+          .width = kArtworkSize * scale,
+          .height = kArtworkSize * scale,
+          .configure = [](Image& image) { image.setZIndex(1); },
+      })
+  );
   mediaStack->addChild(std::move(artworkRow));
 
   mediaStack->addChild(
@@ -450,7 +450,6 @@ ui::image({
 
   tab->addChild(std::move(mediaColumn));
 
-
   if (m_wayland != nullptr && m_renderContext != nullptr) {
     m_playerMenuPopup = std::make_unique<ContextMenuPopup>(*m_wayland, *m_renderContext);
     m_playerMenuPopup->setOnActivate([this](const ContextMenuControlEntry& entry) {
@@ -536,31 +535,31 @@ void MediaTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
   m_mediaStack->layout(renderer);
 
   if (m_artwork != nullptr && m_artworkRow != nullptr) {
-  const float artWidth =
-      std::max(1.0F, m_artworkRow->width() - (m_artworkRow->paddingLeft() + m_artworkRow->paddingRight()));
-  const float artHeight = std::max(
-      kMediaArtworkMinHeight * scale,
-      m_artworkRow->height() - (m_artworkRow->paddingTop() + m_artworkRow->paddingBottom())
-  );
+    const float artWidth =
+        std::max(1.0F, m_artworkRow->width() - (m_artworkRow->paddingLeft() + m_artworkRow->paddingRight()));
+    const float artHeight = std::max(
+        kMediaArtworkMinHeight * scale,
+        m_artworkRow->height() - (m_artworkRow->paddingTop() + m_artworkRow->paddingBottom())
+    );
 
-  // Media art is always presented as a square (album-art convention).
-  const float side = std::min(artWidth, artHeight) * 0.75F;
+    // Media art is always presented as a square (album-art convention).
+    const float side = std::min(artWidth, artHeight) * 0.75F;
 
-  m_artwork->setSize(side, side);
-  m_artwork->setRadius(side * 0.5F);
+    m_artwork->setSize(side, side);
+    m_artwork->setRadius(side * 0.5F);
 
-  if (m_artworkBackground != nullptr) {
-    const float backgroundSide = side * 1.35F;
+    if (m_artworkBackground != nullptr) {
+      const float backgroundSide = side * 1.35F;
 
-    m_artworkBackground->setSize(backgroundSide, backgroundSide);
-    m_artworkBackground->setRadius(backgroundSide * 0.5F);
+      m_artworkBackground->setSize(backgroundSide, backgroundSide);
+      m_artworkBackground->setRadius(backgroundSide * 0.5F);
 
-    // Keep the blurred artwork centered behind the main artwork.
-    const float backgroundX = (artWidth - backgroundSide) * 0.5F;
-    const float backgroundY = (artHeight - backgroundSide) * 0.5F;
+      // Keep the blurred artwork centered behind the main artwork.
+      const float backgroundX = (artWidth - backgroundSide) * 0.5F;
+      const float backgroundY = (artHeight - backgroundSide) * 0.5F;
 
-    m_artworkBackground->setPosition(backgroundX, backgroundY);
-  }
+      m_artworkBackground->setPosition(backgroundX, backgroundY);
+    }
   }
 }
 
@@ -569,7 +568,6 @@ void MediaTab::doUpdate(Renderer& renderer) {
     m_progressTimer.stop();
     return;
   }
-
 
   const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
   const auto now = std::chrono::steady_clock::now();
@@ -603,33 +601,33 @@ void MediaTab::onFrameTick(float deltaMs) {
     return;
   }
 
- // Continuous rotation
-constexpr float rotationSpeed = 0.0005F;
-m_artwork->setRotation(m_artwork->rotation() + deltaMs * rotationSpeed);
+  // Continuous rotation
+  constexpr float rotationSpeed = 0.0005F;
+  m_artwork->setRotation(m_artwork->rotation() + deltaMs * rotationSpeed);
 
-// Smooth, bass-driven pulse
-if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
-  const auto values = m_spectrum->values(m_spectrumListenerId);
+  // Smooth, bass-driven pulse
+  if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
+    const auto values = m_spectrum->values(m_spectrumListenerId);
 
-  if (!values.empty()) {
-    const std::size_t bassBands = std::min<std::size_t>(4, values.size());
+    if (!values.empty()) {
+      const std::size_t bassBands = std::min<std::size_t>(4, values.size());
 
-    float bass = 0.0F;
-    for (std::size_t i = 0; i < bassBands; ++i) {
-      bass += values[i];
+      float bass = 0.0F;
+      for (std::size_t i = 0; i < bassBands; ++i) {
+        bass += values[i];
+      }
+
+      bass /= static_cast<float>(bassBands);
+
+      // The low frequency defines the target of the pulse.
+      const float targetPulse = std::clamp(bass * 0.20F, 0.0F, 0.20F);
+
+      // Faster attack, smoother return.
+      const float smoothing = targetPulse > m_artworkPulse ? 0.16F : 0.055F;
+      m_artworkPulse += (targetPulse - m_artworkPulse) * smoothing;
+
+      m_artwork->setScale(1.0F + m_artworkPulse);
     }
-
-    bass /= static_cast<float>(bassBands);
-
-    // The low frequency defines the target of the pulse.
-    const float targetPulse = std::clamp(bass * 0.20F, 0.0F, 0.20F);
-
-    // Faster attack, smoother return.
-    const float smoothing = targetPulse > m_artworkPulse ? 0.16F : 0.055F;
-    m_artworkPulse += (targetPulse - m_artworkPulse) * smoothing;
-
-    m_artwork->setScale(1.0F + m_artworkPulse);
-  }
   }
 }
 
@@ -670,7 +668,6 @@ void MediaTab::setActive(bool active) {
     m_positionSampleAt = {};
   }
 }
-
 
 void MediaTab::onClose() {
   m_progressTimer.stop();
@@ -741,7 +738,6 @@ void MediaTab::clearArt(Renderer& renderer) {
 
   m_artworkBlurCache.invalidate();
 }
-
 
 void MediaTab::commitPendingSeek(double valueSeconds) {
   if (m_mpris == nullptr) {
@@ -900,9 +896,7 @@ void MediaTab::refresh(Renderer& renderer) {
     }
 
     m_trackTitle->setText(player.title.empty() ? player.identity : player.title);
-    m_trackArtist->setText(
-        joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists)
-    );
+    m_trackArtist->setText(joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists));
 
     const std::string resolvedArtUrl = effectiveArtUrl(player);
     const std::string artPath = resolveArtworkSource(
@@ -942,19 +936,11 @@ void MediaTab::refresh(Renderer& renderer) {
         if (artworkTexture.valid()) {
           m_renderContext->backend().makeCurrentNoSurface();
 
-          const std::uint32_t blurWidth =
-             std::max(1U, static_cast<std::uint32_t>(artworkTexture.width / 2));
-          const std::uint32_t blurHeight =
-             std::max(1U, static_cast<std::uint32_t>(artworkTexture.height / 2));
+          const std::uint32_t blurWidth = std::max(1U, static_cast<std::uint32_t>(artworkTexture.width / 2));
+          const std::uint32_t blurHeight = std::max(1U, static_cast<std::uint32_t>(artworkTexture.height / 2));
 
-          const auto blurredTexture = m_artworkBlurCache.get(
-              m_renderContext->backend(),
-              artworkTexture,
-              blurWidth,
-              blurHeight,
-              8.0F,
-              1
-          );
+          const auto blurredTexture =
+              m_artworkBlurCache.get(m_renderContext->backend(), artworkTexture, blurWidth, blurHeight, 8.0F, 1);
 
           if (blurredTexture.valid()) {
             m_artworkBackground->setExternalTexture(renderer, blurredTexture);
@@ -978,29 +964,23 @@ void MediaTab::refresh(Renderer& renderer) {
       trackLengthUs = m_lastTrackLengthUs;
     }
 
-   auto formatTime = [](std::int64_t microseconds) -> std::string {
-     const auto totalSeconds = std::max<std::int64_t>(0, microseconds / 1000000);
-     const auto minutes = totalSeconds / 60;
-     const auto seconds = totalSeconds % 60;
+    auto formatTime = [](std::int64_t microseconds) -> std::string {
+      const auto totalSeconds = std::max<std::int64_t>(0, microseconds / 1000000);
+      const auto minutes = totalSeconds / 60;
+      const auto seconds = totalSeconds % 60;
 
-    return std::format("{:02}:{:02}", minutes, seconds);
-   };
+      return std::format("{:02}:{:02}", minutes, seconds);
+    };
 
-   if (m_trackAlbum != nullptr) {
-    if (trackLengthUs > 0) {
-      m_trackAlbum->setText(
-         std::format(
-             "{} / {}",
-             formatTime(displayPositionUs),
-             formatTime(trackLengthUs)
-         )
-      );
-       m_trackAlbum->setVisible(true);
-     } else {
-      m_trackAlbum->setText("");
-      m_trackAlbum->setVisible(false);
-     }
-   }
+    if (m_trackAlbum != nullptr) {
+      if (trackLengthUs > 0) {
+        m_trackAlbum->setText(std::format("{} / {}", formatTime(displayPositionUs), formatTime(trackLengthUs)));
+        m_trackAlbum->setVisible(true);
+      } else {
+        m_trackAlbum->setText("");
+        m_trackAlbum->setVisible(false);
+      }
+    }
 
     const bool progressInteracting = m_progressSlider->dragging() || seekPending || withinProgressSettle;
     const bool progressEnabled = player.canSeek && (trackLengthUs > 0 || progressInteracting);

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -282,6 +282,32 @@ std::unique_ptr<Flex> MediaTab::create() {
       )
   );
 
+
+   auto progressTimes = ui::row({
+       .align = FlexAlign::Center,
+       .justify = FlexJustify::SpaceBetween,
+   });
+
+  progressTimes->addChild(
+      ui::label({
+          .out = &m_progressCurrentTime,
+          .text = "00:00",
+          .fontSize = Style::fontSizeCaption * scale,
+          .color = colorSpecFromRole(ColorRole::Secondary),
+      })
+  );
+
+  progressTimes->addChild(
+      ui::label({
+          .out = &m_progressTotalTime,
+          .text = "00:00",
+          .fontSize = Style::fontSizeCaption * scale,
+          .color = colorSpecFromRole(ColorRole::Secondary),
+      })
+  );
+
+  mediaStack->addChild(std::move(progressTimes));
+
   mediaStack->addChild(
       ui::slider({
           .out = &m_progressSlider,
@@ -317,6 +343,9 @@ std::unique_ptr<Flex> MediaTab::create() {
               },
       })
   );
+
+
+
 
   auto controls = ui::row({
       .align = FlexAlign::Center,
@@ -693,10 +722,13 @@ void MediaTab::onClose() {
     m_playerMenuPopup->close();
   }
 
+
   m_playerMenuOpen = false;
   m_trackTitle = nullptr;
   m_trackArtist = nullptr;
   m_trackAlbum = nullptr;
+  m_progressCurrentTime = nullptr;
+  m_progressTotalTime = nullptr;
   m_progressSlider = nullptr;
   m_prevButton = nullptr;
   m_playPauseButton = nullptr;
@@ -716,6 +748,7 @@ void MediaTab::onClose() {
   m_positionTrackSignature.clear();
   m_nextRealtimeUpdateAt = {};
   m_lastRealtimeMprisPollAt = {};
+
 }
 
 bool MediaTab::dismissTransientUi() {
@@ -959,9 +992,9 @@ void MediaTab::refresh(Renderer& renderer) {
 
     std::int64_t trackLengthUs = player.lengthUs;
     if (trackLengthUs > 0) {
-      m_lastTrackLengthUs = trackLengthUs;
-    } else if (m_lastTrackLengthUs > 0 && samePlayerAsDisplayed) {
-      trackLengthUs = m_lastTrackLengthUs;
+        m_lastTrackLengthUs = trackLengthUs;
+    } else if (m_lastTrackLengthUs > 0 && sameDisplayedTrack) {
+        trackLengthUs = m_lastTrackLengthUs;
     }
 
     auto formatTime = [](std::int64_t microseconds) -> std::string {
@@ -972,15 +1005,22 @@ void MediaTab::refresh(Renderer& renderer) {
       return std::format("{:02}:{:02}", minutes, seconds);
     };
 
+
     if (m_trackAlbum != nullptr) {
-      if (trackLengthUs > 0) {
-        m_trackAlbum->setText(std::format("{} / {}", formatTime(displayPositionUs), formatTime(trackLengthUs)));
-        m_trackAlbum->setVisible(true);
-      } else {
-        m_trackAlbum->setText("");
-        m_trackAlbum->setVisible(false);
-      }
+      m_trackAlbum->setText(player.album);
+      m_trackAlbum->setVisible(!player.album.empty());
     }
+
+    if (m_progressCurrentTime != nullptr) {
+      m_progressCurrentTime->setText(formatTime(displayPositionUs));
+    }
+
+    if (m_progressTotalTime != nullptr) {
+      m_progressTotalTime->setText(formatTime(trackLengthUs));
+    }
+
+    m_progressSlider->setPlayingEffect(player.playbackStatus == "Playing");
+
 
     const bool progressInteracting = m_progressSlider->dragging() || seekPending || withinProgressSettle;
     const bool progressEnabled = player.canSeek && (trackLengthUs > 0 || progressInteracting);
@@ -1029,14 +1069,24 @@ void MediaTab::refresh(Renderer& renderer) {
   m_positionSampleAt = {};
   m_trackTitle->setText(i18n::tr("control-center.media.nothing-playing"));
   m_trackArtist->setText(i18n::tr("control-center.media.start-playback"));
-  if (m_trackAlbum != nullptr) {
+if (m_trackAlbum != nullptr) {
     m_trackAlbum->setText("");
     m_trackAlbum->setVisible(false);
-  }
+}
+
+if (m_progressCurrentTime != nullptr) {
+    m_progressCurrentTime->setText("00:00");
+}
+
+if (m_progressTotalTime != nullptr) {
+    m_progressTotalTime->setText("00:00");
+}
+
   clearArt(renderer);
   m_lastArtPath.clear();
   m_syncingProgress = true;
   m_progressSlider->setEnabled(false);
+  m_progressSlider->setPlayingEffect(false);
   m_progressSlider->setRange(0.0F, 100.0F);
   m_progressSlider->setValue(0.0F);
   m_syncingProgress = false;

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -9,13 +9,13 @@
 #include "net/http_client.h"
 #include "pipewire/pipewire_spectrum.h"
 #include "render/core/renderer.h"
+#include "render/render_context.h"
 #include "render/scene/node.h"
 #include "shell/control_center/tab.h"
 #include "shell/panel/panel_manager.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu.h"
 #include "ui/controls/context_menu_popup.h"
-#include "ui/visuals/audio_visualizer.h"
 
 #include <algorithm>
 #include <chrono>
@@ -25,6 +25,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
 
 using namespace control_center;
 using namespace mpris;
@@ -66,7 +67,6 @@ namespace {
   std::string repeatGlyph(const std::string& loopStatus) { return loopStatus == "Track" ? "repeat-once" : "repeat"; }
 
   ButtonVariant toggleVariant(bool active) { return active ? ButtonVariant::Primary : ButtonVariant::Ghost; }
-  constexpr int kVisualizerBandCount = 32;
 
 } // namespace
 
@@ -111,8 +111,7 @@ void MediaTab::openPlayerMenu() {
     );
   }
 
-  Flex* anchor = m_playerMenuButton->parent() != nullptr ? static_cast<Flex*>(m_playerMenuButton->parent())
-                                                         : static_cast<Flex*>(m_nowCard);
+ Flex* anchor = m_playerMenuButton;
   if (anchor == nullptr) {
     return;
   }
@@ -236,20 +235,30 @@ std::unique_ptr<Flex> MediaTab::create() {
   });
 
   auto artworkRow = ui::row(
-      {.out = &m_artworkRow, .align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = 0.0F, .flexGrow = 1.0F},
-      ui::image({
-          .out = &m_artwork,
-          .fit = ImageFit::Cover,
-          .radius = Style::scaledRadiusXl(scale),
-          .width = kArtworkSize * scale,
-          .height = kArtworkSize * scale,
-      })
-  );
+    {.out = &m_artworkRow, .align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = 0.0F, .flexGrow = 1.0F},
+ui::image({
+    .out = &m_artworkBackground,
+    .fit = ImageFit::Cover,
+    .participatesInLayout = false,
+    .configure = [](Image& image) {
+        image.setZIndex(-1);
+        image.setOpacity(0.80F);
+    },
+}),
+    ui::image({
+        .out = &m_artwork,
+        .fit = ImageFit::Cover,
+        .radius = Style::scaledRadiusXl(scale),
+        .width = kArtworkSize * scale,
+        .height = kArtworkSize * scale,
+        .configure = [](Image& image) { image.setZIndex(1); },
+    })
+);
   mediaStack->addChild(std::move(artworkRow));
 
   mediaStack->addChild(
       ui::column(
-          {.align = FlexAlign::Stretch, .gap = Style::spaceSm * scale},
+          {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
           ui::label({
               .out = &m_trackTitle,
               .text = i18n::tr("control-center.media.nothing-playing"),
@@ -280,7 +289,7 @@ std::unique_ptr<Flex> MediaTab::create() {
           .maxValue = 100.0F,
           .step = 1.0F,
           .trackHeight = 7.0F * scale,
-          .thumbSize = 16.0F * scale,
+          .thumbSize = 20.0F * scale,
           .controlHeight = (Style::controlHeight + Style::spaceXs) * scale,
           .onValueChanged =
               [this](double value) {
@@ -439,38 +448,8 @@ std::unique_ptr<Flex> MediaTab::create() {
   nowCard->addChild(std::move(mediaStack));
   mediaColumn->addChild(std::move(nowCard));
 
-  auto visualizerColumn = ui::column({
-      .out = &m_visualizerColumn,
-      .align = FlexAlign::Stretch,
-      .gap = Style::spaceMd * scale,
-      .clipChildren = true,
-      .flexGrow = 2.0F,
-      .configure = [scale, opacity = panelCardOpacity()](Flex& column) {
-        applySectionCardStyle(column, scale, opacity);
-      },
-  });
-
-  auto visualizerBody = ui::row({
-      .out = &m_visualizerBody,
-      .align = FlexAlign::Stretch,
-      .justify = FlexJustify::Start,
-      .fillWidth = true,
-      .flexGrow = 1.0F,
-  });
-
-  auto visualizerSpectrum = std::make_unique<AudioVisualizer>();
-  visualizerSpectrum->setGradient(colorForRole(ColorRole::Secondary), colorForRole(ColorRole::Tertiary));
-  visualizerSpectrum->setOrientation(AudioSpectrumOrientation::Vertical);
-  visualizerSpectrum->setMirrored(true);
-  visualizerSpectrum->setCentered(true);
-  visualizerSpectrum->setValues(std::vector<float>(kVisualizerBandCount, 0.0F));
-  visualizerSpectrum->tick(0.0F);
-  visualizerSpectrum->setFlexGrow(1.0F);
-  m_visualizerSpectrum = visualizerSpectrum.get();
-  visualizerBody->addChild(std::move(visualizerSpectrum));
-  visualizerColumn->addChild(std::move(visualizerBody));
   tab->addChild(std::move(mediaColumn));
-  tab->addChild(std::move(visualizerColumn));
+
 
   if (m_wayland != nullptr && m_renderContext != nullptr) {
     m_playerMenuPopup = std::make_unique<ContextMenuPopup>(*m_wayland, *m_renderContext);
@@ -507,7 +486,7 @@ void MediaTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
 
   const float cardInnerWidth =
       std::max(0.0F, m_nowCard->width() - (m_nowCard->paddingLeft() + m_nowCard->paddingRight()));
-  const float mediaWidth = std::clamp(cardInnerWidth, 1.0F, kMediaUnit * 11.0F * scale);
+  const float mediaWidth = std::max(1.0F, cardInnerWidth);
   const float mediaStackHeight = m_mediaStack->height();
   m_mediaStack->setSize(mediaWidth, mediaStackHeight);
 
@@ -551,36 +530,37 @@ void MediaTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
     m_trackAlbum->setMaxWidth(mediaWidth);
   }
   if (m_progressSlider != nullptr) {
-    m_progressSlider->setSize(mediaWidth, 0.0F);
+    m_progressSlider->setSize(mediaWidth * 0.70F, 0.0F);
   }
 
   m_mediaStack->layout(renderer);
 
   if (m_artwork != nullptr && m_artworkRow != nullptr) {
-    const float artWidth =
-        std::max(1.0F, m_artworkRow->width() - (m_artworkRow->paddingLeft() + m_artworkRow->paddingRight()));
-    const float artHeight = std::max(
-        kMediaArtworkMinHeight * scale,
-        m_artworkRow->height() - (m_artworkRow->paddingTop() + m_artworkRow->paddingBottom())
-    );
-    // Media art is always presented as a square (album-art convention).
-    const float side = std::min(artWidth, artHeight);
-    m_artwork->setSize(side, side);
-    m_artwork->setRadius(Style::scaledRadiusXl(scale));
-    m_mediaStack->layout(renderer);
-  }
+  const float artWidth =
+      std::max(1.0F, m_artworkRow->width() - (m_artworkRow->paddingLeft() + m_artworkRow->paddingRight()));
+  const float artHeight = std::max(
+      kMediaArtworkMinHeight * scale,
+      m_artworkRow->height() - (m_artworkRow->paddingTop() + m_artworkRow->paddingBottom())
+  );
 
-  if (m_visualizerBody != nullptr && m_visualizerSpectrum != nullptr) {
-    const float bodyWidth = std::max(
-        0.0F, m_visualizerBody->width() - (m_visualizerBody->paddingLeft() + m_visualizerBody->paddingRight())
-    );
-    const float bodyHeightAvail = std::max(
-        0.0F, m_visualizerBody->height() - (m_visualizerBody->paddingTop() + m_visualizerBody->paddingBottom())
-    );
-    const float spectrumWidth = std::max(1.0F, bodyWidth);
-    const float spectrumHeight = std::max(1.0F, bodyHeightAvail);
-    m_visualizerSpectrum->setSize(spectrumWidth, spectrumHeight);
-    m_visualizerBody->layout(renderer);
+  // Media art is always presented as a square (album-art convention).
+  const float side = std::min(artWidth, artHeight) * 0.75F;
+
+  m_artwork->setSize(side, side);
+  m_artwork->setRadius(side * 0.5F);
+
+  if (m_artworkBackground != nullptr) {
+    const float backgroundSide = side * 1.35F;
+
+    m_artworkBackground->setSize(backgroundSide, backgroundSide);
+    m_artworkBackground->setRadius(backgroundSide * 0.5F);
+
+    // Keep the blurred artwork centered behind the main artwork.
+    const float backgroundX = (artWidth - backgroundSide) * 0.5F;
+    const float backgroundY = (artHeight - backgroundSide) * 0.5F;
+
+    m_artworkBackground->setPosition(backgroundX, backgroundY);
+  }
   }
 }
 
@@ -589,11 +569,7 @@ void MediaTab::doUpdate(Renderer& renderer) {
     m_progressTimer.stop();
     return;
   }
-  if (m_visualizerSpectrum != nullptr && m_spectrum != nullptr && m_spectrumListenerId != 0) {
-    if (!m_spectrum->idle() || !m_visualizerSpectrum->converged()) {
-      m_visualizerSpectrum->setValues(m_spectrum->values(m_spectrumListenerId));
-    }
-  }
+
 
   const auto active = m_mpris != nullptr ? m_mpris->activePlayer() : std::nullopt;
   const auto now = std::chrono::steady_clock::now();
@@ -623,22 +599,47 @@ void MediaTab::onFrameTick(float deltaMs) {
     return;
   }
 
-  if (m_visualizerSpectrum != nullptr) {
-    if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
-      if (!m_spectrum->idle() || !m_visualizerSpectrum->converged()) {
-        m_visualizerSpectrum->setValues(m_spectrum->values(m_spectrumListenerId));
-      }
+  if (m_artwork == nullptr) {
+    return;
+  }
+
+ // Continuous rotation
+constexpr float rotationSpeed = 0.0005F;
+m_artwork->setRotation(m_artwork->rotation() + deltaMs * rotationSpeed);
+
+// Smooth, bass-driven pulse
+if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
+  const auto values = m_spectrum->values(m_spectrumListenerId);
+
+  if (!values.empty()) {
+    const std::size_t bassBands = std::min<std::size_t>(4, values.size());
+
+    float bass = 0.0F;
+    for (std::size_t i = 0; i < bassBands; ++i) {
+      bass += values[i];
     }
-    m_visualizerSpectrum->tick(deltaMs);
+
+    bass /= static_cast<float>(bassBands);
+
+    // The low frequency defines the target of the pulse.
+    const float targetPulse = std::clamp(bass * 0.20F, 0.0F, 0.20F);
+
+    // Faster attack, smoother return.
+    const float smoothing = targetPulse > m_artworkPulse ? 0.16F : 0.055F;
+    m_artworkPulse += (targetPulse - m_artworkPulse) * smoothing;
+
+    m_artwork->setScale(1.0F + m_artworkPulse);
+  }
   }
 }
 
 void MediaTab::setActive(bool active) {
   const bool becameActive = active && !m_active;
   m_active = active;
+
   if (m_spectrum != nullptr) {
     if (active && m_spectrumListenerId == 0) {
-      m_spectrumListenerId = m_spectrum->addChangeListener(kVisualizerBandCount, [this]() {
+      m_spectrumListenerId = m_spectrum->addChangeListener(4, [this]() {
         if (!m_active || m_spectrum->idle()) {
           return;
         }
@@ -649,7 +650,14 @@ void MediaTab::setActive(bool active) {
       m_spectrumListenerId = 0;
     }
   }
+
   if (!active) {
+    m_artworkPulse = 0.0F;
+
+    if (m_artwork != nullptr) {
+      m_artwork->setScale(1.0F);
+    }
+
     m_progressTimer.stop();
     m_positionSampleAt = {};
     m_positionTrackSignature.clear();
@@ -657,34 +665,37 @@ void MediaTab::setActive(bool active) {
     m_nextRealtimeUpdateAt = {};
     m_lastRealtimeMprisPollAt = {};
   }
+
   if (becameActive && m_mpris != nullptr) {
     m_positionSampleAt = {};
   }
 }
 
+
 void MediaTab::onClose() {
   m_progressTimer.stop();
-  if (m_spectrum != nullptr) {
-    if (m_spectrumListenerId != 0) {
-      m_spectrum->removeChangeListener(m_spectrumListenerId);
-      m_spectrumListenerId = 0;
-    }
+
+  if (m_spectrum != nullptr && m_spectrumListenerId != 0) {
+    m_spectrum->removeChangeListener(m_spectrumListenerId);
+    m_spectrumListenerId = 0;
   }
+
   m_active = false;
+  m_artworkPulse = 0.0F;
+
   m_rootLayout = nullptr;
   m_mediaColumn = nullptr;
-  m_visualizerColumn = nullptr;
-  m_visualizerBody = nullptr;
-  m_visualizerSpectrum = nullptr;
   m_artwork = nullptr;
   m_artworkRow = nullptr;
   m_nowCard = nullptr;
   m_mediaStack = nullptr;
   m_playerMenuButton = nullptr;
+
   if (m_playerMenuPopup != nullptr) {
     PanelManager::instance().clearActivePopup();
     m_playerMenuPopup->close();
   }
+
   m_playerMenuOpen = false;
   m_trackTitle = nullptr;
   m_trackArtist = nullptr;
@@ -695,6 +706,7 @@ void MediaTab::onClose() {
   m_nextButton = nullptr;
   m_repeatButton = nullptr;
   m_shuffleButton = nullptr;
+
   m_lastArtPath.clear();
   m_lastBusName.clear();
   m_lastPlaybackStatus.clear();
@@ -722,7 +734,14 @@ void MediaTab::clearArt(Renderer& renderer) {
   if (m_artwork != nullptr) {
     m_artwork->clear(renderer);
   }
+
+  if (m_artworkBackground != nullptr) {
+    m_artworkBackground->clear(renderer);
+  }
+
+  m_artworkBlurCache.invalidate();
 }
+
 
 void MediaTab::commitPendingSeek(double valueSeconds) {
   if (m_mpris == nullptr) {
@@ -881,11 +900,9 @@ void MediaTab::refresh(Renderer& renderer) {
     }
 
     m_trackTitle->setText(player.title.empty() ? player.identity : player.title);
-    m_trackArtist->setText(joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists));
-    if (m_trackAlbum != nullptr) {
-      m_trackAlbum->setText(player.album);
-      m_trackAlbum->setVisible(!player.album.empty());
-    }
+    m_trackArtist->setText(
+        joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists)
+    );
 
     const std::string resolvedArtUrl = effectiveArtUrl(player);
     const std::string artPath = resolveArtworkSource(
@@ -913,6 +930,30 @@ void MediaTab::refresh(Renderer& renderer) {
 
       // Only lock this URL once we actually have an image.
       // Otherwise keep retrying while metadata/download catches up.
+            if (loaded && m_artworkBackground != nullptr && m_renderContext != nullptr) {
+        const auto artworkTexture = m_artwork->textureHandle();
+
+        if (artworkTexture.valid()) {
+          m_renderContext->backend().makeCurrentNoSurface();
+
+          const std::uint32_t blurWidth = static_cast<std::uint32_t>(artworkTexture.width);
+          const std::uint32_t blurHeight = static_cast<std::uint32_t>(artworkTexture.height);
+
+         const auto blurredTexture = m_artworkBlurCache.get(
+             m_renderContext->backend(),
+             artworkTexture,
+             blurWidth,
+             blurHeight,
+             8.0F,
+             1
+         );
+
+          if (blurredTexture.valid()) {
+            m_artworkBackground->setExternalTexture(renderer, blurredTexture);
+          }
+        }
+      }
+
       m_lastArtPath = loaded ? resolvedArtUrl : std::string{};
       if (loaded) {
         PanelManager::instance().requestLayout();
@@ -928,6 +969,31 @@ void MediaTab::refresh(Renderer& renderer) {
     } else if (m_lastTrackLengthUs > 0 && samePlayerAsDisplayed) {
       trackLengthUs = m_lastTrackLengthUs;
     }
+
+   auto formatTime = [](std::int64_t microseconds) -> std::string {
+     const auto totalSeconds = std::max<std::int64_t>(0, microseconds / 1000000);
+     const auto minutes = totalSeconds / 60;
+     const auto seconds = totalSeconds % 60;
+
+    return std::format("{:02}:{:02}", minutes, seconds);
+   };
+
+   if (m_trackAlbum != nullptr) {
+    if (trackLengthUs > 0) {
+      m_trackAlbum->setText(
+         std::format(
+             "{} / {}",
+             formatTime(displayPositionUs),
+             formatTime(trackLengthUs)
+         )
+      );
+       m_trackAlbum->setVisible(true);
+     } else {
+      m_trackAlbum->setText("");
+      m_trackAlbum->setVisible(false);
+     }
+   }
+
     const bool progressInteracting = m_progressSlider->dragging() || seekPending || withinProgressSettle;
     const bool progressEnabled = player.canSeek && (trackLengthUs > 0 || progressInteracting);
 

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -1,29 +1,54 @@
+#include "util/string_utils.h"
 #include "shell/control_center/tabs/media_tab.h"
 
+#include "util/string_utils.h"
 #include "config/config_service.h"
+#include "util/string_utils.h"
 #include "core/deferred_call.h"
+#include "util/string_utils.h"
 #include "core/log.h"
+#include "util/string_utils.h"
 #include "dbus/mpris/mpris_art.h"
+#include "util/string_utils.h"
 #include "dbus/mpris/mpris_service.h"
+#include "util/string_utils.h"
 #include "i18n/i18n.h"
+#include "util/string_utils.h"
 #include "net/http_client.h"
+#include "util/string_utils.h"
 #include "pipewire/pipewire_spectrum.h"
+#include "util/string_utils.h"
 #include "render/core/renderer.h"
+#include "util/string_utils.h"
 #include "render/render_context.h"
+#include "util/string_utils.h"
 #include "render/scene/node.h"
+#include "util/string_utils.h"
 #include "shell/control_center/tab.h"
+#include "util/string_utils.h"
 #include "shell/panel/panel_manager.h"
+#include "util/string_utils.h"
 #include "ui/builders.h"
+#include "util/string_utils.h"
 #include "ui/controls/context_menu.h"
+#include "util/string_utils.h"
 #include "ui/controls/context_menu_popup.h"
 
+#include "util/string_utils.h"
 #include <algorithm>
+#include "util/string_utils.h"
 #include <chrono>
+#include "util/string_utils.h"
 #include <cmath>
+#include "util/string_utils.h"
 #include <format>
+#include "util/string_utils.h"
 #include <memory>
+#include "util/string_utils.h"
 #include <string>
+#include "util/string_utils.h"
 #include <string_view>
+#include "util/string_utils.h"
 #include <vector>
 
 using namespace control_center;
@@ -928,7 +953,18 @@ void MediaTab::refresh(Renderer& renderer) {
       m_pendingSeekUs = -1;
     }
 
-    m_trackTitle->setText(player.title.empty() ? player.identity : player.title);
+    const auto truncateTrackTitle = [](const std::string& text) {
+      constexpr std::size_t kMaxChars = 25;
+      if (StringUtils::truncateUtf8CodePoints(text, kMaxChars).size() == text.size()) {
+        return text;
+      }
+      return StringUtils::truncateUtf8CodePoints(text, kMaxChars) + "...";
+    };
+
+    const std::string trackTitle = player.title.empty()
+        ? player.identity
+        : truncateTrackTitle(player.title);
+    m_trackTitle->setText(trackTitle);
     m_trackArtist->setText(joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists));
 
     const std::string resolvedArtUrl = effectiveArtUrl(player);

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -215,22 +215,16 @@ std::unique_ptr<Flex> MediaTab::create() {
       .configure = [scale, opacity = panelCardOpacity()](Flex& card) { applySectionCardStyle(card, scale, opacity); },
   });
 
-  auto nowHeader = ui::row(
+  
+      auto nowHeader = ui::row(
       {.align = FlexAlign::Center,
-       .justify = FlexJustify::SpaceBetween,
+       .justify = FlexJustify::End,
        .gap = Style::spaceSm * scale,
-       .minHeight = Style::controlHeightSm * scale},
-      ui::label({
-          .text = i18n::tr("control-center.media.now-playing"),
-          .fontSize = Style::fontSizeTitle * scale,
-          .fontWeight = FontWeight::Bold,
-          .color = colorSpecFromRole(ColorRole::OnSurface),
-          .flexGrow = 1.0F,
-      }),
-      ui::button({
+       .minHeight = Style::controlHeightSm * scale},      
+       ui::button({
           .out = &m_playerMenuButton,
           .glyph = "headphones",
-          .glyphSize = Style::fontSizeBody * scale,
+          .glyphSize = 20.0F * scale,
           .enabled = false,
           .variant = ButtonVariant::Ghost,
           .minWidth = Style::controlHeightSm * scale,
@@ -287,10 +281,13 @@ std::unique_ptr<Flex> MediaTab::create() {
           ui::label({
               .out = &m_trackTitle,
               .text = i18n::tr("control-center.media.nothing-playing"),
-              .fontSize = Style::fontSizeTitle * scale,
-              .fontWeight = FontWeight::Bold,
+              .fontSize = 14.0F * scale,
+              .fontWeight = FontWeight::SemiBold,
               .color = colorSpecFromRole(ColorRole::Primary),
-          }),
+              .maxLines = 1,
+              .autoScroll = true,
+              .autoScrollSpeed = 30.0F * scale,
+      }),
           ui::label({
               .out = &m_trackArtist,
               .text = i18n::tr("control-center.media.start-playback"),
@@ -574,7 +571,7 @@ void MediaTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
   }
 
   if (m_trackTitle != nullptr) {
-    m_trackTitle->setMaxWidth(mediaWidth);
+   m_trackTitle->setMaxWidth(mediaWidth * 0.70F);
   }
   if (m_trackArtist != nullptr) {
     m_trackArtist->setMaxWidth(mediaWidth);
@@ -953,17 +950,9 @@ void MediaTab::refresh(Renderer& renderer) {
       m_pendingSeekUs = -1;
     }
 
-    const auto truncateTrackTitle = [](const std::string& text) {
-      constexpr std::size_t kMaxChars = 25;
-      if (StringUtils::truncateUtf8CodePoints(text, kMaxChars).size() == text.size()) {
-        return text;
-      }
-      return StringUtils::truncateUtf8CodePoints(text, kMaxChars) + "...";
-    };
-
     const std::string trackTitle = player.title.empty()
         ? player.identity
-        : truncateTrackTitle(player.title);
+        : player.title;
     m_trackTitle->setText(trackTitle);
     m_trackArtist->setText(joinArtists(player.artists).empty() ? player.identity : joinArtists(player.artists));
 

--- a/src/shell/control_center/tabs/media_tab.h
+++ b/src/shell/control_center/tabs/media_tab.h
@@ -76,6 +76,8 @@ private:
   Label* m_trackTitle = nullptr;
   Label* m_trackArtist = nullptr;
   Label* m_trackAlbum = nullptr;
+  Label* m_progressCurrentTime = nullptr;
+  Label* m_progressTotalTime = nullptr;
   Slider* m_progressSlider = nullptr;
   Button* m_prevButton = nullptr;
   Button* m_playPauseButton = nullptr;

--- a/src/shell/control_center/tabs/media_tab.h
+++ b/src/shell/control_center/tabs/media_tab.h
@@ -3,6 +3,7 @@
 #include "core/timer_manager.h"
 #include "dbus/mpris/mpris_service.h"
 #include "shell/control_center/tab.h"
+#include "render/core/blur_cache.h"
 
 #include <chrono>
 #include <cstdint>
@@ -21,7 +22,6 @@ class MprisService;
 class PipeWireSpectrum;
 class RenderContext;
 class Slider;
-class AudioVisualizer;
 class ConfigService;
 class WaylandConnection;
 
@@ -61,15 +61,15 @@ private:
   RenderContext* m_renderContext = nullptr;
   std::uint64_t m_spectrumListenerId = 0;
   bool m_active = false;
+  float m_artworkPulse = 0.0F;
 
   Flex* m_rootLayout = nullptr;
   Flex* m_mediaColumn = nullptr;
-  Flex* m_visualizerColumn = nullptr;
-  Flex* m_visualizerBody = nullptr;
-  AudioVisualizer* m_visualizerSpectrum = nullptr;
-  Image* m_artwork = nullptr;
-  Flex* m_artworkRow = nullptr;
   Flex* m_nowCard = nullptr;
+  Image* m_artwork = nullptr;
+  Image* m_artworkBackground = nullptr;
+  BlurCache m_artworkBlurCache;
+  Flex* m_artworkRow = nullptr;
   Flex* m_mediaStack = nullptr;
   Button* m_playerMenuButton = nullptr;
   std::unique_ptr<ContextMenuPopup> m_playerMenuPopup;
@@ -82,6 +82,7 @@ private:
   Button* m_nextButton = nullptr;
   Button* m_repeatButton = nullptr;
   Button* m_shuffleButton = nullptr;
+
 
   std::string m_lastArtPath;
   std::string m_lastBusName;

--- a/src/shell/control_center/tabs/media_tab.h
+++ b/src/shell/control_center/tabs/media_tab.h
@@ -2,8 +2,8 @@
 
 #include "core/timer_manager.h"
 #include "dbus/mpris/mpris_service.h"
-#include "shell/control_center/tab.h"
 #include "render/core/blur_cache.h"
+#include "shell/control_center/tab.h"
 
 #include <chrono>
 #include <cstdint>
@@ -82,7 +82,6 @@ private:
   Button* m_nextButton = nullptr;
   Button* m_repeatButton = nullptr;
   Button* m_shuffleButton = nullptr;
-
 
   std::string m_lastArtPath;
   std::string m_lastBusName;

--- a/src/ui/controls/image.h
+++ b/src/ui/controls/image.h
@@ -67,6 +67,7 @@ public:
   [[nodiscard]] const std::string& sourcePath() const noexcept { return m_sourcePath; }
   [[nodiscard]] bool hasImage() const noexcept { return m_texture.valid(); }
   [[nodiscard]] TextureId textureId() const noexcept { return m_texture.id; }
+  [[nodiscard]] TextureHandle textureHandle() const noexcept { return m_texture; }
   [[nodiscard]] int sourceWidth() const noexcept { return m_texture.sourceWidth; }
   [[nodiscard]] int sourceHeight() const noexcept { return m_texture.sourceHeight; }
   [[nodiscard]] float aspectRatio() const noexcept {

--- a/src/ui/controls/slider.cpp
+++ b/src/ui/controls/slider.cpp
@@ -3,6 +3,8 @@
 #include "core/input/key_symbols.h"
 #include "core/input/keybind_matcher.h"
 #include "cursor-shape-v1-client-protocol.h"
+#include "render/animation/animation.h"
+#include "render/animation/animation_manager.h"
 #include "render/core/render_styles.h"
 #include "render/scene/input_area.h"
 #include "render/scene/rect_node.h"
@@ -226,6 +228,49 @@ void Slider::setWheelAdjustEnabled(bool enabled) { m_wheelAdjustEnabled = enable
 void Slider::setOnValueChanged(std::function<void(double)> callback) { m_onValueChanged = std::move(callback); }
 
 void Slider::setOnDragEnd(std::function<void()> callback) { m_onDragEnd = std::move(callback); }
+void Slider::setPlayingEffect(bool enabled) {
+  if (m_playingEffect == enabled) {
+    return;
+  }
+
+  m_playingEffect = enabled;
+
+  if (!enabled) {
+    if (animationManager() != nullptr && m_playingAnimId != 0) {
+      animationManager()->cancel(m_playingAnimId);
+    }
+
+    m_playingAnimId = 0;
+    m_playingPulse = 0.0F;
+    applyVisualState();
+    markPaintDirty();
+    return;
+  }
+
+  if (animationManager() == nullptr) {
+    return;
+  }
+
+  m_playingAnimId = animationManager()->animate(
+      0.0F, 1.0F, 1400.0F, Easing::EaseInOutCubic,
+      [this](float t) {
+        m_playingPulse = t;
+        applyVisualState();
+        markPaintDirty();
+      },
+      [this]() {
+        m_playingAnimId = 0;
+
+        if (m_playingEffect) {
+          setPlayingEffect(false);
+          setPlayingEffect(true);
+        }
+      },
+      this
+  );
+
+  markPaintDirty();
+}
 
 bool Slider::dragging() const noexcept { return m_inputArea != nullptr && m_inputArea->pressed(); }
 
@@ -305,6 +350,19 @@ void Slider::applyVisualState() {
     thumbBorder = resolved(ColorRole::Hover);
   }
 
+  if (m_playingEffect && m_enabled && !pressing) {
+    const float pulse =
+        0.5F
+        - 0.5F * std::cos(m_playingPulse * 2.0F * 3.14159265358979323846F);
+
+    fillColor = brighten(fillColor, 1.0F + pulse * 0.18F);
+
+    thumbBorder = brighten(
+        resolved(ColorRole::Primary),
+        1.0F + pulse * 0.35F
+    );
+  }
+
   auto trackStyle = solidStyle(trackColor, m_trackHeight * 0.5F);
   m_track->setStyle(trackStyle);
 
@@ -313,7 +371,18 @@ void Slider::applyVisualState() {
 
   auto thumbStyle = solidStyle(thumbColor, m_thumbSizePx * 0.5F);
   thumbStyle.border = thumbBorder;
-  thumbStyle.borderWidth = focused ? Style::focusRingWidth : Style::borderWidth;
+
+  if (m_playingEffect && m_enabled && !pressing) {
+    const float pulse =
+        0.5F
+        - 0.5F * std::cos(m_playingPulse * 2.0F * 3.14159265358979323846F);
+
+    thumbStyle.borderWidth =
+        Style::borderWidth + pulse * Style::borderWidth * 1.5F;
+  } else {
+    thumbStyle.borderWidth = focused ? Style::focusRingWidth : Style::borderWidth;
+  }
+
   m_thumb->setStyle(thumbStyle);
 }
 

--- a/src/ui/controls/slider.cpp
+++ b/src/ui/controls/slider.cpp
@@ -261,10 +261,27 @@ void Slider::setPlayingEffect(bool enabled) {
       [this]() {
         m_playingAnimId = 0;
 
-        if (m_playingEffect) {
-          setPlayingEffect(false);
-          setPlayingEffect(true);
+        if (!m_playingEffect) {
+          return;
         }
+
+        m_playingPulse = 0.0F;
+        applyVisualState();
+        markPaintDirty();
+
+        m_playingAnimId = animationManager()->animateTimer(
+            0.0F, 0.0F, 500.0F, Easing::Linear,
+            [](float) {},
+            [this]() {
+              m_playingAnimId = 0;
+
+              if (m_playingEffect) {
+                m_playingEffect = false;
+                setPlayingEffect(true);
+              }
+            },
+            this
+        );
       },
       this
   );
@@ -351,19 +368,26 @@ void Slider::applyVisualState() {
   }
 
   if (m_playingEffect && m_enabled && !pressing) {
-    const float pulse =
-        0.5F
-        - 0.5F * std::cos(m_playingPulse * 2.0F * 3.14159265358979323846F);
+    const float pulse = [&]() {
+      if (m_playingPulse <= 0.5F) {
+        const float t = m_playingPulse * 2.0F;
+        return 0.5F - 0.5F * std::cos(t * 3.14159265358979323846F);
+      }
+
+      const float t = (m_playingPulse - 0.5F) * 2.0F;
+      return 1.0F - t * t * t;
+    }();
 
     fillColor = brighten(fillColor, 1.0F + pulse * 0.18F);
 
     thumbBorder = brighten(
         resolved(ColorRole::Primary),
-        1.0F + pulse * 0.35F
+        1.0F + pulse * 0.30F
     );
   }
 
-  auto trackStyle = solidStyle(trackColor, m_trackHeight * 0.5F);
+
+    auto trackStyle = solidStyle(trackColor, m_trackHeight * 0.5F);
   m_track->setStyle(trackStyle);
 
   auto fillStyle = solidStyle(fillColor, m_trackHeight * 0.5F);
@@ -372,15 +396,22 @@ void Slider::applyVisualState() {
   auto thumbStyle = solidStyle(thumbColor, m_thumbSizePx * 0.5F);
   thumbStyle.border = thumbBorder;
 
-  if (m_playingEffect && m_enabled && !pressing) {
-    const float pulse =
-        0.5F
-        - 0.5F * std::cos(m_playingPulse * 2.0F * 3.14159265358979323846F);
+    if (m_playingEffect && m_enabled && !pressing) {
+    const float pulse = [&]() {
+      if (m_playingPulse <= 0.5F) {
+        const float t = m_playingPulse * 2.0F;
+        return 0.5F - 0.5F * std::cos(t * 3.14159265358979323846F);
+      }
+
+      const float t = (m_playingPulse - 0.5F) * 2.0F;
+      return 1.0F - t * t * t;
+    }();
 
     thumbStyle.borderWidth =
         Style::borderWidth + pulse * Style::borderWidth * 1.5F;
   } else {
-    thumbStyle.borderWidth = focused ? Style::focusRingWidth : Style::borderWidth;
+    thumbStyle.borderWidth =
+        focused ? Style::focusRingWidth : Style::borderWidth;
   }
 
   m_thumb->setStyle(thumbStyle);

--- a/src/ui/controls/slider.h
+++ b/src/ui/controls/slider.h
@@ -3,6 +3,7 @@
 #include "ui/controls/flex.h"
 #include "ui/style.h"
 
+#include <cstdint>
 #include <functional>
 
 class InputArea;
@@ -21,6 +22,7 @@ public:
   void setControlHeight(float height);
   void setWheelAdjustEnabled(bool enabled);
   void setOnValueChanged(std::function<void(double)> callback);
+  void setPlayingEffect(bool enabled);
   void setOnDragEnd(std::function<void()> callback);
 
   [[nodiscard]] double value() const noexcept { return m_value; }
@@ -57,4 +59,7 @@ private:
   float m_trackHeight = Style::sliderTrackHeight;
   float m_thumbSizePx = Style::sliderThumbSize;
   float m_controlHeightPx = Style::controlHeight;
+  bool m_playingEffect = false;
+  float m_playingPulse = 0.0F;
+  std::uint64_t m_playingAnimId = 0;
 };


### PR DESCRIPTION
## Summary

Improve the Media tab artwork and playback controls with a more polished and consistent layout. The artwork is centered, media controls are arranged horizontally, and the artwork background blur is updated more efficiently.

## Motivation

The previous Media tab layout could feel unbalanced and the artwork blur updates could be unnecessarily expensive during media changes. This improves the visual presentation of the Media tab while reducing unnecessary blur update work.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [x] Refactoring
* [ ] Build / packaging

## Testing

* Built the project successfully from the updated branch.
* Tested the Media tab manually.
* Verified artwork positioning, playback controls, and artwork blur behavior.

## Manual Coverage

* [x] Tested on Niri
* [x] Tested on Hyprland
* [ ] Tested on Sway
* [ ] Tested on another compositor:
* [ ] Tested with different bar positions and density settings
* [ ] Tested at different interface scaling values
* [ ] Tested with multiple monitors

## Screenshots / Videos

The Media tab UI changes are visible in the attached screenshots/video.

## Checklist

* [x] This PR is ready for review, or it is marked as Draft.
* [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
* [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
* [x] I ran the relevant build or test commands, or explained why they were not run.
* [x] I self-reviewed the changes.
* [x] I checked for new warnings or errors.
* [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
* [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
* [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
* [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

This PR is intentionally separate from the existing media controls changes in #4159 and focuses on the Media tab artwork, controls, and blur update behavior.



https://github.com/user-attachments/assets/6e8b79cf-e415-4f54-8b57-7ba705ba2049



