### PR TITLE
fix(templates): close Umbriel include.files on the real array, not a comment

### DIFF
--- a/assets/templates/umbriel/apply.sh
+++ b/assets/templates/umbriel/apply.sh
@@ -35,37 +35,37 @@ awk '
         added = 1
     }
 
-    # Code before an inline '#' comment. Needed so "# []" is not array syntax.
-    function code_before_comment(s,   hash) {
-        hash = index(s, "#")
-        if (hash == 0)
-            return s
-        return substr(s, 1, hash - 1)
+    # Offset of the first ch at or after start that is real array syntax: not
+    # inside a quoted string and not inside a # comment. Strings and comments
+    # end at a newline. Returns 0 when the buffer has no such character.
+    # Entries are TOML basic strings, matching the rest of this script.
+    function find_syntax(s, start, ch,   i, c, in_str, in_comment) {
+        for (i = start; i <= length(s); i++) {
+            c = substr(s, i, 1)
+            if (c == "\n") { in_str = 0; in_comment = 0; continue }
+            if (in_comment) continue
+            if (in_str) {
+                if (c == "\\") { i++; continue }
+                if (c == "\"") in_str = 0
+                continue
+            }
+            if (c == "\"") { in_str = 1; continue }
+            if (c == "#") { in_comment = 1; continue }
+            if (c == ch) return i
+        }
+        return 0
     }
 
     function has_array_close(s) {
-        return index(code_before_comment(s), "]") > 0
-    }
-
-    # First ']' after open that is not inside a '#' comment on that line.
-    function find_close(buf, open,   i, c, in_comment) {
-        in_comment = 0
-        for (i = open + 1; i <= length(buf); i++) {
-            c = substr(buf, i, 1)
-            if (c == "\n") { in_comment = 0; continue }
-            if (in_comment) continue
-            if (c == "#") { in_comment = 1; continue }
-            if (c == "]") return i
-        }
-        return 0
+        return find_syntax(s, 1, "]") > 0
     }
 
     # Rebuild a complete "files = [ ... ]" statement (buf may span lines),
     # dropping any existing noctalia.toml entry and appending it last so it
     # overrides earlier includes. Handles single-line and multi-line arrays.
     function build(buf,   open, endp, head, inner, tail, test, multiline, indent) {
-        open = index(buf, "[")
-        endp = find_close(buf, open)
+        open = find_syntax(buf, 1, "[")
+        endp = find_syntax(buf, open + 1, "]")
         if (open == 0 || endp == 0 || endp < open) {
             print "error: include.files must be an array" > "/dev/stderr"
             exit 2
@@ -125,7 +125,7 @@ awk '
 
     in_include && /^[[:space:]]*files[[:space:]]*=/ {
         saw_files = 1
-        if (index($0, "[") == 0) {
+        if (find_syntax($0, 1, "[") == 0) {
             print "error: include.files must be an array" > "/dev/stderr"
             exit 2
         }

--- a/assets/templates/umbriel/apply.sh
+++ b/assets/templates/umbriel/apply.sh
@@ -35,14 +35,37 @@ awk '
         added = 1
     }
 
+    # Code before an inline '#' comment. Needed so "# []" is not array syntax.
+    function code_before_comment(s,   hash) {
+        hash = index(s, "#")
+        if (hash == 0)
+            return s
+        return substr(s, 1, hash - 1)
+    }
+
+    function has_array_close(s) {
+        return index(code_before_comment(s), "]") > 0
+    }
+
+    # First ']' after open that is not inside a '#' comment on that line.
+    function find_close(buf, open,   i, c, in_comment) {
+        in_comment = 0
+        for (i = open + 1; i <= length(buf); i++) {
+            c = substr(buf, i, 1)
+            if (c == "\n") { in_comment = 0; continue }
+            if (in_comment) continue
+            if (c == "#") { in_comment = 1; continue }
+            if (c == "]") return i
+        }
+        return 0
+    }
+
     # Rebuild a complete "files = [ ... ]" statement (buf may span lines),
     # dropping any existing noctalia.toml entry and appending it last so it
     # overrides earlier includes. Handles single-line and multi-line arrays.
-    function build(buf,   open, endp, i, head, inner, tail, test, multiline, indent) {
+    function build(buf,   open, endp, head, inner, tail, test, multiline, indent) {
         open = index(buf, "[")
-        endp = 0
-        for (i = length(buf); i >= 1; i--)
-            if (substr(buf, i, 1) == "]") { endp = i; break }
+        endp = find_close(buf, open)
         if (open == 0 || endp == 0 || endp < open) {
             print "error: include.files must be an array" > "/dev/stderr"
             exit 2
@@ -79,7 +102,7 @@ awk '
 
     collecting {
         buf = buf "\n" $0
-        if (index($0, "]") > 0) {
+        if (has_array_close($0)) {
             print build(buf)
             collecting = 0
             added = 1
@@ -107,7 +130,7 @@ awk '
             exit 2
         }
         buf = $0
-        if (index($0, "]") > 0) {
+        if (has_array_close($0)) {
             print build(buf)
             added = 1
         } else {

--- a/meson.build
+++ b/meson.build
@@ -1300,4 +1300,9 @@ if build_tests
     args: ['tests/template_undo_signal_test.sh', meson.current_source_dir() / 'assets/templates'],
     workdir: meson.current_source_dir(),
   )
+  test('umbriel_apply_include_comment',
+    bash_program,
+    args: ['tests/umbriel_apply_include_comment_test.sh', meson.current_source_dir() / 'assets/templates/umbriel/apply.sh'],
+    workdir: meson.current_source_dir(),
+  )
 endif # build_tests

--- a/tests/umbriel_apply_include_comment_test.sh
+++ b/tests/umbriel_apply_include_comment_test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# apply.sh must close include.files on the real array ']', not a '#' comment's
-# brackets. Otherwise wallpaper apply moves noctalia.toml into the comment and
-# empties the array (noctalia-dev/noctalia#4332).
+# apply.sh must close include.files on the real array ']', not on brackets
+# inside a '#' comment or inside a quoted entry name. Otherwise wallpaper apply
+# moves noctalia.toml into the comment and empties the array
+# (noctalia-dev/noctalia#4332), or splices it into a file name.
 
 set -euo pipefail
 
@@ -43,6 +44,23 @@ expect() {
   fi
 }
 
+expect_error() {
+  local name=$1
+  shift
+  local home="$work_dir/$name"
+  mkdir -p "$home/umbriel"
+  printf '%s\n' "$@" >"$home/umbriel/config.toml"
+  local before status=0
+  before=$(cat "$home/umbriel/config.toml")
+  XDG_CONFIG_HOME="$home" bash "$apply_sh" 2>/dev/null || status=$?
+  if [ "$status" != 2 ]; then
+    fail "$name: expected exit 2, got $status"
+  fi
+  if [ "$(cat "$home/umbriel/config.toml")" != "$before" ]; then
+    fail "$name: config rewritten despite the error"
+  fi
+}
+
 expect reporter \
   'files = ["noctalia.toml"] # []' \
   '[include]' \
@@ -69,3 +87,18 @@ expect multiline \
   'files = [' \
   '  "user.toml",' \
   ']'
+
+expect quoted_hash \
+  'files = ["a#b.toml", "noctalia.toml"]' \
+  '[include]' \
+  'files = ["a#b.toml"]'
+
+expect quoted_close \
+  'files = ["a]b.toml", "noctalia.toml"]' \
+  '[include]' \
+  'files = ["a]b.toml"]'
+
+# A scalar value whose only brackets sit in a comment is not an array.
+expect_error scalar_bracket_comment \
+  '[include]' \
+  'files = "user.toml" # [a]'

--- a/tests/umbriel_apply_include_comment_test.sh
+++ b/tests/umbriel_apply_include_comment_test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# apply.sh must close include.files on the real array ']', not a '#' comment's
+# brackets. Otherwise wallpaper apply moves noctalia.toml into the comment and
+# empties the array (noctalia-dev/noctalia#4332).
+
+set -euo pipefail
+
+apply_sh=${1:?apply.sh path}
+
+fail() {
+  printf '%s\n' "umbriel_apply_include_comment_test: FAIL: $*" >&2
+  exit 1
+}
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+files_line() {
+  sed -n '/^[[:space:]]*files[[:space:]]*=/,$p' "$1"
+}
+
+run_apply() {
+  local name=$1
+  shift
+  local home="$work_dir/$name"
+  mkdir -p "$home/umbriel"
+  printf '%s\n' "$@" >"$home/umbriel/config.toml"
+  XDG_CONFIG_HOME="$home" bash "$apply_sh" \
+    || fail "$name: apply.sh exited non-zero"
+  files_line "$home/umbriel/config.toml"
+}
+
+expect() {
+  local name=$1
+  shift
+  local want=$1
+  shift
+  local got
+  got=$(run_apply "$name" "$@")
+  if [ "$got" != "$want" ]; then
+    fail "$name: expected $(printf '%q' "$want") got $(printf '%q' "$got")"
+  fi
+}
+
+expect reporter \
+  'files = ["noctalia.toml"] # []' \
+  '[include]' \
+  'files = ["noctalia.toml"] # []'
+
+expect control_nocomment \
+  'files = ["noctalia.toml"]' \
+  '[include]' \
+  'files = ["noctalia.toml"]'
+
+expect control_comment \
+  'files = ["noctalia.toml"] # keep this' \
+  '[include]' \
+  'files = ["noctalia.toml"] # keep this'
+
+expect user_comment \
+  'files = ["user.toml", "noctalia.toml"] # []' \
+  '[include]' \
+  'files = ["user.toml"] # []'
+
+expect multiline \
+  $'files = [\n  "user.toml",\n  "noctalia.toml",\n]' \
+  '[include]' \
+  'files = [' \
+  '  "user.toml",' \
+  ']'


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item. -->

## Summary

Close Umbriel `include.files` on the first `]` that is not inside a `#` comment, so an inline `# []` is not treated as the array closer.

- `assets/templates/umbriel/apply.sh` `build()` used a reverse scan for the last `]` in the whole buffer.
- `files = ["noctalia.toml"] # []` therefore became `files = [] # [, "noctalia.toml"]`.
- Keep the existing multi-line array path. `undo.sh` is unchanged.

## Motivation

Origin issue #4332: wallpaper apply rewrites `[include].files` and can move `noctalia.toml` into the comment when the line ends with `# []`. The control without a `]` in the comment is already fine.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Fixes #4332

## Testing

- `tests/umbriel_apply_include_comment_test.sh` (meson `umbriel_apply_include_comment`):
  - reporter: `files = ["noctalia.toml"] # []` keeps `noctalia.toml` inside the real array
  - `files = ["user.toml"] # []` becomes `["user.toml", "noctalia.toml"] # []`
  - no-comment single-line and comment-without-brackets stay valid
  - multi-line include array still appends last
- Neighbor `template_undo_signal` still passes.
- Fail-then-pass on the pinned baseline blob vs this SHA.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Shell-only template rewrite; no compositor or bar UI change. Manual compositor coverage does not apply.

## Screenshots / Videos

Not applicable (config-file rewrite, no UI).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No C++ or TOML-parser rewrite. Comment text after a real `]` is preserved.