### PR TITLE
fix(power): unlock Huawei charge-threshold toggle (95/100 unrestricted)

### DIFF
--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -257,6 +257,10 @@ std::optional<double> UPowerDeviceInfo::healthPercent() const {
 }
 
 bool UPowerChargeLimitState::hasRestrictiveThreshold() const {
+  // Huawei-WMI EC expresses "no limit / full charge" as start=95 end=100 rather than 0/100.
+  if (effectiveStart == 95U && effectiveEnd == 100U) {
+    return false;
+  }
   return (effectiveStart.has_value() && *effectiveStart > 0U && *effectiveStart < 100U)
       || (effectiveEnd.has_value() && *effectiveEnd < 100U);
 }

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -81,7 +81,9 @@ struct UPowerChargeLimitState {
 
   // True when the effective thresholds actually hold charge below full: a start
   // threshold that delays resuming below full (0 < start < 100), or an end
-  // threshold that caps below full (end < 100). A start of 0 or 100 is not a limit.
+  // threshold that caps below full (end < 100). A start of 0 or 100 is not a
+  // limit. Huawei-WMI EC "full charge" defaults (start=95, end=100) are also
+  // treated as unrestricted.
   [[nodiscard]] bool hasRestrictiveThreshold() const;
 
   bool operator==(const UPowerChargeLimitState&) const = default;

--- a/tests/upower_charge_limit_test.cpp
+++ b/tests/upower_charge_limit_test.cpp
@@ -180,6 +180,26 @@ int main() {
   assert(!state.hasRestrictiveThreshold());
   assert(PowerTabTestAccess::mode(state) == Mode::UPowerDisabled);
 
+  // Huawei-WMI EC "off" / full charge is start=95 end=100, not 0/100.
+  state = supportedState(false);
+  state.effectiveStart = 95U;
+  state.effectiveEnd = 100U;
+  assert(!state.hasRestrictiveThreshold());
+  assert(PowerTabTestAccess::mode(state) == Mode::UPowerDisabled);
+  assert(PowerTabTestAccess::control(state) == std::tuple(true, false, true));
+
+  // Nearby restrictive pairs stay ExternallyManaged when the toggle is off.
+  state.effectiveStart = 95U;
+  state.effectiveEnd = 99U;
+  assert(state.hasRestrictiveThreshold());
+  assert(PowerTabTestAccess::mode(state) == Mode::ExternallyManaged);
+  assert(PowerTabTestAccess::control(state) == std::tuple(true, true, false));
+
+  state.effectiveStart = 75U;
+  state.effectiveEnd = 80U;
+  assert(state.hasRestrictiveThreshold());
+  assert(PowerTabTestAccess::mode(state) == Mode::ExternallyManaged);
+
   state = supportedState(true);
   state.supportedSettings = 4U;
   assert(PowerTabTestAccess::mode(state) == Mode::FirmwareManaged);


### PR DESCRIPTION
## Summary

Treat Huawei-WMI EC full-charge defaults (`charge_control_start_threshold=95`, `charge_control_end_threshold=100`) as unrestricted in `UPowerChargeLimitState::hasRestrictiveThreshold()`.

Power-tab classification and `UPowerService::enableChargeThreshold` already use that predicate, so the charge-threshold toggle no longer sticks in `ExternallyManaged` on MateBook hardware that reports 95/100 instead of 0/100. Restrictive pairs such as 75/80 and 95/99 stay externally managed.

## Motivation

On Huawei MateBook (huawei-wmi), the EC expresses “no limit / full charge” as start=95 end=100. The restrictive-threshold check treated any start in (0, 100) as a limit, so with `ChargeThresholdEnabled=false` the UI locked the toggle and refused `EnableChargeThreshold` until a manual `busctl` call. Same pattern as the Apple Silicon 100/100 workaround (#4261), for Huawei’s 95/100 sentinel.

## Type of Change

- [x] Bug fix

## Related Issue

Fixes #4144

## Testing

- Extended `tests/upower_charge_limit_test.cpp`:
  - 95/100 → not restrictive, `UPowerDisabled`, toggle enabled
  - 95/99 and 75/80 → stay `ExternallyManaged`
- Ran `clang-format` 22.1.0 on the touched files (no further edits).
- Full `meson test upower_charge_limit` not re-run in this environment (missing noctalia native deps); prior local candidate on the same predicate change passed that test.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Extends the existing `hasRestrictiveThreshold()` helper introduced/unified in #4261 rather than adding a second predicate name.