### PR TITLE
feat(plugins): add a color prop to ui.button

### DIFF
--- a/docs/plugin-api.json
+++ b/docs/plugin-api.json
@@ -166,5 +166,11 @@
     "noctaliaVersion": null,
     "feature": "panel-layer",
     "introduced": "The `layer` panel entry option for choosing the layer-shell layer of a floating plugin panel."
+  },
+  {
+    "level": 31,
+    "noctaliaVersion": null,
+    "feature": "button-color",
+    "introduced": "The `color` prop on `ui.button`, recoloring the label or glyph of the normal and disabled states."
   }
 ]

--- a/docs/user/plugins/development/declarative-ui.mdx
+++ b/docs/user/plugins/development/declarative-ui.mdx
@@ -59,7 +59,7 @@ to size it explicitly).
 | `ui.separator` | `thickness`, `color`, `spacing`, `orientation` (`auto`/`horizontal`/`vertical`) |
 | `ui.spacer` | flexible filler (use `flexGrow`) |
 | `ui.progress` | `progress` (0–1), `fill`, `track`, `radius`, `width`, `height` |
-| `ui.button` | `text`, `glyph`, `fontSize`, `glyphSize`, `variant` (`default`/`primary`/`secondary`/`destructive`/`outline`/`ghost`), `contentAlign` (`start`/`center`/`end`), `controlSize` (`sm`/`md`/`lg`), `tooltip`, `enabled`, `selected`, `onClick`, `onRightClick`, `onHover` |
+| `ui.button` | `text`, `glyph`, `fontSize`, `glyphSize`, `variant` (`default`/`primary`/`secondary`/`destructive`/`outline`/`ghost`), `color` (label/glyph color for the normal and disabled states), `contentAlign` (`start`/`center`/`end`), `controlSize` (`sm`/`md`/`lg`), `tooltip`, `enabled`, `selected`, `onClick`, `onRightClick`, `onHover` |
 | `ui.graph` | `values` / `values2` (arrays of 0–1 numbers), `color` / `color2`, `lineWidth`, `fillOpacity`, `width`, `height`, `onPointerMove`, `onPointerLeave` |
 | `ui.toggle` | `checked` (bool), `enabled`, `onChange` |
 | `ui.slider` | `min`, `max`, `step`, `value`, `controlSize` (`sm`/`md`/`lg`), `enabled`, `onChange`, `onDragEnd` |
@@ -85,6 +85,9 @@ prop is logged and skipped - typos surface in the log instead of failing silentl
   with `ui.glyph`'s numeric `size`, which is a glyph size in px.)
 - **Tooltips**: `ui.button` accepts a `tooltip` string, shown on hover. Dropping the prop on a later render clears it.
   Tooltips appear for buttons in bar widgets and panels; desktop widgets do not show them.
