### PR TITLE
fix(dock): release the input region when hiding starts

### DIFF
--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -152,9 +152,7 @@ namespace shell::dock {
       return;
     }
 
-    const bool fullSurface = instance.pointerInside
-        || instance.hideOpacity > 0.5F
-        || (cfg.smartAutoHide && instance.smartAutoHidePinnedVisible);
+    const bool fullSurface = instance.pointerInside || (cfg.smartAutoHide && instance.smartAutoHidePinnedVisible);
     if (fullSurface) {
       instance.surface->setInputRegion({InputRect{0, 0, surfW, surfH}});
       return;
@@ -426,14 +424,9 @@ namespace shell::dock {
           syncDockSlideLayerTransform(inst, cfg);
           applyDockCompositorBlur(inst, cfg);
         },
-        [&inst, &config]() {
-          inst.hideAnimId = 0;
-          if (inst.surface == nullptr) {
-            return;
-          }
-          syncDockAutoHideInputRegion(inst, config.config().dock, DockPanelGeometry{});
-        }
+        [&inst]() { inst.hideAnimId = 0; }
     );
+    syncDockAutoHideInputRegion(inst, config.config().dock, DockPanelGeometry{});
     if (inst.surface) {
       inst.surface->requestRedraw();
     }


### PR DESCRIPTION
## Summary

Limit the auto-hide input region to the screen-edge strip when hiding starts.

## Motivation

With auto-hide enabled and an edge margin or shadow, reveal the dock, move away, then quickly return to its transparent margin without reaching the screen edge. The dock captures the pointer and reopens over controls in the underlying window. The hiding animation should already let that input reach the window.

## Type of Change

- [x] Bug fix

## Testing

`just format` with clang-format 22.1.8 and a GCC 15 `debugoptimized` build with `-Dwerror=true` pass. All five selected tests pass:

```sh
meson test -C build-review --no-rebuild animation_manager dock_edge_overlap dock_pinned_apps config_schema_roundtrip config_validate_cli
```

In isolated headless Umbriel at 1920x1080 and UI scale 1.25, returning 110 px above the bottom edge during hiding no longer enters the dock surface. Edge reveal remains immediate. Tested with pointer and smart auto-hide; closing the last window still reveals the smart dock.

The additional strict clang-tidy check fails on the same unchanged `config_migrations.h:29` defaulted equality operator as the baseline, with no new diagnostics. Full lint was not run.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
