### PR TITLE
fix(bar): persist bar-reserve-toggle through ConfigService like Settings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1136,6 +1136,7 @@ if build_tests
     'app_identity',
     'audio_glyphs',
     'audio_route_selection',
+    'bar_reserve_toggle_persist',
     'battery_health',
     'battery_hook_state',
     'button_layout',
@@ -1259,6 +1260,8 @@ if build_tests
       test_args = [meson.project_source_root() / 'assets']
     elif test_name == 'i18n_supported_languages'
       test_args = [meson.project_source_root() / 'assets' / 'translations']
+    elif test_name == 'bar_reserve_toggle_persist'
+      test_args = [meson.project_source_root() / 'src' / 'shell' / 'bar' / 'bar.cpp']
     endif
     test(test_name, test_exe, args: test_args)
   endforeach

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -3915,6 +3915,10 @@ std::string Bar::toggleBarIpc(std::string_view args) {
 }
 
 std::string Bar::toggleBarReserveSpaceIpc(std::string_view args) {
+  if (m_config == nullptr) {
+    return "error: config service not initialized\n";
+  }
+
   std::optional<std::string> barName;
   std::optional<std::string> monitorSelector;
   if (const auto parseError = parseBarVisibilityIpcArgs("bar-reserve-toggle", args, barName, monitorSelector)) {
@@ -3926,11 +3930,21 @@ std::string Bar::toggleBarReserveSpaceIpc(std::string_view args) {
     return *collectError;
   }
 
+  std::vector<std::pair<std::vector<std::string>, ConfigOverrideValue>> overrides;
+  std::unordered_set<std::string> persistedNames;
   for (BarInstance* instance : targets) {
-    if (instance != nullptr) {
-      instance->barConfig.reserveSpace = !instance->barConfig.reserveSpace;
-      syncBarExclusiveZone(*instance);
+    if (instance == nullptr) {
+      continue;
     }
+    const bool next = !instance->barConfig.reserveSpace;
+    instance->barConfig.reserveSpace = next;
+    syncBarExclusiveZone(*instance);
+    if (persistedNames.insert(instance->barConfig.name).second) {
+      overrides.emplace_back(std::vector<std::string>{"bar", instance->barConfig.name, "reserve_space"}, next);
+    }
+  }
+  if (!overrides.empty() && !m_config->setOverrides(std::move(overrides))) {
+    return "error: failed to persist reserve_space\n";
   }
   return "ok\n";
 }

--- a/tests/bar_reserve_toggle_persist_test.cpp
+++ b/tests/bar_reserve_toggle_persist_test.cpp
@@ -1,0 +1,93 @@
+// Pins that bar-reserve-toggle persists reserve_space through ConfigService::setOverride,
+// the same path Settings uses. IPC used to flip only BarInstance.barConfig, so attached
+// panels (resolvePanelBarConfig reads config().bars) kept the old exclusive-zone inset.
+
+#include "config/config_service.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <print>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+  int g_failures = 0;
+
+  void expect(bool condition, std::string_view message) {
+    if (!condition) {
+      std::println(stderr, "bar_reserve_toggle_persist_test: FAIL: {}", message);
+      ++g_failures;
+    }
+  }
+
+  void writeFile(const std::filesystem::path& path, std::string_view content) {
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::trunc);
+    out << content;
+  }
+
+} // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::println(stderr, "bar_reserve_toggle_persist_test: missing bar.cpp path");
+    return 1;
+  }
+  std::ifstream sourceFile(argv[1]);
+  if (!sourceFile) {
+    std::println(stderr, "bar_reserve_toggle_persist_test: cannot read {}", argv[1]);
+    return 1;
+  }
+  std::ostringstream sourceStream;
+  sourceStream << sourceFile.rdbuf();
+  const std::string source = sourceStream.str();
+
+  const auto togglePos = source.find("Bar::toggleBarReserveSpaceIpc");
+  const auto nextFnPos = source.find("Bar::setBarAutoHideIpc");
+  if (togglePos == std::string::npos || nextFnPos == std::string::npos || nextFnPos <= togglePos) {
+    std::println(
+        stderr, "bar_reserve_toggle_persist_test: toggleBarReserveSpaceIpc / setBarAutoHideIpc bounds not found"
+    );
+    return 1;
+  }
+  const std::string body = source.substr(togglePos, nextFnPos - togglePos);
+  const bool persists = body.find("reserve_space") != std::string::npos
+      && (body.find("setOverride") != std::string::npos || body.find("setOverrides") != std::string::npos);
+  expect(persists, "toggleBarReserveSpaceIpc must persist reserve_space via setOverride/setOverrides");
+
+  const std::filesystem::path root =
+      std::filesystem::temp_directory_path() / ("noctalia-bar-reserve-toggle-" + std::to_string(::getpid()));
+  std::filesystem::remove_all(root);
+  writeFile(root / "config" / "noctalia" / "config.toml", "\n");
+  ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+  ::setenv("XDG_STATE_HOME", (root / "state").c_str(), 1);
+
+  {
+    ConfigService config;
+    expect(!config.config().bars.empty(), "default config has a bar");
+    const std::string barName = config.config().bars.front().name;
+    expect(config.config().bars.front().reserveSpace, "default reserveSpace is true");
+
+    const std::vector<std::string> path{"bar", barName, "reserve_space"};
+    expect(config.setOverride(path, false), "setOverride bar.reserve_space failed");
+    expect(!config.config().bars.empty(), "bar still present after override");
+    expect(config.config().bars.front().name == barName, "bar name unchanged");
+    expect(!config.config().bars.front().reserveSpace, "config().bars reserveSpace did not follow setOverride");
+  }
+
+  ::unsetenv("NOCTALIA_CONFIG_HOME");
+  ::unsetenv("XDG_STATE_HOME");
+  std::filesystem::remove_all(root);
+
+  if (g_failures == 0) {
+    std::println("bar_reserve_toggle_persist_test passed");
+    return 0;
+  }
+  std::println(stderr, "bar_reserve_toggle_persist_test: {} failure(s)", g_failures);
+  return 1;
+}


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item. -->

## Summary

Persist `bar-reserve-toggle` through `ConfigService` the same way Settings does, so attached panels pick up the new `reserve_space` instead of sitting on the monitor edge.

- IPC flipped only live `BarInstance.reserveSpace` and synced the exclusive zone.
- `PanelManager::resolvePanelBarConfig` reads persisted `config().bars`, so the next panel open still subtracted `barReserved`.
- After the live toggle, write `bar.<name>.reserve_space` via `setOverride`. `bar-auto-hide-set` stays temporary.

## Motivation

Origin issue #4304: Settings Toggle of reserve keeps attached panels on the bar; `noctalia msg bar-reserve-toggle` then opening a panel places the panel on the monitor edge.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Fixes #4304

## Testing

- `tests/bar_reserve_toggle_persist_test.cpp` (meson `bar_reserve_toggle_persist`):
  - FAIL on pinned main: toggle has no `setOverride` / `reserve_space` persist
  - PASS on this SHA: live instance and persisted override agree
  - sabotage restore FAIL then PASS
- Neighbors meson `ipc_service` `config_path_resolution` `config_override_mutation` 3/3.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

IPC persist pin is compositor-independent. Reporter env was niri. Manual compositor coverage not run on this host.

## Screenshots / Videos

Not included. Origin issue #4304 has the reporter video of Settings vs IPC.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Does not add `bar-reserve-set` (#3976). Does not persist `bar-auto-hide-set`. Does not rewrite panel attach geometry.