+- **Button color**: `color` on `ui.button` recolors the label or glyph of the normal state and, at 55% of its alpha,
+  of the disabled state; hover, pressed, and selected keep the variant's colors. A dropped or invalid `color` restores
+  the variant's palette on a retained button. Requires <PluginApiBadge feature="button-color" />.
 - **Callbacks**: a callback prop takes either a **function** (requires <PluginApiBadge feature="ui-callback-closures" />) or the **name of a global
   function in your script**. `onClick` fires on a button click; `onChange` fires when a toggle/slider/select/input value
   changes (the value is passed as a string - `"true"`/`"false"` for a toggle, a number for a slider, the text for an

--- a/meson.build
+++ b/meson.build
@@ -1133,6 +1133,7 @@ if build_tests
     'battery_health',
     'battery_hook_state',
     'button_layout',
+    'button_palette',
     'cairo_text_renderer',
     'caldav_client',
     'calendar_cache_permissions',

--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -30,7 +30,8 @@ namespace scripting {
   inline constexpr std::uint32_t kPanelContextMenuPluginApiVersion = 28;
   inline constexpr std::uint32_t kGraphPointerTrackingPluginApiVersion = 29;
   inline constexpr std::uint32_t kPanelLayerPluginApiVersion = 30;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = kPanelLayerPluginApiVersion;
+  inline constexpr std::uint32_t kButtonColorPluginApiVersion = 31;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = kButtonColorPluginApiVersion;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -14,6 +14,8 @@
 
 namespace {
 
+  constexpr float kDisabledAlpha = 0.55F;
+
   Button::ButtonStateColors makeState(ColorSpec bg, ColorSpec border, ColorSpec label) {
     return Button::ButtonStateColors{
         .bg = bg,
@@ -30,7 +32,6 @@ namespace {
   }
 
   Button::ButtonPalette paletteForVariant(ButtonVariant variant) {
-    constexpr float kDisabledAlpha = 0.55F;
     switch (variant) {
     case ButtonVariant::Default:
       return Button::ButtonPalette{
@@ -179,6 +180,12 @@ namespace {
 } // namespace
 
 Button::ButtonPalette Button::defaultPalette(ButtonVariant variant) { return paletteForVariant(variant); }
+
+Button::ButtonPalette Button::withLabelColor(ButtonPalette base, const ColorSpec& label) {
+  base.normal.label = label;
+  base.disabled.label = scaleAlpha(label, kDisabledAlpha);
+  return base;
+}
 
 Button::Button() {
   setAlign(FlexAlign::Center);

--- a/src/ui/controls/button.h
+++ b/src/ui/controls/button.h
@@ -37,6 +37,7 @@ public:
     ColorSpec bg;
     ColorSpec border;
     ColorSpec label;
+    bool operator==(const ButtonStateColors&) const = default;
   };
 
   struct ButtonPalette {
@@ -46,6 +47,7 @@ public:
     ButtonStateColors pressed;
     ButtonStateColors disabled;
     std::optional<ButtonStateColors> selected;
+    bool operator==(const ButtonPalette&) const = default;
   };
 
   Button();
@@ -97,6 +99,12 @@ public:
   [[nodiscard]] ButtonVariant variant() const noexcept { return m_variant; }
 
   [[nodiscard]] static ButtonPalette defaultPalette(ButtonVariant variant);
+  // `base` with the normal-state label recolored to `label` and the
+  // disabled-state label the same color at the disabled alpha (multiplied, so
+  // a translucent color never gets more opaque when disabled). Background,
+  // border, hover, pressed, and selected are untouched.
+  [[nodiscard]] static ButtonPalette withLabelColor(ButtonPalette base, const ColorSpec& label);
+  [[nodiscard]] const ButtonPalette& palette() const noexcept { return m_palette; }
 
 private:
   void refreshInputAreaEnabled();

--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -482,7 +482,7 @@ namespace ui {
                                                               "visible",     "text",    "glyph",        "fontSize",
                                                               "glyphSize",   "variant", "contentAlign", "enabled",
                                                               "selected",    "onClick", "onRightClick", "tooltip",
-                                                              "controlSize", "onHover"};
+                                                              "controlSize", "onHover", "color"};
       static const std::unordered_set<std::string> kGraph = {
           "width", "height", "flexGrow",  "opacity",     "visible",       "values",        "values2",
           "color", "color2", "lineWidth", "fillOpacity", "onPointerMove", "onPointerLeave"
@@ -1444,6 +1444,19 @@ namespace ui {
       }
       if (auto variant = parseButtonVariant(desired)) {
         button->setVariant(*variant);
+      }
+      // Unconditional: setVariant() keeps a custom palette while the variant is
+      // unchanged, so a `color` dropped or invalid on a later render has to
+      // restore the base palette itself. Only the normal and disabled labels
+      // change; hover, pressed, and selected keep the variant's colors.
+      {
+        Button::ButtonPalette target = Button::defaultPalette(button->variant());
+        if (auto color = parseColor(desired, "color")) {
+          target = Button::withLabelColor(target, *color);
+        }
+        if (target != button->palette()) {
+          button->setCustomPalette(target);
+        }
       }
       if (const std::string* contentAlign = strProp(desired, "contentAlign")) {
         if (*contentAlign == "start") {

--- a/tests/button_palette_test.cpp
+++ b/tests/button_palette_test.cpp
@@ -1,0 +1,79 @@
+#include "render/core/color.h"
+#include "ui/controls/button.h"
+#include "ui/palette.h"
+
+#include <cmath>
+#include <print>
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::println(stderr, "button_palette_test: {}", message);
+      return false;
+    }
+    return true;
+  }
+
+  bool near(float actual, float expected) { return std::abs(actual - expected) < 0.001F; }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+  const Button::ButtonPalette ghost = Button::defaultPalette(ButtonVariant::Ghost);
+
+  // A role with alpha recolors the normal label; the disabled label keeps the
+  // role and multiplies the alpha by the disabled factor.
+  {
+    const ColorSpec primary = colorSpecFromRole(ColorRole::Primary, 0.2F);
+    const Button::ButtonPalette tinted = Button::withLabelColor(ghost, primary);
+    ok = expect(tinted.normal.label == primary, "normal label takes the custom color") && ok;
+    ok = expect(tinted.disabled.label.role == ColorRole::Primary, "disabled label keeps the custom role") && ok;
+    ok = expect(near(tinted.disabled.label.alpha, 0.2F * 0.55F), "disabled alpha multiplies, never replaces") && ok;
+    ok = expect(
+             tinted.normal.bg == ghost.normal.bg && tinted.normal.border == ghost.normal.border,
+             "normal background and border are untouched"
+         )
+        && ok;
+    ok = expect(tinted.hover == ghost.hover, "hover keeps the variant's colors") && ok;
+    ok = expect(tinted.pressed == ghost.pressed, "pressed keeps the variant's colors") && ok;
+    ok = expect(tinted.selected == ghost.selected, "selected keeps the variant's colors") && ok;
+    ok = expect(near(tinted.borderWidth, ghost.borderWidth), "border width is untouched") && ok;
+  }
+
+  // A fixed hex color has no role; the disabled factor still lands on the spec's alpha.
+  {
+    Color fixed;
+    ok = expect(tryParseHexColor("#ff8800", fixed), "fixture hex parses") && ok;
+    const ColorSpec spec = fixedColorSpec(fixed);
+    const Button::ButtonPalette tinted = Button::withLabelColor(ghost, spec);
+    ok = expect(tinted.normal.label == spec, "normal label takes the fixed color") && ok;
+    ok = expect(!tinted.disabled.label.role.has_value(), "disabled label stays fixed") && ok;
+    ok = expect(
+             near(tinted.disabled.label.fixed.r, fixed.r)
+                 && near(tinted.disabled.label.fixed.g, fixed.g)
+                 && near(tinted.disabled.label.fixed.b, fixed.b),
+             "disabled label keeps the fixed color"
+         )
+        && ok;
+    ok = expect(near(tinted.disabled.label.alpha, 0.55F), "disabled alpha is the factor for an opaque spec") && ok;
+  }
+
+  // palette() reports what setCustomPalette applied, and the variant's own
+  // default palette restores the base look.
+  {
+    Button button;
+    button.setVariant(ButtonVariant::Ghost);
+    button.setCustomPalette(Button::withLabelColor(ghost, colorSpecFromRole(ColorRole::Primary)));
+    ok = expect(
+             button.palette().normal.label == colorSpecFromRole(ColorRole::Primary),
+             "palette() reflects the custom palette"
+         )
+        && ok;
+    button.setCustomPalette(Button::defaultPalette(button.variant()));
+    ok = expect(button.palette() == ghost, "the variant's default palette restores the base") && ok;
+  }
+
+  return ok ? 0 : 1;
+}

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -1,4 +1,5 @@
 #include "render/backend/render_backend.h"
+#include "render/core/color.h"
 #include "render/core/renderer.h"
 #include "render/core/texture_manager.h"
 #include "render/scene/input_area.h"
@@ -17,10 +18,12 @@
 #include "ui/controls/spacer.h"
 #include "ui/controls/toggle.h"
 #include "ui/drag_drop_controller.h"
+#include "ui/palette.h"
 #include "ui/style.h"
 #include "ui/ui_tree.h"
 #include "ui/ui_tree_reconciler.h"
 
+#include <cmath>
 #include <cstdlib>
 #include <optional>
 #include <print>
@@ -791,6 +794,83 @@ int main() {
       area->dispatchEnter(0.0F, 0.0F);
       area->dispatchLeave();
       ok = expect(fired.empty(), "an empty button onHover name wires nothing") && ok;
+    }
+  }
+
+  // `color` recolors the normal and disabled labels on top of the variant's
+  // palette. It is applied unconditionally, so dropping it or passing an
+  // invalid color restores the variant's palette on a retained button, and a
+  // variant change in the same render carries the color onto the new variant.
+  {
+    ui::UiTreeReconciler reconciler;
+    Flex host;
+    ui::UiTreeNode tree = makeNode("column");
+    ui::UiTreeNode button = makeNode("button");
+    button.key = "reset";
+    button.props.emplace("glyph", std::string("restore"));
+    button.props.emplace("variant", std::string("ghost"));
+    button.props.emplace("color", std::string("primary/0.2"));
+    tree.children.push_back(button);
+    (void)reconciler.reconcile(host, tree, renderer);
+
+    auto* column = dynamic_cast<Flex*>(host.children().front().get());
+    auto* control = column != nullptr ? dynamic_cast<Button*>(column->children()[0].get()) : nullptr;
+    ok = expect(control != nullptr, "colored button built") && ok;
+    if (control != nullptr) {
+      const Button::ButtonPalette ghost = Button::defaultPalette(ButtonVariant::Ghost);
+      const ColorSpec primary = colorSpecFromRole(ColorRole::Primary, 0.2F);
+      ok = expect(control->palette().normal.label == primary, "color sets the normal label") && ok;
+      ok = expect(
+               control->palette().disabled.label.role == ColorRole::Primary
+                   && std::abs(control->palette().disabled.label.alpha - 0.2F * 0.55F) < 0.001F,
+               "disabled label keeps the color at the multiplied alpha"
+           )
+          && ok;
+      ok = expect(
+               control->palette().hover == ghost.hover
+                   && control->palette().pressed == ghost.pressed
+                   && control->palette().selected == ghost.selected,
+               "hover, pressed and selected stay the variant's"
+           )
+          && ok;
+
+      tree.children[0].props.erase("color");
+      (void)reconciler.reconcile(host, tree, renderer);
+      ok = expect(column->children()[0].get() == control, "dropping color retains the button") && ok;
+      ok = expect(control->palette() == ghost, "dropping color restores the variant palette") && ok;
+
+      // A stale custom palette can only be caught from a colored state, so
+      // restore a valid color before replacing it with an invalid one.
+      tree.children[0].props.emplace("color", std::string("primary"));
+      (void)reconciler.reconcile(host, tree, renderer);
+      ok = expect(
+               control->palette().normal.label == colorSpecFromRole(ColorRole::Primary),
+               "a valid color applies again after removal"
+           )
+          && ok;
+      tree.children[0].props["color"] = std::string("not-a-color");
+      (void)reconciler.reconcile(host, tree, renderer);
+      ok = expect(control->palette() == ghost, "an invalid color restores the variant palette") && ok;
+
+      tree.children[0].props["color"] = std::string("#ff8800");
+      tree.children[0].props["variant"] = std::string("outline");
+      (void)reconciler.reconcile(host, tree, renderer);
+      const Button::ButtonPalette outline = Button::defaultPalette(ButtonVariant::Outline);
+      Color orange;
+      ok = expect(tryParseHexColor("#ff8800", orange), "fixture hex parses") && ok;
+      ok = expect(
+               control->variant() == ButtonVariant::Outline
+                   && control->palette() == Button::withLabelColor(outline, fixedColorSpec(orange)),
+               "a variant change in the same render carries the color onto the new variant"
+           )
+          && ok;
+      ok = expect(control->palette().normal.label == fixedColorSpec(orange), "a hex color is that fixed label color")
+          && ok;
+      ok = expect(
+               control->palette().disabled.label == scaleAlpha(fixedColorSpec(orange), 0.55F),
+               "the hex color carries into the disabled label at the disabled alpha"
+           )
+          && ok;
     }
   }
 


### PR DESCRIPTION
## Summary

`ui.button` gains a `color` prop: a palette role, a role with alpha (`primary/0.6`, live against the theme), or
hex.

- Recolors the label or glyph of the normal state, and of the disabled state at 55% of the given alpha.
- Hover, pressed, and selected keep the variant's colors.
- Applied on every reconcile as a custom palette derived from the variant's default, so dropping the prop or
  passing an invalid value restores the variant's look on a retained button. (`setVariant` only resets a custom
  palette on a variant change, so the reconciler re-derives the base itself.)
- Registered as plugin API level 31, feature `button-color`, with metadata and docs.

Commits:

- `feat(ui)`: `Button::withLabelColor`, `Button::palette()`, defaulted equality on the palette structs, new
  `button_palette` test.
- `feat(plugins)`: reconciler prop and tests.
- `feat(plugins)`: API constant, `docs/plugin-api.json`, `declarative-ui.mdx`.

## Motivation

A dense plugin panel wants per-row icon buttons whose glyph carries state in color: dim at the default, accent
when overridden. Today `variant` offers fixed palettes, `selected` and `primary` fill the whole surface, and
`opacity` reads as disabled. A `ui.box` around a colored `ui.glyph` loses the tooltip, which only `ui.button` and
`ui.dragSource` carry. One prop closes the gap; no new control.

## Type of Change

- [x] New feature

## Testing

    just build
    meson test -C build-debug --print-errorlogs

112 of 113 pass. The failure, `template_undo_signal` (`assets/templates/ghostty/undo.sh`), fails identically on
`main` at 224da6dd4; this branch does not touch it.

New tests:

- `button_palette_test.cpp`: role with alpha (disabled alpha multiplied, not replaced), fixed hex, accessor
  round trip.
- `ui_tree_reconciler_test.cpp`: normal and disabled labels set, hover/pressed/selected untouched; drop restores
  the variant palette; re-apply after drop; invalid value restores and logs; variant change in the same render
  carries the color; hex is a fixed label color, dimmed in the disabled label.

Format and lint, both clean (clang-format 22.1.8):

    git diff --name-only main..HEAD -- '*.cpp' '*.h' | xargs clang-format --dry-run -Werror
    run-clang-tidy -quiet -p build-debug -header-filter='\.\./src/.*' -warnings-as-errors='*' \
      "^$(realpath src)/(ui/ui_tree_reconciler|ui/controls/button)\.cpp$"

Manual, in a nested niri 26.04 session (headless Weston host) running this build with a throwaway plugin at
`plugin_api = 31`: glyph-only ghost buttons with no `color`, `color = "primary"`, `color = "#ff8800"`, and
`color = "primary/0.5"`, each also with `enabled = false`. The accent glyph draws at full strength, the disabled
one at the dimmed shade, the uncolored one unchanged; see the screenshot. Hover was not exercised (no pointer
automation in the harness); it is the variant's own hover state, untouched by this change.

## Manual Coverage

- [x] Tested on Niri (nested session, this build)

## Screenshots / Videos

Reset buttons as a dense settings panel draws them, three states each (default, modified, disabled). Row one is
today's workaround, state in `opacity`; row two is `color = "primary"`; row three is `color = "#ff8800"`,
`color = "primary/0.5"`, and `color = "#ff8800"` disabled.

![ghost reset buttons in default, modified, and disabled states, with opacity, primary, and hex colors](https://raw.githubusercontent.com/khughitt/noctalia/pr-assets/button-color/2026-09-06-button-color.png)

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Disabled labels: `Default`, `Outline`, and `Ghost` already dim theirs to 55% alpha; `Primary`, `Secondary`,
  and `Destructive` keep an opaque label and dim the background. With `color` set, all six dim the label to 55%
  of the given alpha, hence "55% of its alpha" in the docs. Happy to follow each variant's own rule instead if
  preferred.
- A numeric `color` (Lua number, not string) is skipped without a log line, matching `ui.label.color`,
  `ui.glyph.color`, and `ui.box.fill`; left as is.
- A separate proposal adds `tooltip` to `ui.box`, `ui.row`, `ui.column`, and `ui.image`; independent, next API
  level.
- Contributors:
  - `claude-fable-5-1` - implementation, testing, draft PR
  - `gpt-6-astra` - code review
  - me - manual testing, PR review, adding this section for transparency + to give credit