### PR TITLE
fix(plugins): inherit widget colors in bar UI

### DIFF
--- a/docs/user/plugins/development/declarative-ui.mdx
+++ b/docs/user/plugins/development/declarative-ui.mdx
@@ -43,7 +43,8 @@ share this vocabulary** - panels additionally use the interactive controls below
 
 `ui.label` and `ui.glyph` inherit the host's text defaults when a prop is unset: in a bar widget they use the bar's
 (or widget's) `font_family`/`font_weight` and the widget `scale`, matching the imperative `barWidget.setText` look.
-An explicit `fontSize`/`size`/`fontWeight`/`fontFamily` prop overrides the default. In bar widgets, `ui.button` renders compact:
+Labels without `color` use the widget foreground, while glyphs without `color` use the widget icon color. An explicit
+`fontSize`/`size`/`fontWeight`/`fontFamily`/`color` prop overrides the default. In bar widgets, `ui.button` renders compact:
 it hugs its content instead of using the taller settings-panel control height (pass `width`/`height` or `controlSize`
 to size it explicitly).
 

--- a/docs/user/plugins/development/declarative-ui.mdx
+++ b/docs/user/plugins/development/declarative-ui.mdx
@@ -43,10 +43,11 @@ share this vocabulary** - panels additionally use the interactive controls below
 
 `ui.label` and `ui.glyph` inherit the host's text defaults when a prop is unset: in a bar widget they use the bar's
 (or widget's) `font_family`/`font_weight` and the widget `scale`, matching the imperative `barWidget.setText` look.
-Labels without `color` use the widget foreground, while glyphs without `color` use the widget icon color. An explicit
-`fontSize`/`size`/`fontWeight`/`fontFamily`/`color` prop overrides the default. In bar widgets, `ui.button` renders compact:
-it hugs its content instead of using the taller settings-panel control height (pass `width`/`height` or `controlSize`
-to size it explicitly).
+There, labels without `color` also use the widget foreground and glyphs without `color` use the widget icon color;
+in panels and desktop widgets an unset `color` stays `on_surface`. An explicit
+`fontSize`/`size`/`fontWeight`/`fontFamily`/`color` prop overrides the default. In bar widgets, `ui.button` renders
+compact: it hugs its content instead of using the taller settings-panel control height (pass `width`/`height` or
+`controlSize` to size it explicitly).
 
 | Constructor | Props |
 |-------------|-------|

--- a/src/shell/bar/widgets/plugin_widget.cpp
+++ b/src/shell/bar/widgets/plugin_widget.cpp
@@ -337,6 +337,8 @@ void PluginWidget::doLayout(Renderer& renderer, float containerWidth, float cont
     m_reconciler.setScale(contentScale());
     m_reconciler.setFontScale(fontScaleMultiplier());
     m_reconciler.setTextDefaults(labelFontFamily(), labelFontWeight());
+    const ColorSpec fallback = colorSpecFromRole(ColorRole::OnSurface);
+    m_reconciler.setColorDefaults(widgetForegroundOr(fallback), widgetIconColorOr(fallback));
     (void)m_reconciler.reconcile(*m_uiHost, *m_tree, renderer);
     m_uiHost->layout(renderer);
     if (m_area)
@@ -344,7 +346,8 @@ void PluginWidget::doLayout(Renderer& renderer, float containerWidth, float cont
     return;
   }
 
-  m_label->setColor(resolveScriptColor(m_textColor));
+  const ColorSpec fallback = colorSpecFromRole(ColorRole::OnSurface);
+  m_label->setColor(resolveScriptColor(m_textColor, widgetForegroundOr(fallback)));
   m_label->setFontWeight(labelFontWeight());
   m_label->setVisible(!m_label->text().empty());
   if (m_label->visible()) {
@@ -352,7 +355,7 @@ void PluginWidget::doLayout(Renderer& renderer, float containerWidth, float cont
   }
 
   if (m_glyphVisible) {
-    m_glyph->setColor(resolveScriptColor(m_glyphColor));
+    m_glyph->setColor(resolveScriptColor(m_glyphColor, widgetIconColorOr(fallback)));
     m_glyph->measure(renderer);
   }
 
@@ -534,17 +537,16 @@ PluginWidget::dispatchIpc(std::string_view event, std::string_view payload, cons
   return DispatchResult::Handled;
 }
 
-ColorSpec PluginWidget::resolveScriptColor(const ScriptColorState& state) const noexcept {
-  const ColorSpec fallback = colorSpecFromRole(ColorRole::OnSurface);
+ColorSpec PluginWidget::resolveScriptColor(const ScriptColorState& state, const ColorSpec& defaultColor) noexcept {
   if (!state.color.has_value()) {
-    return widgetForegroundOr(fallback);
+    return defaultColor;
   }
   if (!state.color->role.has_value()
       || state.mode == ScriptColorMode::Script
       || *state.color->role != ColorRole::OnSurface) {
     return *state.color;
   }
-  return widgetForegroundOr(fallback);
+  return defaultColor;
 }
 
 PluginWidget::ScriptColorMode PluginWidget::scriptColorModeFromToken(std::string_view token) noexcept {

--- a/src/shell/bar/widgets/plugin_widget.cpp
+++ b/src/shell/bar/widgets/plugin_widget.cpp
@@ -330,6 +330,8 @@ void PluginWidget::doLayout(Renderer& renderer, float containerWidth, float cont
   if (!m_flex)
     return;
 
+  const ColorSpec fallback = colorSpecFromRole(ColorRole::OnSurface);
+
   m_flex->setDirection(m_isVertical ? FlexDirection::Vertical : FlexDirection::Horizontal);
 
   if (m_tree.has_value() && m_uiHost != nullptr) {
@@ -337,7 +339,6 @@ void PluginWidget::doLayout(Renderer& renderer, float containerWidth, float cont
     m_reconciler.setScale(contentScale());
     m_reconciler.setFontScale(fontScaleMultiplier());
     m_reconciler.setTextDefaults(labelFontFamily(), labelFontWeight());
-    const ColorSpec fallback = colorSpecFromRole(ColorRole::OnSurface);
     m_reconciler.setColorDefaults(widgetForegroundOr(fallback), widgetIconColorOr(fallback));
     (void)m_reconciler.reconcile(*m_uiHost, *m_tree, renderer);
     m_uiHost->layout(renderer);
@@ -346,7 +347,6 @@ void PluginWidget::doLayout(Renderer& renderer, float containerWidth, float cont
     return;
   }
 
-  const ColorSpec fallback = colorSpecFromRole(ColorRole::OnSurface);
   m_label->setColor(resolveScriptColor(m_textColor, widgetForegroundOr(fallback)));
   m_label->setFontWeight(labelFontWeight());
   m_label->setVisible(!m_label->text().empty());
@@ -537,6 +537,9 @@ PluginWidget::dispatchIpc(std::string_view event, std::string_view payload, cons
   return DispatchResult::Handled;
 }
 
+// `on_surface` from an imperative setColor/setGlyphColor means "host default", so the widget's
+// `color`/`icon_color` still applies; a `script` mode color or any other role is taken literally.
+// The declarative path has no such sentinel: `ui.label{color = "on_surface"}` stays on_surface.
 ColorSpec PluginWidget::resolveScriptColor(const ScriptColorState& state, const ColorSpec& defaultColor) noexcept {
   if (!state.color.has_value()) {
     return defaultColor;

--- a/src/shell/bar/widgets/plugin_widget.h
+++ b/src/shell/bar/widgets/plugin_widget.h
@@ -82,7 +82,8 @@ private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
 
-  [[nodiscard]] ColorSpec resolveScriptColor(const ScriptColorState& state) const noexcept;
+  [[nodiscard]] static ColorSpec
+  resolveScriptColor(const ScriptColorState& state, const ColorSpec& defaultColor) noexcept;
   [[nodiscard]] static ScriptColorMode scriptColorModeFromToken(std::string_view token) noexcept;
   [[nodiscard]] static std::optional<ColorSpec> scriptColorFromToken(std::string_view token) noexcept;
   [[nodiscard]] std::filesystem::path resolvePluginPath(std::string_view path) const;

--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -1293,6 +1293,8 @@ namespace ui {
       }
       if (auto color = parseColor(desired, "color")) {
         label->setColor(*color);
+      } else {
+        label->setColor(m_defaultLabelColor);
       }
       if (auto weight = parseFontWeight(desired)) {
         label->setFontWeight(*weight);
@@ -1323,6 +1325,8 @@ namespace ui {
       }
       if (auto color = parseColor(desired, "color")) {
         glyph->setColor(*color);
+      } else {
+        glyph->setColor(m_defaultGlyphColor);
       }
       return;
     }

--- a/src/ui/ui_tree_reconciler.h
+++ b/src/ui/ui_tree_reconciler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ui/palette.h"
+
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -86,6 +88,11 @@ namespace ui {
       m_defaultFontFamily = std::move(fontFamily);
       m_defaultFontWeight = fontWeight;
     }
+    // Host colors for labels and glyphs whose tree nodes leave color unset.
+    void setColorDefaults(ColorSpec labelColor, ColorSpec glyphColor) {
+      m_defaultLabelColor = std::move(labelColor);
+      m_defaultGlyphColor = std::move(glyphColor);
+    }
     // Compact control chrome for space-tight hosts (bar widgets): buttons drop
     // the settings-tier min-height/padding and hug their content instead.
     void setCompactControls(bool compact) { m_compactControls = compact; }
@@ -140,6 +147,8 @@ namespace ui {
     float m_fontScale = 1.0F;
     std::string m_defaultFontFamily;
     FontWeight m_defaultFontWeight; // initialized in the ctor (opaque enum here)
+    ColorSpec m_defaultLabelColor = colorSpecFromRole(ColorRole::OnSurface);
+    ColorSpec m_defaultGlyphColor = colorSpecFromRole(ColorRole::OnSurface);
     bool m_compactControls = false;
     bool m_dragDropEnabled = false;
     // The node currently reporting hover, with the callback and key it opened

--- a/src/ui/ui_tree_reconciler.h
+++ b/src/ui/ui_tree_reconciler.h
@@ -89,9 +89,9 @@ namespace ui {
       m_defaultFontWeight = fontWeight;
     }
     // Host colors for labels and glyphs whose tree nodes leave color unset.
-    void setColorDefaults(ColorSpec labelColor, ColorSpec glyphColor) {
-      m_defaultLabelColor = std::move(labelColor);
-      m_defaultGlyphColor = std::move(glyphColor);
+    void setColorDefaults(const ColorSpec& labelColor, const ColorSpec& glyphColor) {
+      m_defaultLabelColor = labelColor;
+      m_defaultGlyphColor = glyphColor;
     }
     // Compact control chrome for space-tight hosts (bar widgets): buttons drop
     // the settings-tier min-height/padding and hug their content instead.

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -1,6 +1,7 @@
 #include "render/backend/render_backend.h"
 #include "render/core/renderer.h"
 #include "render/core/texture_manager.h"
+#include "render/scene/glyph_node.h"
 #include "render/scene/input_area.h"
 #include "render/scene/rect_node.h"
 #include "ui/controls/box.h"
@@ -8,6 +9,7 @@
 #include "ui/controls/drag_source.h"
 #include "ui/controls/drop_zone.h"
 #include "ui/controls/flex.h"
+#include "ui/controls/glyph.h"
 #include "ui/controls/graph.h"
 #include "ui/controls/input.h"
 #include "ui/controls/label.h"
@@ -191,6 +193,53 @@ int main() {
       ok = expect(column->children().size() == 1, "children removed") && ok;
       ok = expect(column->children()[0].get() == labelBefore, "surviving child reused on removal") && ok;
     }
+  }
+
+  // Host label/glyph colors apply only while the tree leaves color unset.
+  {
+    ui::UiTreeReconciler reconciler;
+    Flex host;
+    const Color labelDefault = rgbHex(0x112233);
+    const Color glyphDefault = rgbHex(0x445566);
+    reconciler.setColorDefaults(fixedColorSpec(labelDefault), fixedColorSpec(glyphDefault));
+
+    ui::UiTreeNode tree = makeNode("row");
+    tree.children.push_back(makeLabel("Default"));
+    ui::UiTreeNode glyphNode = makeNode("glyph");
+    glyphNode.props.emplace("name", std::string("cpu"));
+    tree.children.push_back(std::move(glyphNode));
+    (void)reconciler.reconcile(host, tree, renderer);
+
+    auto* row = dynamic_cast<Flex*>(host.children().front().get());
+    auto* label = row != nullptr ? dynamic_cast<Label*>(row->children()[0].get()) : nullptr;
+    auto* glyph = row != nullptr ? dynamic_cast<Glyph*>(row->children()[1].get()) : nullptr;
+    auto* renderedGlyph = glyph != nullptr ? findFirst<GlyphNode>(*glyph) : nullptr;
+    ok = expect(label != nullptr && label->color() == labelDefault, "label inherits host color") && ok;
+    ok = expect(renderedGlyph != nullptr && renderedGlyph->color() == glyphDefault, "glyph inherits host color") && ok;
+
+    const Color explicitLabel = rgbHex(0x778899);
+    const Color explicitGlyph = rgbHex(0xAABBCC);
+    tree.children[0].props["color"] = std::string("#778899");
+    tree.children[1].props["color"] = std::string("#aabbcc");
+    (void)reconciler.reconcile(host, tree, renderer);
+    ok = expect(label != nullptr && label->color() == explicitLabel, "explicit label color overrides host color") && ok;
+    ok = expect(
+             renderedGlyph != nullptr && renderedGlyph->color() == explicitGlyph,
+             "explicit glyph color overrides host color"
+         )
+        && ok;
+
+    const Color nextLabelDefault = rgbHex(0x102030);
+    const Color nextGlyphDefault = rgbHex(0x405060);
+    reconciler.setColorDefaults(fixedColorSpec(nextLabelDefault), fixedColorSpec(nextGlyphDefault));
+    tree.children[0].props.erase("color");
+    tree.children[1].props.erase("color");
+    (void)reconciler.reconcile(host, tree, renderer);
+    ok = expect(label != nullptr && label->color() == nextLabelDefault, "label restores changed host color") && ok;
+    ok = expect(
+             renderedGlyph != nullptr && renderedGlyph->color() == nextGlyphDefault, "glyph restores changed host color"
+         )
+        && ok;
   }
 
   // Keyed reorder reuses control instances.


### PR DESCRIPTION
## Summary

- Make declarative plugin labels inherit the bar widget's configured foreground color when `color` is omitted.
- Make declarative and imperative plugin glyphs inherit the widget's configured icon color independently.
- Preserve explicit node colors and reset retained nodes to host defaults when an explicit color is removed.
- Document the inheritance behavior and cover it with a reconciler regression test.

## Motivation

`barWidget.render()` already inherited font weight and scale from the widget editor, but its label and glyph nodes defaulted directly to `on_surface`. As a result, the standard Color and Icon color controls did not style declarative plugin content. The imperative glyph path also used the foreground color instead of the icon color.

This surfaced in https://github.com/noctalia-dev/community-plugins/issues/634 while testing the System Monitor plugin.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Related to https://github.com/noctalia-dev/community-plugins/issues/634

## Testing

- `just format` with clang-format 22.1.8
- `meson compile -C build-debug ui_tree_reconciler_test`
- `meson test -C build-debug ui_tree_reconciler --print-errorlogs`
- Full Meson suite: 108 tests passed in the sandbox; the four socket/DBus-dependent tests were rerun outside the sandbox and passed, for 112/112 total
- `meson compile -C build-debug noctalia`
- Manual Niri runtime check with System Monitor using `Color = #ff3366`, `Icon color = #00e5ff`, `Font weight = Bold`, and value highlighting disabled; labels and glyphs rendered with their distinct configured colors

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Manually verified on Niri with deliberately distinct fixed colors for labels and glyphs. The focused regression is also covered by `ui_tree_reconciler_test`, including retained-node reset behavior.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

CC @ItsLemmy because this extends the existing `barWidget.render()` font/scale inheritance path to the two widget color roles.
