### PR TITLE
fix(uri): preserve percent escapes in plain local paths

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1226,6 +1226,7 @@ if build_tests
     'ui_tree_reconciler',
     'upower_charge_limit',
     'upower_device_catalog',
+    'uri',
     'vdir_reader',
     'virtual_grid_view_gesture',
     'wallpaper_shuffle_state',

--- a/src/net/uri.cpp
+++ b/src/net/uri.cpp
@@ -74,8 +74,9 @@ namespace uri {
         const auto firstSlash = path.find('/');
         path = firstSlash == std::string::npos ? std::string{} : path.substr(firstSlash);
       }
+      return decodeComponent(path);
     }
-    return decodeComponent(path);
+    return path;
   }
 
 } // namespace uri

--- a/tests/uri_test.cpp
+++ b/tests/uri_test.cpp
@@ -1,0 +1,152 @@
+#include "dbus/mpris/mpris_art.h"
+#include "dbus/notification/notification_service.h"
+#include "net/uri.h"
+#include "notification/notification_history_store.h"
+#include "notification/notification_manager.h"
+#include "render/core/image_encoder.h"
+#include "render/core/image_file_loader.h"
+#include "tests/test_check.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <print>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+  struct TempDirectory {
+    std::filesystem::path path;
+
+    TempDirectory() {
+      std::string pattern = (std::filesystem::temp_directory_path() / "noctalia-uri-consumers-XXXXXX").string();
+      const char* created = mkdtemp(pattern.data());
+      TEST_CHECK(created != nullptr);
+      path = created;
+    }
+
+    ~TempDirectory() {
+      std::error_code ec;
+      std::filesystem::remove_all(path, ec);
+    }
+  };
+
+  void writePixel(const std::filesystem::path& path, const std::vector<std::uint8_t>& pixel) {
+    const auto png = encodePng(pixel.data(), 1, 1);
+    TEST_CHECK(!png.empty());
+    std::ofstream file(path, std::ios::binary);
+    file.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+    file.close();
+    TEST_CHECK(file.good());
+  }
+
+  bool check(bool condition, const std::string& context) {
+    if (!condition) {
+      std::println(stderr, "uri_test: {}", context);
+    }
+    return condition;
+  }
+
+  bool expectPath(std::string_view input, std::string_view expected) {
+    const auto actual = uri::normalizeFileUrl(input);
+    return check(actual == expected, "unexpected normalized path for " + std::string(input));
+  }
+
+} // namespace
+
+int main() {
+  TempDirectory temp;
+  const auto literal = temp.path / "icon%20name.png";
+  const auto space = temp.path / "icon name.png";
+  const std::vector<std::uint8_t> green{0, 255, 0, 255};
+  const std::vector<std::uint8_t> red{255, 0, 0, 255};
+  writePixel(literal, green);
+  writePixel(space, red);
+
+  struct Case {
+    std::string input;
+    std::vector<std::uint8_t> expected;
+  };
+  const std::vector<Case> cases{
+      {literal.string(), green},
+      {space.string(), red},
+      {"file://" + (temp.path / "icon%2520name.png").string(), green},
+      {"file://" + (temp.path / "icon%20name.png").string(), red},
+  };
+
+  bool ok = true;
+  // Keep cases that do not require file loading, including icon names and
+  // unsupported inputs. Native paths and file URIs are exercised below.
+  ok = expectPath("/tmp/icon%2Fname.png", "/tmp/icon%2Fname.png") && ok;
+  ok = expectPath("/tmp/icon%00name.png", "/tmp/icon%00name.png") && ok;
+  ok = expectPath("/tmp/100% ready.png", "/tmp/100% ready.png") && ok;
+  ok = expectPath("icon%20name", "icon%20name") && ok;
+  ok = expectPath("file://localhost/tmp/icon%20name.png", "/tmp/icon name.png") && ok;
+  ok = expectPath("file:///tmp/icon%2bname.png", "/tmp/icon+name.png") && ok;
+  ok = expectPath("", "") && ok;
+  ok = expectPath("http://example.com/icon.png", "") && ok;
+  ok = expectPath("https://example.com/icon.png", "") && ok;
+
+  NotificationManager manager;
+  std::map<std::uint32_t, std::vector<std::uint8_t>> expectedSnapshots;
+  for (const auto& test : cases) {
+    // Resolve artwork through the consumer and decode the selected file, so a
+    // different existing filename cannot silently satisfy the test.
+    std::unordered_set<std::string> pending;
+    const auto artPath = mpris::resolveArtworkSource(nullptr, pending, test.input, []() {}, {});
+    const auto image = loadImageFile(artPath);
+    ok = check(
+             image && image->width == 1 && image->height == 1 && image->rgba == test.expected,
+             "wrong MPRIS artwork pixels for " + test.input
+         )
+        && ok;
+
+    for (const char* key : {"image-path", "image_path"}) {
+      const std::map<std::string, sdbus::Variant> hints{{key, sdbus::Variant(test.input)}};
+      const auto id = notification_dbus::ingestNotify(manager, "uri-test", 0, "", test.input, "", {}, hints, 0);
+      expectedSnapshots.emplace(id, test.expected);
+      const auto& notification = manager.all().back();
+      TEST_CHECK(notification.id == id);
+      const auto& snapshot = notification.imageData;
+      ok = check(
+               snapshot && snapshot->width == 1 && snapshot->height == 1 && snapshot->data == test.expected,
+               std::string("wrong notification snapshot for ") + key + ": " + test.input
+           )
+          && ok;
+      TEST_CHECK(manager.close(id, CloseReason::Expired));
+    }
+  }
+
+  // History must keep the captured pixels even after the original images vanish.
+  std::filesystem::remove(literal);
+  std::filesystem::remove(space);
+  const auto historyFile = temp.path / "history.json";
+  TEST_CHECK(saveNotificationHistoryToFile(historyFile, manager.history(), 100, manager.changeSerial()));
+  std::deque<NotificationHistoryEntry> restored;
+  std::uint32_t nextId = 0;
+  std::uint64_t serial = 0;
+  TEST_CHECK(loadNotificationHistoryFromFile(historyFile, restored, nextId, serial));
+  TEST_CHECK(restored.size() == expectedSnapshots.size());
+  for (const auto& entry : restored) {
+    const auto& snapshot = entry.notification.imageData;
+    const auto& expected = expectedSnapshots.at(entry.notification.id);
+    bool matches =
+        snapshot && snapshot->width == 1 && snapshot->height == 1 && snapshot->data.size() == expected.size();
+    if (matches) {
+      // History uses lossy WebP; allow small color changes while distinguishing
+      // the red and green source files unambiguously.
+      for (std::size_t i = 0; i < expected.size(); ++i) {
+        matches = std::abs(static_cast<int>(snapshot->data[i]) - static_cast<int>(expected[i])) <= 16 && matches;
+      }
+    }
+    ok = check(matches, "wrong persisted snapshot for " + entry.notification.summary) && ok;
+  }
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Only percent-decode `file://` inputs in `uri::normalizeFileUrl`, preserving plain filesystem paths and icon names verbatim. Add a regression test and register it with Meson.

The change applies to all four consumers of this shared helper:

- Notification toast icons.
- Icons displayed in notification history.
- Notification image snapshots loaded from `image-path` / `image_path` hints.
- MPRIS artwork resolution.

## Motivation

Noctalia already supports absolute filesystem paths for notification icons. The existing [notification test script](https://github.com/noctalia-dev/noctalia/blob/29f66472fb7600cb8aa55b4958d4d81c254343f9/tools/notifications-test.sh#L20-L26) explicitly exercises both `/usr/share/pixmaps/steam.png` and `file:///usr/share/pixmaps/steam.png`.

The [notification service](https://github.com/noctalia-dev/noctalia/blob/29f66472fb7600cb8aa55b4958d4d81c254343f9/src/dbus/notification/notification_service.cpp#L244-L263) forwards icon values without URI encoding. The [toast icon resolver](https://github.com/noctalia-dev/noctalia/blob/29f66472fb7600cb8aa55b4958d4d81c254343f9/src/shell/notification/notification_toast.cpp#L3009-L3015) then normalizes them and uses the resulting absolute path for filesystem access.

[RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1) defines percent-encoding for URI components, and [RFC 8089 §4](https://www.rfc-editor.org/rfc/rfc8089.html#section-4) describes its use when representing filesystem names as file URIs. Native Linux pathnames follow the byte-based rules documented in [pathname(7)](https://man7.org/linux/man-pages/man7/pathname.7.html); `%20` in a native filename is a literal sequence, not an encoded space.

Previously, `/tmp/icon%20name.png` was incorrectly converted to `/tmp/icon name.png`, potentially selecting a different file or failing to find the requested image. This fix preserves literal percent sequences in plain paths while retaining decoding for `file://` inputs.

## Type of Change

- [x] Bug fix

## Testing

The `uri` regression test fails with the original URI implementation and passes with the fix. It covers:

- Normalization edge cases, including literal `%2F` and `%00`, icon names, localhost file URIs, lowercase hex escapes, empty input, and HTTP(S) rejection.
- MPRIS artwork resolution followed by decoding the selected file and checking its pixels.
- Notification ingestion with both `image-path` and `image_path`, checking the captured pixels.
- Saving and restoring notification history after removing the source images. Restored colors allow a small tolerance because history uses lossy WebP compression.

Two distinct PNG files ensure that accidentally selecting the filename containing a space cannot pass as a successful load. Both native paths and encoded file URIs are exercised. A separate filesystem reproduction also confirmed that the original code opened the wrong file, while the fixed code opened the requested file.

Completed local CI checks:

- `just format` with clang-format 22.1.8.
- `just build`: debug build passed.
- `just test debug --print-errorlogs`: all 113 tests passed, including `uri`.
- `just lint`: all 572 production translation units passed.
- `clang-tidy -p build-debug tests/uri_test.cpp --warnings-as-errors='*'`: passed.
- `git diff --check`: passed.

All four affected consumers were also exercised with the fixed debug build on Niri 26.04 running as a nested Wayland compositor, using isolated configuration and private D-Bus sessions:

1. Notification toasts: icon values were sent directly through D-Bus in the `app_icon` argument.
2. Notification history: those toasts were dismissed and their icons were checked in the history panel.
3. Notification `image-path`: PNG paths were sent in the hint with an empty `app_icon`. The original PNG files were then deleted before capturing the displayed notifications.
4. MPRIS artwork: a test D-Bus player exported each input as `mpris:artUrl` and emitted metadata changes. The artwork was checked in Noctalia's media panel.

Each visual check used two distinct image files: a green check and a red cross. All three inputs produced the expected result:

| Input | Expected and observed image |
| --- | --- |
| Native path containing literal `%20` | Green check |
| File URI containing `%2520` | Green check |
| File URI containing `%20` | Red cross from the filename containing a space |

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

**1. Notification toasts (`app_icon`)**

<img width="390" height="320" alt="Notification toasts with the fixed build" src="https://github.com/user-attachments/assets/0e4b7291-c095-4ee4-a453-b30bc36f4d14" />

**2. Notification history**

The same notifications after dismissing the toasts, shown newest first.

<img width="620" height="530" alt="02-notification-history" src="https://github.com/user-attachments/assets/366e5e10-3e7b-4144-a00d-73a3dbc1a16b" />

**3. Notification image-path**

Notifications sent with an empty `app_icon` and an `image-path` hint. Source PNG files were removed after notification ingestion.

<img width="390" height="320" alt="03-image-path" src="https://github.com/user-attachments/assets/acb3b414-4519-4102-8183-54554d6ba050" />

**4. MPRIS artwork**

Three cropped captures from the media panel, placed side by side in input order. The captures show sequential states of the same test player.

<img width="1020" height="460" alt="04-mpris" src="https://github.com/user-attachments/assets/22b3b9c4-bc43-408f-86f3-a9f839e9aa0a" />

The red cross is the expected test image for the filename containing a space. Screenshots are crops of the actual Noctalia session.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
