### PR TITLE
fix(network): treat OWE / OWE-TM as passwordless

### DIFF
--- a/src/dbus/network/network_manager_security.h
+++ b/src/dbus/network/network_manager_security.h
@@ -38,8 +38,10 @@ namespace network_manager_security {
   // Pure OWE / OWE-TM only. Ignored when SAE, PSK, or 802.1X is also advertised so
   // transitional APs still prompt for a password / EAP credentials.
   [[nodiscard]] constexpr bool supportsOwe(std::uint32_t rsnFlags) noexcept {
-    constexpr std::uint32_t kPassworded = kNm80211ApSecKeyMgmtPsk | kNm80211ApSecKeyMgmt8021X
-                                        | kNm80211ApSecKeyMgmtSae | kNm80211ApSecKeyMgmtEapSuiteB192;
+    constexpr std::uint32_t kPassworded = kNm80211ApSecKeyMgmtPsk
+        | kNm80211ApSecKeyMgmt8021X
+        | kNm80211ApSecKeyMgmtSae
+        | kNm80211ApSecKeyMgmtEapSuiteB192;
     if ((rsnFlags & kPassworded) != 0U) {
       return false;
     }

--- a/src/dbus/network/network_manager_security.h
+++ b/src/dbus/network/network_manager_security.h
@@ -10,11 +10,14 @@ namespace network_manager_security {
   inline constexpr std::uint32_t kNm80211ApSecKeyMgmtPsk = 0x00000100U;
   inline constexpr std::uint32_t kNm80211ApSecKeyMgmt8021X = 0x00000200U;
   inline constexpr std::uint32_t kNm80211ApSecKeyMgmtSae = 0x00000400U;
+  inline constexpr std::uint32_t kNm80211ApSecKeyMgmtOwe = 0x00000800U;
+  inline constexpr std::uint32_t kNm80211ApSecKeyMgmtOweTm = 0x00001000U;
   inline constexpr std::uint32_t kNm80211ApSecKeyMgmtEapSuiteB192 = 0x00002000U;
 
   enum class KeyManagement : std::uint8_t {
     Psk,              // wpa-psk: WPA/WPA2 Personal
     Sae,              // sae: WPA3 Personal
+    Owe,              // owe: Enhanced Open (passwordless)
     Enterprise,       // wpa-eap: WPA2/WPA3 Enterprise (802.1X)
     EnterpriseSuiteB, // wpa-eap-suite-b-192: WPA3 Enterprise 192-bit (CNSA)
   };
@@ -32,9 +35,21 @@ namespace network_manager_security {
     return (rsnFlags & (kNm80211ApSecKeyMgmt8021X | kNm80211ApSecKeyMgmtEapSuiteB192)) != 0U;
   }
 
+  // Pure OWE / OWE-TM only. Ignored when SAE, PSK, or 802.1X is also advertised so
+  // transitional APs still prompt for a password / EAP credentials.
+  [[nodiscard]] constexpr bool supportsOwe(std::uint32_t rsnFlags) noexcept {
+    constexpr std::uint32_t kPassworded = kNm80211ApSecKeyMgmtPsk | kNm80211ApSecKeyMgmt8021X
+                                        | kNm80211ApSecKeyMgmtSae | kNm80211ApSecKeyMgmtEapSuiteB192;
+    if ((rsnFlags & kPassworded) != 0U) {
+      return false;
+    }
+    return (rsnFlags & (kNm80211ApSecKeyMgmtOwe | kNm80211ApSecKeyMgmtOweTm)) != 0U;
+  }
+
   // Enterprise outranks SAE: an AP advertising 802.1X needs EAP credentials, and
   // no PSK the user could type would authenticate against it. Suite-B outranks
   // plain enterprise because its 192-bit suite is not negotiable down to wpa-eap.
+  // OWE is last among secured modes: only pure Enhanced Open maps here.
   [[nodiscard]] constexpr KeyManagement keyManagementFor(std::uint32_t rsnFlags) noexcept {
     if (supportsSuiteB192(rsnFlags)) {
       return KeyManagement::EnterpriseSuiteB;
@@ -45,6 +60,9 @@ namespace network_manager_security {
     if (supportsSae(rsnFlags)) {
       return KeyManagement::Sae;
     }
+    if (supportsOwe(rsnFlags)) {
+      return KeyManagement::Owe;
+    }
     return KeyManagement::Psk;
   }
 
@@ -52,6 +70,8 @@ namespace network_manager_security {
     switch (kind) {
     case KeyManagement::Sae:
       return "sae";
+    case KeyManagement::Owe:
+      return "owe";
     case KeyManagement::Enterprise:
       return "wpa-eap";
     case KeyManagement::EnterpriseSuiteB:
@@ -64,6 +84,12 @@ namespace network_manager_security {
 
   [[nodiscard]] constexpr bool isEnterprise(KeyManagement kind) noexcept {
     return kind == KeyManagement::Enterprise || kind == KeyManagement::EnterpriseSuiteB;
+  }
+
+  // Secured APs that still need a password / EAP prompt. OWE is encrypted but
+  // passwordless, so it is excluded.
+  [[nodiscard]] constexpr bool requiresPsk(bool secured, KeyManagement kind) noexcept {
+    return secured && kind != KeyManagement::Owe;
   }
 
 } // namespace network_manager_security

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -362,7 +362,7 @@ bool NetworkManagerService::activateAccessPoint(const AccessPointInfo& ap) {
             }
             if (err.has_value()) {
               kLog.debug("ActivateConnection(/) failed for ssid={}: {}; trying AddAndActivate", ap.ssid, err->what());
-              if (!ap.secured) {
+              if (!ap.requiresPsk()) {
                 addAndActivateAccessPoint(ap, std::nullopt);
               } else {
                 m_emitOnNextRefresh = true;
@@ -380,7 +380,7 @@ bool NetworkManagerService::activateAccessPoint(const AccessPointInfo& ap) {
     }
   }
 
-  if (ap.secured) {
+  if (ap.requiresPsk()) {
     return false;
   }
   return addAndActivateAccessPoint(ap, std::nullopt);
@@ -393,7 +393,7 @@ bool NetworkManagerService::activateAccessPoint(const AccessPointInfo& ap, const
   if (ap.active) {
     return true;
   }
-  if (ap.secured && psk.empty()) {
+  if (ap.requiresPsk() && psk.empty()) {
     return false;
   }
   // An 802.1X AP has no pre-shared key to accept. Falling through would build a
@@ -438,9 +438,10 @@ bool NetworkManagerService::addAndActivateAccessPoint(
   ConnectionSettings settings;
   if (ap.secured) {
     // Minimal secured-wifi settings — NM fills in ssid from the specific_object.
+    // OWE uses key-mgmt owe with no psk (Enhanced Open is passwordless).
     settings["802-11-wireless-security"]["key-mgmt"] =
         sdbus::Variant{std::string(network_manager_security::keyManagementName(ap.keyManagement))};
-    if (psk.has_value()) {
+    if (psk.has_value() && ap.keyManagement != network_manager_security::KeyManagement::Owe) {
       settings["802-11-wireless-security"]["psk"] = sdbus::Variant{*psk};
     }
     if (credentials.has_value()) {

--- a/src/dbus/network/network_types.h
+++ b/src/dbus/network/network_types.h
@@ -19,6 +19,12 @@ struct AccessPointInfo {
 
   [[nodiscard]] bool isEnterprise() const noexcept { return network_manager_security::isEnterprise(keyManagement); }
 
+  // True when the UI should collect credentials before connecting. OWE stays
+  // secured (lock icon) but has no password to ask for.
+  [[nodiscard]] bool requiresPsk() const noexcept {
+    return network_manager_security::requiresPsk(secured, keyManagement);
+  }
+
   bool operator==(const AccessPointInfo&) const = default;
 };
 

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -1321,7 +1321,7 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
                 if (clicked.active || m_network == nullptr) {
                   return;
                 }
-                if (clicked.secured && !m_network->hasSavedConnection(clicked.ssid)) {
+                if (clicked.requiresPsk() && !m_network->hasSavedConnection(clicked.ssid)) {
                   showPasswordPrompt(clicked);
                   PanelManager::instance().refresh();
                   return;

--- a/tests/network_manager_security_test.cpp
+++ b/tests/network_manager_security_test.cpp
@@ -13,6 +13,8 @@ namespace {
   constexpr std::uint32_t kWpa3Personal = kCiphers | 0x00000400U;
   constexpr std::uint32_t kWpa2Enterprise = kCiphers | 0x00000200U;
   constexpr std::uint32_t kWpa3Enterprise192 = kCiphers | 0x00000200U | 0x00002000U;
+  constexpr std::uint32_t kOwe = kCiphers | 0x00000800U;
+  constexpr std::uint32_t kOweTm = kCiphers | 0x00001000U;
 
 } // namespace
 
@@ -32,9 +34,21 @@ int main() {
   TEST_CHECK(!network_manager_security::supportsSuiteB192(kWpa2Enterprise));
   TEST_CHECK(network_manager_security::supportsSuiteB192(kWpa3Enterprise192));
 
+  TEST_CHECK(network_manager_security::supportsOwe(kOwe));
+  TEST_CHECK(network_manager_security::supportsOwe(kOweTm));
+  TEST_CHECK(network_manager_security::supportsOwe(kCiphers | 0x00000800U | 0x00001000U));
+  // Mixed OWE + passworded key-mgmt stays passworded.
+  TEST_CHECK(!network_manager_security::supportsOwe(kCiphers | 0x00000800U | 0x00000100U));
+  TEST_CHECK(!network_manager_security::supportsOwe(kCiphers | 0x00000800U | 0x00000400U));
+  TEST_CHECK(!network_manager_security::supportsOwe(kCiphers | 0x00000800U | 0x00000200U));
+  TEST_CHECK(!network_manager_security::supportsOwe(kWpa2Personal));
+  TEST_CHECK(!network_manager_security::supportsOwe(0U));
+
   TEST_CHECK(network_manager_security::keyManagementFor(0U) == KeyManagement::Psk);
   TEST_CHECK(network_manager_security::keyManagementFor(kWpa2Personal) == KeyManagement::Psk);
   TEST_CHECK(network_manager_security::keyManagementFor(kWpa3Personal) == KeyManagement::Sae);
+  TEST_CHECK(network_manager_security::keyManagementFor(kOwe) == KeyManagement::Owe);
+  TEST_CHECK(network_manager_security::keyManagementFor(kOweTm) == KeyManagement::Owe);
   TEST_CHECK(network_manager_security::keyManagementFor(kWpa2Enterprise) == KeyManagement::Enterprise);
   TEST_CHECK(network_manager_security::keyManagementFor(kWpa3Enterprise192) == KeyManagement::EnterpriseSuiteB);
 
@@ -53,27 +67,50 @@ int main() {
       network_manager_security::keyManagementFor(kCiphers | 0x00002000U | 0x00000400U)
       == KeyManagement::EnterpriseSuiteB
   );
+  // Mixed OWE + PSK/SAE/802.1X stays on the passworded path.
+  TEST_CHECK(network_manager_security::keyManagementFor(kCiphers | 0x00000800U | 0x00000100U) == KeyManagement::Psk);
+  TEST_CHECK(network_manager_security::keyManagementFor(kCiphers | 0x00000800U | 0x00000400U) == KeyManagement::Sae);
+  TEST_CHECK(
+      network_manager_security::keyManagementFor(kCiphers | 0x00000800U | 0x00000200U) == KeyManagement::Enterprise
+  );
 
   TEST_CHECK(network_manager_security::keyManagementName(KeyManagement::Psk) == "wpa-psk");
   TEST_CHECK(network_manager_security::keyManagementName(KeyManagement::Sae) == "sae");
+  TEST_CHECK(network_manager_security::keyManagementName(KeyManagement::Owe) == "owe");
   TEST_CHECK(network_manager_security::keyManagementName(KeyManagement::Enterprise) == "wpa-eap");
   TEST_CHECK(network_manager_security::keyManagementName(KeyManagement::EnterpriseSuiteB) == "wpa-eap-suite-b-192");
 
   TEST_CHECK(!network_manager_security::isEnterprise(KeyManagement::Psk));
   TEST_CHECK(!network_manager_security::isEnterprise(KeyManagement::Sae));
+  TEST_CHECK(!network_manager_security::isEnterprise(KeyManagement::Owe));
   TEST_CHECK(network_manager_security::isEnterprise(KeyManagement::Enterprise));
   TEST_CHECK(network_manager_security::isEnterprise(KeyManagement::EnterpriseSuiteB));
+
+  TEST_CHECK(!network_manager_security::requiresPsk(false, KeyManagement::Psk));
+  TEST_CHECK(network_manager_security::requiresPsk(true, KeyManagement::Psk));
+  TEST_CHECK(network_manager_security::requiresPsk(true, KeyManagement::Sae));
+  TEST_CHECK(!network_manager_security::requiresPsk(true, KeyManagement::Owe));
+  TEST_CHECK(network_manager_security::requiresPsk(true, KeyManagement::Enterprise));
 
   // A default-constructed AP stays personal, so nothing starts out asking for
   // EAP credentials before its RSN flags have been read.
   const AccessPointInfo accessPoint;
   TEST_CHECK(accessPoint.keyManagement == KeyManagement::Psk);
   TEST_CHECK(!accessPoint.isEnterprise());
+  TEST_CHECK(!accessPoint.requiresPsk());
 
   AccessPointInfo enterpriseAp;
+  enterpriseAp.secured = true;
   enterpriseAp.keyManagement = network_manager_security::keyManagementFor(kWpa2Enterprise);
   TEST_CHECK(enterpriseAp.isEnterprise());
+  TEST_CHECK(enterpriseAp.requiresPsk());
   TEST_CHECK(enterpriseAp != accessPoint);
+
+  AccessPointInfo oweAp;
+  oweAp.secured = true;
+  oweAp.keyManagement = network_manager_security::keyManagementFor(kOwe);
+  TEST_CHECK(oweAp.keyManagement == KeyManagement::Owe);
+  TEST_CHECK(!oweAp.requiresPsk());
 
   return 0;
 }


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item. -->

## Summary

Treat pure Enhanced Open (OWE / OWE-TM) access points as passwordless.

- Add `KEY_MGMT_OWE` / `OWE_TM` and `KeyManagement::Owe` (`key-mgmt owe`).
- `supportsOwe` is true only when OWE bits are set and SAE/PSK/802.1X are not.
- `requiresPsk` skips the Wi-Fi password prompt for OWE (lock icon still shows).
- `addAndActivateAccessPoint` writes `key-mgmt owe` with no `psk`.
- SAE / PSK / 802.1X paths unchanged.

## Motivation

Origin issue #4085: OWE / Enhanced Open networks (e.g. `#SFO FREE WIFI`) have no password, but any non-zero RSN flags were treated as credential-required, so the panel prompted for a PSK. NetworkManager already connects with `key-mgmt owe` and no PSK.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4085

## Testing

- `g++ -std=c++23 -I. -I src tests/network_manager_security_test.cpp` → exit 0 (OWE/OWE-TM map to owe; mixed OWE+PSK/SAE/802.1X stay passworded; `requiresPsk` false for OWE).
- `g++ -std=c++23 -I. -I src tests/enterprise_credentials_test.cpp` → exit 0.
- clang-format v22+ not available in this environment (box has v19; `.clang-format` needs v22 `BreakBinaryOperations`). Touched files follow existing style.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Candidate originally verified on pre-#4174 `supportsSae`/`keyManagement(bool)` API (`4e7c5e4a` on `21af8b9e`). Recreated on current `main` against the post-#4174 `KeyManagement` enum so the PR merges cleanly. SAE/PSK/enterprise behavior preserved.