### PR TITLE
lockscreen: animated WebP background

### DIFF
--- a/docs/user/lockscreen/widgets.mdx
+++ b/docs/user/lockscreen/widgets.mdx
@@ -102,3 +102,22 @@ background_radius = 16.0
 input_opacity = 0.9
 input_radius = 8.0
 ```
+
+---
+## Animated background
+
+The lockscreen background (the `[lockscreen]` `wallpaper` key) accepts an **animated WebP** in addition to still images. When the configured wallpaper is an animated WebP, Noctalia streams it frame by frame and loops it for as long as the session is locked. A still image (or a still WebP) keeps using the static path unchanged.
+
+Only a single frame is held in video memory at a time, so clip length does not increase GPU usage, and decoding pauses while the display is blanked (DPMS).
+
+```toml
+[lockscreen]
+wallpaper = "/path/to/background.webp"
+```
+
+To produce an animated WebP from a video with ffmpeg:
+
+```sh
+ffmpeg -i input.mp4 -vf "fps=24,scale=1920:1080:flags=lanczos" \
+  -c:v libwebp_anim -loop 0 -an -q:v 80 -compression_level 6 output.webp
+```

--- a/meson.build
+++ b/meson.build
@@ -619,6 +619,7 @@ _noctalia_sources = files(
   'src/shell/desktop/editor/desktop_widgets_editor_types.cpp',
   'src/shell/desktop/editor/desktop_widgets_editor_settings.cpp',
   'src/shell/desktop/desktop_widgets_host.cpp',
+  'src/shell/lockscreen/animated_webp_background.cpp',
   'src/shell/lockscreen/lockscreen_login_box.cpp',
   'src/shell/lockscreen/lockscreen_widgets_controller.cpp',
   'src/shell/lockscreen/lockscreen_widgets_host.cpp',

--- a/src/render/core/image_decoder.cpp
+++ b/src/render/core/image_decoder.cpp
@@ -256,6 +256,14 @@ namespace {
     if (WebPGetFeatures(data, size, &features) != VP8_STATUS_OK) {
       return std::unexpected("libwebp: failed to read WebP header");
     }
+    // A WebP (especially VP8X) can declare a canvas far larger than its file
+    // size; cap it before libwebp allocates the full RGBA canvas to avoid OOM.
+    if (features.width <= 0
+        || features.height <= 0
+        || static_cast<std::uint64_t>(features.width) * static_cast<std::uint64_t>(features.height) * 4
+            > kMaxWebpCanvasBytes) {
+      return std::unexpected("libwebp: WebP canvas exceeds size cap");
+    }
     if (features.has_animation) {
       return decodeWebPFirstFrame(data, size);
     }

--- a/src/render/core/image_decoder.h
+++ b/src/render/core/image_decoder.h
@@ -6,6 +6,13 @@
 #include <string>
 #include <vector>
 
+// Upper bound on a WebP canvas we will decode, in RGBA bytes. A WebP VP8X header
+// can declare a canvas far larger than its (small) file size, and libwebp would
+// allocate the full canvas (twice, for animation) before any downstream check,
+// so an attacker-sized canvas is an OOM vector. 256 MiB (~8192x8192 RGBA)
+// is far above any real display while bounding the allocation.
+inline constexpr std::size_t kMaxWebpCanvasBytes = 256ULL * 1024 * 1024;
+
 struct DecodedRasterImage {
   std::vector<std::uint8_t> pixels;
   int width = 0;

--- a/src/shell/lockscreen/animated_webp_background.cpp
+++ b/src/shell/lockscreen/animated_webp_background.cpp
@@ -1,0 +1,253 @@
+#include "shell/lockscreen/animated_webp_background.h"
+
+#include "core/log.h"
+#include "render/backend/render_backend.h"
+#include "render/core/image_decoder.h" // kMaxWebpCanvasBytes
+#include "render/core/texture_manager.h"
+#include "render/render_context.h"
+#include "util/file_utils.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <utility>
+#include <webp/decode.h>
+#include <webp/demux.h>
+
+namespace {
+
+  constexpr Logger kLog("lockscreen");
+
+  // Floor on a frame's on-screen time. Guards against a 0ms (or malformed
+  // negative) inter-frame delta spinning the timer, and keeps the cadence at or
+  // under one display refresh (~60Hz) so decode+upload cannot starve input.
+  constexpr int kMinFrameDelayMs = 16;
+
+} // namespace
+
+void AnimatedWebpBackground::DecoderDeleter::operator()(WebPAnimDecoder* decoder) const noexcept {
+  WebPAnimDecoderDelete(decoder);
+}
+
+AnimatedWebpBackground::~AnimatedWebpBackground() { stop(); }
+
+AnimatedWebpBackground::StartResult AnimatedWebpBackground::start(
+    RenderContext& ctx, const std::string& path, std::function<void()> onFrame, std::function<void()> onFailure
+) {
+  stop();
+
+  std::vector<std::uint8_t> bytes = FileUtils::readBinaryFile(path);
+  if (bytes.empty()) {
+    return StartResult::TransientFailure; // missing/unreadable now; may appear later
+  }
+
+  WebPBitstreamFeatures features;
+  if (WebPGetFeatures(bytes.data(), bytes.size(), &features) != VP8_STATUS_OK) {
+    return StartResult::NotAnimated; // not a WebP
+  }
+  if (features.has_animation == 0) {
+    return StartResult::NotAnimated; // still WebP -> static path
+  }
+  // Reject an oversized canvas BEFORE WebPAnimDecoderNew: a VP8X header can
+  // declare dimensions independent of the (small) file size, and the decoder
+  // would allocate the full canvas twice up front (an OOM vector).
+  if (features.width <= 0
+      || features.height <= 0
+      || static_cast<std::uint64_t>(features.width) * static_cast<std::uint64_t>(features.height) * 4
+          > kMaxWebpCanvasBytes) {
+    kLog.warn("animated WebP \"{}\" canvas {}x{} exceeds size cap; ignoring", path, features.width, features.height);
+    return StartResult::NotAnimated; // treat like a still image: fall back, do not stream
+  }
+
+  WebPAnimDecoderOptions options;
+  if (WebPAnimDecoderOptionsInit(&options) == 0) {
+    return StartResult::TransientFailure;
+  }
+  options.color_mode = MODE_RGBA; // non-premultiplied RGBA8, matches TextureDataFormat::Rgba
+  options.use_threads = 0;
+
+  // The decoder references the encoded bytes without copying them, so they must
+  // outlive it. Build decoder + bytes as locals and only commit to members once
+  // every probe has passed, so the failure paths above need no cleanup.
+  const WebPData webpData{.bytes = bytes.data(), .size = bytes.size()};
+  std::unique_ptr<WebPAnimDecoder, DecoderDeleter> decoder(WebPAnimDecoderNew(&webpData, &options));
+  if (!decoder) {
+    kLog.warn("failed to open WebP animation \"{}\"", path);
+    return StartResult::NotAnimated;
+  }
+
+  WebPAnimInfo info;
+  if (WebPAnimDecoderGetInfo(decoder.get(), &info) == 0 || info.canvas_width == 0 || info.canvas_height == 0) {
+    kLog.warn("failed to read WebP animation info \"{}\"", path);
+    return StartResult::NotAnimated;
+  }
+
+  m_ctx = &ctx;
+  m_path = path;
+  m_bytes = std::move(bytes);
+  m_decoder = std::move(decoder);
+  m_width = static_cast<int>(info.canvas_width);
+  m_height = static_cast<int>(info.canvas_height);
+  m_prevTimestampMs = 0;
+  m_paused = false;
+  m_onFrame = std::move(onFrame);
+  m_onFailure = std::move(onFailure);
+
+  kLog.info("streaming animated WebP background \"{}\" ({}x{}, {} frames)", path, m_width, m_height, info.frame_count);
+
+  // Show the first frame immediately, then self-schedule the rest.
+  int firstDelayMs = kMinFrameDelayMs;
+  switch (pumpFrame(firstDelayMs)) {
+  case FrameStatus::Ok:
+    scheduleNext(firstDelayMs);
+    return StartResult::Started;
+  case FrameStatus::ContextLost:
+    stop();
+    return StartResult::TransientFailure; // context not ready (e.g. mid GPU reset); caller retries
+  case FrameStatus::DecodeError:
+    stop();
+    return StartResult::NotAnimated; // frame 0 is undecodable -> treat as a broken/still file
+  }
+  return StartResult::TransientFailure; // unreachable
+}
+
+void AnimatedWebpBackground::stop() {
+  m_frameTimer.stop();
+  releaseTexture();
+  m_decoder.reset();
+  m_bytes.clear();
+  m_bytes.shrink_to_fit();
+  m_onFrame = nullptr;
+  m_onFailure = nullptr;
+  m_ctx = nullptr;
+  m_path.clear();
+  m_width = 0;
+  m_height = 0;
+  m_prevTimestampMs = 0;
+  m_paused = false;
+}
+
+void AnimatedWebpBackground::pause() {
+  if (m_paused || !m_decoder) {
+    return;
+  }
+  m_paused = true;
+  m_frameTimer.stop();
+}
+
+void AnimatedWebpBackground::resume() {
+  if (!m_paused || !m_decoder) {
+    return;
+  }
+  m_paused = false;
+  advanceAndUpload();
+}
+
+void AnimatedWebpBackground::invalidateGpu() {
+  m_frameTimer.stop();
+  // The GL name is already gone after a context loss; forget the handle without
+  // issuing a delete. ensureTexture() recreates it on the next frame. Do NOT
+  // touch m_prevTimestampMs: the decoder position is unchanged, so the previous
+  // frame's end time is still the correct pacing baseline.
+  m_texture = {};
+}
+
+void AnimatedWebpBackground::kick() {
+  if (!m_decoder || m_paused) {
+    return;
+  }
+  advanceAndUpload();
+}
+
+bool AnimatedWebpBackground::ensureTexture() {
+  if (m_texture.id.valid()) {
+    return true;
+  }
+  if (m_ctx == nullptr) {
+    return false;
+  }
+  m_texture = m_ctx->textureManager().createEmpty(m_width, m_height, TextureDataFormat::Rgba, TextureFilter::Linear);
+  return m_texture.id.valid();
+}
+
+AnimatedWebpBackground::FrameStatus AnimatedWebpBackground::pumpFrame(int& outDelayMs) {
+  if (m_ctx == nullptr || !m_decoder) {
+    return FrameStatus::DecodeError;
+  }
+  // Timer-driven GL work must make the context current itself; during a graphics
+  // reset it is not, and we retry rather than deleting the texture.
+  if (!m_ctx->backend().makeCurrentNoSurface()) {
+    return FrameStatus::ContextLost;
+  }
+  if (!ensureTexture()) {
+    return FrameStatus::ContextLost;
+  }
+
+  // Loop: rewind to the first frame once the clip is exhausted.
+  if (WebPAnimDecoderHasMoreFrames(m_decoder.get()) == 0) {
+    WebPAnimDecoderReset(m_decoder.get());
+    m_prevTimestampMs = 0;
+  }
+
+  std::uint8_t* frame = nullptr;
+  int timestampMs = 0;
+  if (WebPAnimDecoderGetNext(m_decoder.get(), &frame, &timestampMs) == 0 || frame == nullptr) {
+    return FrameStatus::DecodeError;
+  }
+
+  m_ctx->textureManager().updateSubImage(m_texture, frame, 0, 0, m_width, m_height, TextureDataFormat::Rgba);
+
+  // The returned timestamp is the frame's cumulative END time; the delta from the
+  // previous end is how long this frame should stay on screen.
+  outDelayMs = std::max(timestampMs - m_prevTimestampMs, kMinFrameDelayMs);
+  m_prevTimestampMs = timestampMs;
+
+  if (m_onFrame) {
+    m_onFrame();
+  }
+  return FrameStatus::Ok;
+}
+
+void AnimatedWebpBackground::advanceAndUpload() {
+  if (!m_decoder || m_paused) {
+    return;
+  }
+  int delayMs = kMinFrameDelayMs;
+  switch (pumpFrame(delayMs)) {
+  case FrameStatus::Ok:
+    scheduleNext(delayMs);
+    break;
+  case FrameStatus::ContextLost:
+    scheduleNext(kMinFrameDelayMs); // retry shortly; keep the decoder and texture intent
+    break;
+  case FrameStatus::DecodeError:
+    failStop();
+    break;
+  }
+}
+
+void AnimatedWebpBackground::scheduleNext(int delayMs) {
+  if (!m_decoder || m_paused) {
+    return;
+  }
+  m_frameTimer.start(std::chrono::milliseconds(delayMs), [this] { advanceAndUpload(); });
+}
+
+void AnimatedWebpBackground::failStop() {
+  kLog.warn("WebP animation decode failed, stopping playback \"{}\"", m_path);
+  // Capture the callback before stop() clears it, then notify the owner so it can
+  // drop the now-deleted texture and fall back to a static background.
+  auto onFailure = m_onFailure;
+  stop();
+  if (onFailure) {
+    onFailure();
+  }
+}
+
+void AnimatedWebpBackground::releaseTexture() {
+  if (m_texture.id.valid() && m_ctx != nullptr) {
+    m_ctx->backend().makeCurrentNoSurface();
+    m_ctx->textureManager().unload(m_texture);
+  }
+  m_texture = {};
+}

--- a/src/shell/lockscreen/animated_webp_background.h
+++ b/src/shell/lockscreen/animated_webp_background.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "core/timer_manager.h"
+#include "render/core/texture_handle.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+class RenderContext;
+struct WebPAnimDecoder;
+
+/// Streams an animated WebP onto a single, reused GPU texture: one frame is
+/// decoded per timer tick (paced by the frame's own duration) and uploaded in
+/// place via TextureManager::updateSubImage, so VRAM stays at ~one frame
+/// regardless of clip length. Used as the lockscreen background when the
+/// configured `[lockscreen] wallpaper` path is an animated WebP.
+///
+/// All work happens on the main loop thread (timer callbacks, GL uploads); the
+/// class is not thread-safe by design.
+class AnimatedWebpBackground {
+public:
+  enum class StartResult {
+    NotAnimated,      ///< not a WebP, a still WebP, or an oversized canvas -> use the static path (and don't retry)
+    TransientFailure, ///< a readable animated WebP but a transient error (e.g. lost GL context) -> retry later
+    Started,          ///< streaming
+  };
+
+  AnimatedWebpBackground() = default;
+  ~AnimatedWebpBackground();
+
+  AnimatedWebpBackground(const AnimatedWebpBackground&) = delete;
+  AnimatedWebpBackground& operator=(const AnimatedWebpBackground&) = delete;
+
+  /// Begins playback if `path` is an animated WebP within the canvas-size cap.
+  /// `onFrame` fires after each uploaded frame (rebind the node texture + redraw).
+  /// `onFailure` fires once if a mid-stream decode/GPU error stops playback, so
+  /// the owner can drop the now-deleted texture and fall back to a static path.
+  /// The distinction in the return value lets the caller retry transient errors
+  /// while permanently ruling out still/broken files.
+  StartResult
+  start(RenderContext& ctx, const std::string& path, std::function<void()> onFrame, std::function<void()> onFailure);
+
+  /// Full teardown: stops the timer, releases the GPU texture, frees the decoder.
+  /// Safe when inactive. Must run while `ctx` (from start) is still valid.
+  void stop();
+
+  /// Suspend/resume decoding without tearing down (e.g. DPMS blank / unblank).
+  void pause();
+  void resume();
+
+  /// Forget the GPU texture after a graphics-context loss without touching GL
+  /// (the name is already gone). The next frame recreates it. Pair with kick()
+  /// once the context is restored. Does NOT rewind the decoder or its pacing.
+  void invalidateGpu();
+
+  /// Decode and upload the next frame immediately, then resume pacing. Used to
+  /// repaint after a GPU reset. No-op when inactive or paused.
+  void kick();
+
+  [[nodiscard]] bool active() const noexcept { return m_decoder != nullptr; }
+  [[nodiscard]] const std::string& path() const noexcept { return m_path; }
+  [[nodiscard]] TextureHandle texture() const noexcept { return m_texture; }
+
+private:
+  enum class FrameStatus {
+    Ok,          ///< a frame was decoded and uploaded
+    ContextLost, ///< GL context not current / texture alloc failed -> retry, keep the decoder
+    DecodeError, ///< the bitstream failed to decode -> stop (permanent for this file)
+  };
+
+  struct DecoderDeleter {
+    void operator()(WebPAnimDecoder* decoder) const noexcept;
+  };
+
+  bool ensureTexture();
+  FrameStatus pumpFrame(int& outDelayMs);
+  void advanceAndUpload();
+  void scheduleNext(int delayMs);
+  void failStop();
+  void releaseTexture();
+
+  RenderContext* m_ctx = nullptr;
+  std::string m_path;
+  std::vector<std::uint8_t> m_bytes; // owns the encoded data the decoder references
+  std::unique_ptr<WebPAnimDecoder, DecoderDeleter> m_decoder;
+  int m_width = 0;
+  int m_height = 0;
+  int m_prevTimestampMs = 0; // cumulative end time of the last shown frame (libwebp semantics)
+  bool m_paused = false;
+  TextureHandle m_texture{};
+  Timer m_frameTimer;
+  std::function<void()> m_onFrame;
+  std::function<void()> m_onFailure;
+};

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -547,6 +547,7 @@ LockSurface::LockSurface(WaylandConnection& connection, ConfigService* config) :
 
 LockSurface::~LockSurface() {
   m_aliveGuard.reset();
+  m_animatedBackground.stop(); // release the streaming texture while the render context is still valid
   releaseCaptureTextures();
   if (m_wallpaperTexture.id != 0) {
     releaseWallpaperTextureRef(m_textureWallpaperPath);
@@ -761,6 +762,9 @@ void LockSurface::setBlackout(bool blackout) {
   m_blackout = blackout;
   if (m_blackout) {
     m_inputDispatcher.setFocus(nullptr);
+    m_animatedBackground.pause(); // stop decoding while the output is blanked (DPMS)
+  } else {
+    m_animatedBackground.resume();
   }
   requestLayout();
 }
@@ -1636,15 +1640,109 @@ void LockSurface::releaseWallpaperTextureRef(const std::string& path) {
   }
 }
 
+bool LockSurface::pathLooksLikeWebp(const std::string& path) { return StringUtils::toLower(path).ends_with(".webp"); }
+
+// Streams the wallpaper as an animated WebP when the configured path is one.
+// Returns true when the animated background owns the wallpaper node; false tells
+// the caller to fall through to the static image/color path.
+bool LockSurface::applyAnimatedWallpaper() {
+  const bool wantAnimated = pathLooksLikeWebp(m_wallpaperPath);
+
+  // Navigated away from a running clip (to a different path or a still image):
+  // tear the player down and clear the node so the static path can take over.
+  if (m_animatedBackground.active() && (!wantAnimated || m_animatedBackground.path() != m_wallpaperPath)) {
+    m_animatedBackground.stop();
+    if (m_wallpaper != nullptr) {
+      m_wallpaper->setTextures({}, {}, 0.0F, 0.0F, 0.0F, 0.0F);
+    }
+  }
+
+  if (!wantAnimated || renderContext() == nullptr) {
+    return false;
+  }
+  if (m_animatedBackground.active() && m_animatedBackground.path() == m_wallpaperPath) {
+    return true; // already streaming this clip
+  }
+  if (m_animatedBackgroundRuledOut == m_wallpaperPath) {
+    return false; // known still WebP -> static path
+  }
+
+  // Release any static wallpaper textures before switching the node to streaming.
+  renderContext()->backend().makeCurrentNoSurface();
+  if (m_wallpaperTexture.id != 0) {
+    releaseWallpaperTextureRef(m_textureWallpaperPath); // also zeroes m_wallpaperTexture + clears the path
+  }
+  if (m_blurredWallpaperTexture.id != 0) {
+    renderContext()->textureManager().unload(m_blurredWallpaperTexture);
+    m_blurredWallpaperTexture = {};
+  }
+
+  switch (m_animatedBackground.start(
+      *renderContext(), m_wallpaperPath, [this] { onAnimatedBackgroundFrame(); },
+      [this] { onAnimatedBackgroundFailed(); }
+  )) {
+  case AnimatedWebpBackground::StartResult::Started:
+    m_animatedBackgroundRuledOut.clear();
+    // Apply the node's fill/transition once, now that the first frame is bound;
+    // these are CPU-side node fields that survive later in-place texture updates.
+    m_wallpaper->setTransition(WallpaperTransition::Fade, 0.0F, TransitionParams{});
+    m_wallpaper->setFillMode(m_wallpaperFillMode);
+    m_wallpaper->setFillColor(m_wallpaperFillColor);
+    return true;
+  case AnimatedWebpBackground::StartResult::NotAnimated:
+    // A still/broken/oversized WebP: remember it so we don't re-probe every frame,
+    // and let the static image path take over.
+    m_animatedBackgroundRuledOut = m_wallpaperPath;
+    return false;
+  case AnimatedWebpBackground::StartResult::TransientFailure:
+    // Readable but not ready (e.g. mid graphics-reset); leave m_wallpaperDirty so
+    // the next frame retries, and do NOT rule the path out.
+    return false;
+  }
+  return false;
+}
+
+// Invoked after each streamed frame is uploaded. Rebinding is idempotent:
+// WallpaperNode::setSources no-ops when the texture id/size are unchanged, and a
+// texture recreated after a GPU reset has a new id, so it rebinds naturally.
+void LockSurface::onAnimatedBackgroundFrame() {
+  if (m_wallpaper != nullptr) {
+    const TextureHandle texture = m_animatedBackground.texture();
+    m_wallpaper->setTextures(
+        texture.id, {}, static_cast<float>(texture.width), static_cast<float>(texture.height), 0.0F, 0.0F
+    );
+  }
+  requestRedraw();
+}
+
+// Invoked once if streaming stops on a mid-clip decode error. The streaming
+// texture is already gone, so drop the node's now-stale reference (a freed GL
+// name can be recycled to another shell texture and leak on screen behind the
+// lock) and fall back to the static first-frame path.
+void LockSurface::onAnimatedBackgroundFailed() {
+  if (m_wallpaper != nullptr) {
+    m_wallpaper->setTextures({}, {}, 0.0F, 0.0F, 0.0F, 0.0F);
+  }
+  m_animatedBackgroundRuledOut = m_wallpaperPath; // corrupt stream -> don't restart-thrash
+  m_wallpaperDirty = true;
+  requestLayout();
+}
+
 void LockSurface::applyWallpaperTexture() {
   if (m_desktopCapture.has_value() && !m_desktopCapture->rgba.empty()) {
     applyBlurredDesktopTexture();
     if (m_blurredDesktopTexture.id != 0) {
+      m_animatedBackground.stop(); // the blurred-desktop capture owns the node now
       return;
     }
   }
 
   if (!m_wallpaperDirty) {
+    return;
+  }
+
+  if (applyAnimatedWallpaper()) {
+    m_wallpaperDirty = false;
     return;
   }
 
@@ -1812,7 +1910,11 @@ void LockSurface::applyBlurredDesktopTexture() {
 void LockSurface::onGpuResourcesInvalidated() {
   releaseCaptureTextures();
 
-  if (!m_wallpaperPath.empty() && m_textureCache != nullptr) {
+  if (m_animatedBackground.active()) {
+    // Recreate the streaming texture and re-upload the current frame; the rebind
+    // is picked up via consumeRebind() in onAnimatedBackgroundFrame().
+    m_animatedBackground.kick();
+  } else if (!m_wallpaperPath.empty() && m_textureCache != nullptr) {
     if (m_textureCache->shared()) {
       m_wallpaperTexture = m_textureCache->peek(m_wallpaperPath);
     } else if (renderContext() != nullptr) {
@@ -1829,6 +1931,7 @@ void LockSurface::onGpuResourcesInvalidated() {
 }
 
 void LockSurface::prepareForGraphicsReset() noexcept {
+  m_animatedBackground.invalidateGpu();
   m_blurCache.abandon();
   m_wallpaperBlurCache.abandon();
   m_wallpaperTexture = {};

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -8,6 +8,7 @@
 #include "render/core/texture_manager.h"
 #include "render/scene/input_dispatcher.h"
 #include "render/scene/node.h"
+#include "shell/lockscreen/animated_webp_background.h"
 #include "shell/lockscreen/lockscreen_login_box.h"
 #include "wayland/surface.h"
 
@@ -104,6 +105,10 @@ private:
 
   void prepareFrame(bool needsUpdate, bool needsLayout);
   void applyWallpaperTexture();
+  [[nodiscard]] bool applyAnimatedWallpaper();
+  void onAnimatedBackgroundFrame();
+  void onAnimatedBackgroundFailed();
+  [[nodiscard]] static bool pathLooksLikeWebp(const std::string& path);
   void applyBlurredDesktopTexture();
   void releaseWallpaperTextureRef(const std::string& path);
   void releaseCaptureTextures();
@@ -170,6 +175,10 @@ private:
   bool m_captureDirty = true;
   std::string m_wallpaperPath;
   std::string m_textureWallpaperPath;
+  AnimatedWebpBackground m_animatedBackground;
+  // Path already ruled out as a still (non-animated) WebP, so applyWallpaperTexture
+  // does not re-probe the file every frame before falling back to the static path.
+  std::string m_animatedBackgroundRuledOut;
   WallpaperFillMode m_wallpaperFillMode = WallpaperFillMode::Crop;
   Color m_wallpaperFillColor = rgba(0.0F, 0.0F, 0.0F, 0.0F);
   bool m_wallpaperDirty = false;

--- a/tests/webp_decoder_test.cpp
+++ b/tests/webp_decoder_test.cpp
@@ -79,5 +79,18 @@ int main() {
   const auto truncated = decodeRasterImage(kAnimatedRedThenBlue.data(), 48);
   ok = check(!truncated.has_value(), "truncated animated WebP decoded instead of failing") && ok;
 
+  // A tiny file declaring a huge VP8X canvas must be rejected before libwebp
+  // allocates it (out-of-memory guard). Enlarge the animation's canvas to
+  // 8192x8193 (~256 MiB RGBA, over the cap) while leaving the frames intact.
+  auto oversized = kAnimatedRedThenBlue;
+  oversized[24] = 0xFF; // canvas width minus one, low byte  (8191)
+  oversized[25] = 0x1F; // canvas width minus one, mid byte
+  oversized[26] = 0x00; // canvas width minus one, high byte
+  oversized[27] = 0x00; // canvas height minus one, low byte (8192)
+  oversized[28] = 0x20; // canvas height minus one, mid byte
+  oversized[29] = 0x00; // canvas height minus one, high byte
+  const auto capped = decodeRasterImage(oversized.data(), oversized.size());
+  ok = check(!capped.has_value(), "oversized WebP canvas decoded instead of being rejected") && ok;
+
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Adds an animated WebP background for the lockscreen. Noctalia already links `libwebp`/`libwebpdemux` and decodes the first frame of animated WebPs; this wires up full playback on the lock surface, with no new dependencies.

`AnimatedWebpBackground` streams an animated WebP onto a single reused GPU texture: one frame is decoded per timer tick, paced by each frame's own duration, and uploaded in place via `TextureManager::updateSubImage`. Video memory stays bounded to roughly one frame regardless of clip length.

Point the existing lockscreen wallpaper key at an animated `.webp`:

```toml
[lockscreen]
wallpaper = "/path/to/background.webp"
```

A still image (or a still WebP) transparently uses the existing static path, so the key keeps working exactly as before for non-animated files.

Behaviour notes:

- Detects an animated WebP at the wallpaper path and streams it into the existing `WallpaperNode` (fill mode and tint preserved); a still or broken file is remembered so it is not re-probed every frame.
- Pauses decoding on DPMS blank; recreates its texture across GPU-context resets; makes the GL context current before timer-driven uploads.
- On a mid-clip decode failure it drops the node's texture and falls back to the static path rather than leaving a freed GL name bound.
- The WebP canvas size is capped before decoding (256 MiB RGBA, applied to the static WebP decoder too), so a small file declaring a huge VP8X canvas cannot drive an out-of-memory allocation.

## Motivation

Lets users set a looping animated lock background natively, without a compositor-specific video lock fork, and without pulling in a video stack: it reuses the WebP libraries the shell already depends on. The streaming design keeps GPU memory flat, so a long clip costs the same as a short one.

## Type of Change

- [x] New feature

## Testing

- `meson compile -C build-debug noctalia`: clean, no new warnings (project warning set includes `-Wall -Wextra -Wconversion -Wshadow -Wpedantic`).
- `meson test -C build-debug webp_decoder`: passes, including a new case asserting an oversized VP8X canvas is rejected rather than decoded.
- Manual: on Niri (aarch64), locked and unlocked repeatedly with an animated 1080p/24fps WebP set as `[lockscreen] wallpaper`. The background streams and loops smoothly, the login box remains responsive, and unlock works. Logs confirm the streaming path engages with no decode or GL warnings.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

A short screen recording of the animated lock

[A short screen recording of the animated lock.](https://github.com/user-attachments/assets/2c8cea08-d218-4e62-829b-39f897938b46)

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Follow-up ideas out of scope here: sharing one decoder across mirrored outputs (each lock surface currently owns its own decoder/texture/timer), and porting the same approach to `noctalia-greeter`.

