### PR TITLE
fix(notification): sanitizeMarkup leaves markup tags in bodies (dangling string_view)

### DIFF
--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -412,7 +412,7 @@ namespace StringUtils {
       return tag.size() >= expected.size() && tagEquals(tag.substr(0, expected.size()), expected);
     };
     const auto isMarkupTag = [&tagEquals, &tagStartsWith](std::string_view tag) {
-      tag = trim(tag);
+      tag = trimRightView(trimLeftView(tag));
       return tagEquals(tag, "b")
           || tagEquals(tag, "/b")
           || tagEquals(tag, "i")
@@ -438,7 +438,8 @@ namespace StringUtils {
         if (close != std::string_view::npos) {
           const std::string_view tag = s.substr(i + 1, close - i - 1);
           if (isMarkupTag(tag)) {
-            if (tagEquals(trim(tag), "br") || tagEquals(trim(tag), "br/") || tagEquals(trim(tag), "br /")) {
+            const std::string_view trimmedTag = trimRightView(trimLeftView(tag));
+            if (tagEquals(trimmedTag, "br") || tagEquals(trimmedTag, "br/") || tagEquals(trimmedTag, "br /")) {
               out += '\n';
             }
             i = close + 1;


### PR DESCRIPTION
## Summary

`StringUtils::sanitizeMarkup` leaves `<b>`, `<i>`, `<u>` and `<a>` tags in notification bodies in release builds, and `string_utils_test` fails on `main`:

```
string_utils_test: strips supported notification markup: expected 'bold
next', got '<b>bold
next'
```

Root cause: `isMarkupTag` does `tag = trim(tag);` where `trim()` returns a `std::string` and `tag` is a `std::string_view`. The view is left pointing at a destroyed temporary, so the tag comparison reads freed memory and fails. This PR switches the trimming to the view-returning `trimLeftView`/`trimRightView` helpers, and hoists the `<br>` check onto the same trimmed view instead of calling `trim()` three times.

## Motivation

Introduced in 44371790 (fix(notification): preserve literal angle-bracket text). Undefined behavior: the test passes or fails depending on build mode and allocator, and users see raw markup in notifications.

## Type of Change

- [x] Bug fix

## Testing

- `just build release && just test release`: `string_utils` passes, 115/116 overall (the remaining failure is the pre-existing `upower_charge_limit_integration` SIGSEGV in its dbus test fixture, unrelated).
- `just format` with clang-format 22.1.8: no changes.
- Running the release build on Hyprland: notification bodies with `<b>`/`<br>` render stripped again.

## Manual Coverage

- [x] Tested on Hyprland

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
