### PR TITLE
feat(control-center): Manual rescan DDC monitors

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -286,7 +286,7 @@
     "display": {
       "disabled": "Disabled",
       "no-displays": "No monitors available",
-      "rescan": "Rescan monitors",
+      "rescan": "Rescan DDC/CI monitors",
       "unknown-resolution": "Unknown resolution"
     },
     "home": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -286,6 +286,7 @@
     "display": {
       "disabled": "Disabled",
       "no-displays": "No monitors available",
+      "rescan": "Rescan monitors",
       "unknown-resolution": "Unknown resolution"
     },
     "home": {

--- a/src/shell/control_center/tabs/monitor_tab.cpp
+++ b/src/shell/control_center/tabs/monitor_tab.cpp
@@ -116,12 +116,11 @@ std::unique_ptr<Flex> MonitorTab::create() {
 
 std::unique_ptr<Flex> MonitorTab::createHeaderActions() {
   const float scale = contentScale();
-  return ui::row(
+  auto row = ui::row(
       {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
       ui::button({
           .out = &m_rescanButton,
           .glyph = "refresh",
-          .enabled = m_configService != nullptr && m_configService->config().brightness.enableDdcutil,
           .tooltip = i18n::tr("control-center.display.rescan"),
           .onClick =
               [this]() {
@@ -132,6 +131,15 @@ std::unique_ptr<Flex> MonitorTab::createHeaderActions() {
           .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
       })
   );
+  syncHeaderActions();
+  return row;
+}
+
+// The rescan only re-runs ddcutil detect, so it is meaningless without DDC/CI.
+void MonitorTab::syncHeaderActions() {
+  if (m_rescanButton != nullptr) {
+    m_rescanButton->setVisible(m_configService != nullptr && m_configService->config().brightness.enableDdcutil);
+  }
 }
 
 void MonitorTab::setActive(bool active) {
@@ -199,9 +207,7 @@ void MonitorTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeig
 void MonitorTab::doUpdate(Renderer& renderer) {
   rebuildCards(renderer);
 
-  if (m_rescanButton != nullptr && m_configService != nullptr) {
-    m_rescanButton->setEnabled(m_configService->config().brightness.enableDdcutil);
-  }
+  syncHeaderActions();
 
   if (m_brightness == nullptr) {
     return;

--- a/src/shell/control_center/tabs/monitor_tab.cpp
+++ b/src/shell/control_center/tabs/monitor_tab.cpp
@@ -3,6 +3,7 @@
 #include "config/config_service.h"
 #include "i18n/i18n.h"
 #include "render/core/renderer.h"
+#include "shell/panel/panel_button_style.h"
 #include "system/brightness_service.h"
 #include "ui/builders.h"
 #include "ui/controls/scroll_view.h"
@@ -113,6 +114,26 @@ std::unique_ptr<Flex> MonitorTab::create() {
   return tab;
 }
 
+std::unique_ptr<Flex> MonitorTab::createHeaderActions() {
+  const float scale = contentScale();
+  return ui::row(
+      {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
+      ui::button({
+          .out = &m_rescanButton,
+          .glyph = "refresh",
+          .enabled = m_configService != nullptr && m_configService->config().brightness.enableDdcutil,
+          .tooltip = i18n::tr("control-center.display.rescan"),
+          .onClick =
+              [this]() {
+                if (m_brightness != nullptr) {
+                  m_brightness->requestDdcRescan();
+                }
+              },
+          .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
+      })
+  );
+}
+
 void MonitorTab::setActive(bool active) {
   const bool becameActive = active && !m_active;
   m_active = active;
@@ -128,6 +149,7 @@ void MonitorTab::onClose() {
   m_emptyState = nullptr;
   m_cardsScroll = nullptr;
   m_cardsLayout = nullptr;
+  m_rescanButton = nullptr;
   m_cards.clear();
   m_lastDisplayListKey.clear();
 }
@@ -176,6 +198,10 @@ void MonitorTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeig
 
 void MonitorTab::doUpdate(Renderer& renderer) {
   rebuildCards(renderer);
+
+  if (m_rescanButton != nullptr && m_configService != nullptr) {
+    m_rescanButton->setEnabled(m_configService->config().brightness.enableDdcutil);
+  }
 
   if (m_brightness == nullptr) {
     return;

--- a/src/shell/control_center/tabs/monitor_tab.h
+++ b/src/shell/control_center/tabs/monitor_tab.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 class BrightnessService;
+class Button;
 class ConfigService;
 class Flex;
 class Glyph;
@@ -21,6 +22,7 @@ public:
   MonitorTab(BrightnessService* brightness, ConfigService* config);
 
   std::unique_ptr<Flex> create() override;
+  std::unique_ptr<Flex> createHeaderActions() override;
   void setActive(bool active) override;
   void onClose() override;
   [[nodiscard]] bool dragging() const noexcept;
@@ -52,6 +54,7 @@ private:
   Flex* m_emptyState = nullptr;
   ScrollView* m_cardsScroll = nullptr;
   Flex* m_cardsLayout = nullptr;
+  Button* m_rescanButton = nullptr;
   std::vector<DisplayCard> m_cards;
   std::string m_lastDisplayListKey;
 

--- a/src/shell/control_center/tabs/monitor_tab.h
+++ b/src/shell/control_center/tabs/monitor_tab.h
@@ -30,6 +30,7 @@ public:
 private:
   void doLayout(Renderer& renderer, float contentWidth, float bodyHeight) override;
   void doUpdate(Renderer& renderer) override;
+  void syncHeaderActions();
   void rebuildCards(Renderer& renderer);
   void queueBrightness(const std::string& displayId, float value);
   void flushPendingBrightness(bool force = false);

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -1555,6 +1555,8 @@ void BrightnessService::setAllBrightness(float value) { m_impl->setAllBrightness
 
 void BrightnessService::requestDdcRefresh() { m_impl->queueDdcRefreshes(); }
 
+void BrightnessService::requestDdcRescan() { m_impl->scheduleDdcDetect(); }
+
 void BrightnessService::reload(const BrightnessConfig& config) { m_impl->reload(config); }
 
 void BrightnessService::onOutputsChanged() { m_impl->onOutputsChanged(); }

--- a/src/system/brightness_service.h
+++ b/src/system/brightness_service.h
@@ -47,6 +47,7 @@ public:
   void setAllBrightness(float value);
   void setBrightness(const std::string& displayId, float value);
   void requestDdcRefresh();
+  void requestDdcRescan();
   void reload(const BrightnessConfig& config);
   void onOutputsChanged();
   void registerIpc(IpcService& ipc, std::function<void(BatchChangePhase)> onBatchChange = {});


### PR DESCRIPTION
## Summary

Added "Refresh" button inside "Displays" view

## Motivation

DDC is complicated. Some monitors handle it better than others, and sometimes common "requestDdcRefresh()" that fires with "Displays" tab opening is not enough for a proper monitor detection. 

For example, I have a DELL monitor.

1. Turn off the display
2. Start the Noctalia
3. Turn on the display

With current requestDdcRefresh() implementation, Noctalia will not register a state change of my monitor and it'll stay inactive in controls - it requires separate "ddcutil detect" to refresh it's state. This button does it.   


## Type of Change

<!-- Mark all that apply. -->

- [x] New feature

## Testing

Tested the patch on my machine.

## Screenshots / Videos

<img width="486" height="305" alt="image" src="https://github.com/user-attachments/assets/c854d2b8-6ab2-41e0-b9b9-32d636885a46" />

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

1. Code is generated by Astra. 
2. Actually, "ddcutil detect" can be injected inside requestDdcRefresh(). Maybe more invisible approach is better one - but it can (potentially) make the view a little bit less responsive.