### PR TITLE
fix(widget/taskbar): fix Highlight Focused Monitor Only widget setting

### DIFF
--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -796,7 +796,6 @@ void TaskbarWidget::rebuild(Renderer& renderer) {
   if (m_taskStrip == nullptr) {
     return;
   }
-  m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   m_taskTiles.clear();
   m_taskTiles.reserve(m_tasks.size());
   // The strip's children are about to be destroyed; drop the gesture and its visuals so nothing
@@ -1288,8 +1287,8 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
 
     auto createWorkspaceBadge = [&](const WorkspaceModel& ws, const WorkspaceDiscSize& disc, bool hover) {
       Button::ButtonPalette badgePalette{};
-      const ColorSpec fill = m_minimal ? clearColorSpec() : workspaceFillColor(ws.workspace);
-      const ColorSpec text = workspaceTextColor(ws.workspace);
+      const ColorSpec fill = m_minimal ? clearColorSpec() : workspaceFillColor(ws);
+      const ColorSpec text = workspaceTextColor(ws);
       badgePalette.normal = Button::ButtonStateColors{fill, clearColorSpec(), text};
       badgePalette.hover = badgePalette.normal;
       badgePalette.pressed = badgePalette.normal;
@@ -1544,8 +1543,11 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       }
 
       const bool emptyWorkspace = tasks.empty();
-      const auto surfaceFill = colorSpecFromRole(ColorRole::SurfaceVariant, ws.workspace.active ? 0.52F : 0.18F);
-      const auto borderColor = colorSpecFromRole(ColorRole::Primary, ws.workspace.active ? 0.65F : 0.16F);
+      const bool focusedWorkspace = workspaceUsesFocusedStyle(ws);
+
+      const auto surfaceFill = colorSpecFromRole(ColorRole::SurfaceVariant, focusedWorkspace ? 0.52F : 0.18F);
+
+      const auto borderColor = colorSpecFromRole(ColorRole::Primary, focusedWorkspace ? 0.65F : 0.16F);
 
       const float crossSize = std::round(tileSize + groupPad * 2.0F);
 
@@ -3416,19 +3418,26 @@ wl_output* TaskbarWidget::workspaceHostOutput(const WorkspaceModel& model) const
   return model.hostOutput != nullptr ? model.hostOutput : m_output;
 }
 
-ColorSpec TaskbarWidget::workspaceFillColor(const Workspace& workspace) const {
+bool TaskbarWidget::workspaceUsesFocusedStyle(const WorkspaceModel& model) const noexcept {
+  return model.workspace.active
+      && (!m_focusedOutputOnly || m_platform.preferredInteractiveOutput() == workspaceHostOutput(model));
+}
+
+ColorSpec TaskbarWidget::workspaceFillColor(const WorkspaceModel& model) const {
+  const Workspace& workspace = model.workspace;
+
   if (workspace.active) {
-    if (m_activeUsesFocusedColor) {
-      return m_focusedColor;
-    }
-    return m_occupiedColor;
+    return workspaceUsesFocusedStyle(model) ? m_focusedColor : m_occupiedColor;
   }
+
   if (workspace.urgent) {
     return m_urgentColor;
   }
+
   if (workspace.occupied) {
     return m_occupiedColor;
   }
+
   ColorSpec color = m_emptyColor;
   color.alpha *= 0.55F;
   return color;
@@ -3436,22 +3445,25 @@ ColorSpec TaskbarWidget::workspaceFillColor(const Workspace& workspace) const {
 
 bool TaskbarWidget::isFocusedOutput() const { return m_platform.preferredInteractiveOutput() == m_output; }
 
-ColorSpec TaskbarWidget::workspaceTextColor(const Workspace& workspace) const {
+ColorSpec TaskbarWidget::workspaceTextColor(const WorkspaceModel& model) const {
+  const Workspace& workspace = model.workspace;
+
   if (workspace.urgent) {
     return m_minimal ? m_urgentColor : readableColorForFill(m_urgentColor);
   }
+
   if (!m_minimal) {
-    return readableColorForFill(workspaceFillColor(workspace));
+    return readableColorForFill(workspaceFillColor(model));
   }
+
   if (workspace.active) {
-    if (m_activeUsesFocusedColor) {
-      return m_focusedColor;
-    }
-    return m_occupiedColor;
+    return workspaceUsesFocusedStyle(model) ? m_focusedColor : m_occupiedColor;
   }
+
   if (workspace.occupied) {
     return m_occupiedColor;
   }
+
   ColorSpec color = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurfaceVariant));
   color.alpha *= 0.55F;
   return color;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -198,8 +198,9 @@ private:
   [[nodiscard]] bool useMultiOutputWorkspaceKeys() const noexcept;
   [[nodiscard]] std::string workspaceKeyPrefixForOutput(wl_output* out) const;
   [[nodiscard]] wl_output* workspaceHostOutput(const WorkspaceModel& model) const noexcept;
-  [[nodiscard]] ColorSpec workspaceFillColor(const Workspace& workspace) const;
-  [[nodiscard]] ColorSpec workspaceTextColor(const Workspace& workspace) const;
+  [[nodiscard]] bool workspaceUsesFocusedStyle(const WorkspaceModel& model) const noexcept;
+  [[nodiscard]] ColorSpec workspaceFillColor(const WorkspaceModel& model) const;
+  [[nodiscard]] ColorSpec workspaceTextColor(const WorkspaceModel& model) const;
   [[nodiscard]] bool isFocusedOutput() const;
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
@@ -241,7 +242,6 @@ private:
   bool m_workspaceGroupCapsule = true;
   bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;
-  bool m_activeUsesFocusedColor = true;
   bool m_minimal = false;
   bool m_groupSingleIconPerApp = false;
   bool m_showActiveIndicator = true;


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->
Fixes the "Highlight Focused Monitor Only" option in the taskbar widget when using it alongside the "Show All Monitors" setting.

Hyprland considers the current workspace on each monitor active. With "Show All Monitors" enabled, Noctalia was applying the taskbar's focused state to every active workspace, causing workspaces on unfocused monitors to also appear focused.

Focused styling is now determined per workspace using its host output, so only the active workspace on the currently focused monitor receives the focused styling.


## Motivation

<!-- What problem does this solve? -->
Fixes "Highlight Focused Monitor Only" to behave as described by helper text when used alongside "Show All Monitors".


## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Ran `just build`
- Ran `just test` (114 tests passed)
- Manually tested with two monitors on Hyprland
- Verified focused styling follows the focused monitor with "Show All Monitors" enabled
- Verified active workspaces on unfocused monitors use occupied styling

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="1827" height="1505" alt="image" src="https://github.com/user-attachments/assets/67306dda-5986-4542-8348-98efea8f4a5c" />
<img width="509" height="397" alt="image" src="https://github.com/user-attachments/assets/d69b5a23-749a-4f7f-b682-c795f199b063" />

With Fix:
<img width="1286" height="775" alt="image" src="https://github.com/user-attachments/assets/05933709-37ca-4de1-8187-e472a12ac49f" />
<img width="981" height="754" alt="image" src="https://github.com/user-attachments/assets/dfa9e24b-a71d-4489-868d-135ee424c477" />


## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
