### PR TITLE
fix(templates/starship): stop forking stat(1) per process during config discovery

### DIFF
--- a/assets/templates/starship/apply.sh
+++ b/assets/templates/starship/apply.sh
@@ -17,11 +17,17 @@ read_env_value() {
     awk -F= -v env_name="$1" '$1 == env_name { sub(/^[^=]*=/, ""); print; exit }'
 }
 
-discover_starship_config_from_environ_file() {
-    local environ_file="$1"
+# One grep over every /proc/*/environ instead of a stat(1) fork and a tr|awk pipeline
+# per process: the same first-match-in-glob-order result for ~1/250th of the cost.
+# No uid filter is needed: /proc/PID/environ is mode 0400 and gated by the ptrace
+# access check, so an unreadable entry is simply skipped.
+discover_starship_config_from_procfs() {
     local value
-    [ -r "$environ_file" ] || return 1
-    value=$(tr '\0' '\n' <"$environ_file" | read_env_value STARSHIP_CONFIG || true)
+    value=$(
+        grep -zhoam1 '^STARSHIP_CONFIG=.*' /proc/[0-9]*/environ </dev/null 2>/dev/null |
+            tr '\0' '\n' | head -n 1 || true
+    )
+    value=${value#STARSHIP_CONFIG=}
     if [ -n "$value" ]; then
         expand_tilde "$value"
         return 0
@@ -48,18 +54,12 @@ discover_starship_config() {
         fi
     fi
 
-    local proc pid owner discovered
+    local discovered
     shopt -s nullglob
-    for proc in /proc/[0-9]*/environ; do
-        pid=${proc#/proc/}
-        pid=${pid%/environ}
-        owner=$(stat -c '%u' "/proc/$pid" 2>/dev/null || true)
-        [ "$owner" = "$(id -u)" ] || continue
-        if discovered=$(discover_starship_config_from_environ_file "$proc"); then
-            printf '%s' "$discovered"
-            return 0
-        fi
-    done
+    if discovered=$(discover_starship_config_from_procfs); then
+        printf '%s' "$discovered"
+        return 0
+    fi
 
     printf '%s' "${XDG_CONFIG_HOME:-$HOME/.config}/starship.toml"
 }


### PR DESCRIPTION
## Summary

The `STARSHIP_CONFIG` discovery in `assets/templates/starship/apply.sh` scanned
`/proc/[0-9]*/environ` with a `stat(1)` fork per pid and a `tr | awk` pipeline per owned
pid. This replaces that with a single `grep -z` over the same glob.

## Motivation

On a 363 process machine the old loop costs 1.5s to 2.8s whenever
`systemctl --user show-environment` does not carry the variable, which is the case on any
system without a systemd user session, or where nothing pushed the variable into it. The
hook is async, but `TemplateApplyService` drains hooks before reporting a theme as applied
(`src/theme/template_apply_service.cpp:511`) and before starting the next request (`:292`),
so the cost lands on every apply.

The discovery order is deliberately unchanged. Checking the default path before the scan
would silently theme a stale `~/.config/starship.toml` for anyone who exports
`STARSHIP_CONFIG` from `.bashrc` or `.zshrc`, which the hook's `sh -lc` does not source.
Their real prompt would never change and nothing would report an error.

The uid gate is dropped as redundant: `/proc/PID/environ` is mode 0400 behind the ptrace
access check, so an unreadable entry is skipped anyway. That also removes a live defect,
since the old `[ -r "$environ_file" ]` guard is `access(2)` and can pass while `open()`
fails, printing `apply.sh: line 24: /proc/1563/environ: Permission denied` to stderr on
every run.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #4339

## Testing

`bash -n` clean. No build needed; this PR touches one shell script.

Differential harness against a synthetic procfs, nine cases: no match, match, tilde value,
`XSTARSHIP_CONFIG=` non match, first in glob order wins, unreadable environ, empty environ,
empty procfs, and a value containing a space. The old and new implementations agree on all
nine.

Timing against real `/proc`, 363 pids, with step 2 disabled so the scan is reached:

```
OLD:  1549 ms  2172 ms  2778 ms
NEW:    24 ms    23 ms    15 ms
```

## Manual Coverage

- [x] Tested on Hyprland

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Unrelated pre-existing bug found while testing, not touched by this PR because it is a
behaviour change rather than a performance one, and it reproduces identically before and
after. `expand_tilde` at lines 8 to 14 never expands: in `${1#~/}` the `~/` pattern is
itself tilde expanded, so it becomes `/home/<user>/` and the prefix strip never matches.
`STARSHIP_CONFIG=~/cfg/s.toml` yields `/home/<user>/~/cfg/s.toml`. The fix is `${1#\~/}`.
Happy to send that separately, or fold it in here if you would rather have both at once.
