### PR TITLE
fix(sway): implement missing focusWindow method

### DIFF
--- a/src/compositors/sway/sway_workspace_backend.cpp
+++ b/src/compositors/sway/sway_workspace_backend.cpp
@@ -434,6 +434,14 @@ std::vector<WorkspaceWindow> SwayWorkspaceBackend::workspaceWindows(wl_output* o
   return filtered;
 }
 
+void SwayWorkspaceBackend::focusWindow(const std::string& windowId) {
+  if (m_socketFd < 0 || windowId.empty()) {
+    return;
+  }
+
+  sendMessage(kIpcRunCommand, "[con_id=" + windowId + "] focus");
+}
+
 void SwayWorkspaceBackend::cleanup() {
   if (m_socketFd >= 0) {
     ::close(m_socketFd);

--- a/src/compositors/sway/sway_workspace_backend.h
+++ b/src/compositors/sway/sway_workspace_backend.h
@@ -38,6 +38,7 @@ public:
   [[nodiscard]] std::unordered_map<std::uintptr_t, WorkspaceWindow>
   assignTaskbarWindows(const std::vector<TaskbarWindowCandidate>& windows, wl_output* output) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(wl_output* output) const override;
+  void focusWindow(const std::string& windowId) override;
   void cleanup() override;
 
   [[nodiscard]] int pollFd() const noexcept override { return m_socketFd; }


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Implement missing focusWindow method for sway.

## Motivation

Fixes /win in the launcher not focusing the selected window if it's on a different workspace.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Fixes https://github.com/noctalia-dev/noctalia/issues/4327

## Testing

Tested on sway. Can confirm it fixes https://github.com/noctalia-dev/noctalia/issues/4327, and it also fixes clicking apps in the taskbar (i.e. now it will focus them correctly if they're on another workspace by opening that workspace).

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
