### PR TITLE
fix(fingerprint): retry transient authorization failures after resume

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1276,6 +1276,21 @@ if build_tests
   )
   dbus_run_session = find_program('dbus-run-session', required: false)
   if dbus_run_session.found()
+    fingerprint_integration_exe = executable('fingerprint_authenticator_integration_test',
+      sources: files('tests/fingerprint_authenticator_integration_test.cpp'),
+      dependencies: noctalia_core_dep,
+      override_options: ['b_ndebug=false'],
+    )
+    test('fingerprint_authenticator_integration',
+      dbus_run_session,
+      args: [
+        '--', 'sh', '-c',
+        'export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"; exec "$1"',
+        'sh', fingerprint_integration_exe.full_path(),
+      ],
+      depends: fingerprint_integration_exe,
+      timeout: 60,
+    )
     test('upower_charge_limit_integration',
       dbus_run_session,
       args: [

--- a/src/auth/fingerprint_authenticator.cpp
+++ b/src/auth/fingerprint_authenticator.cpp
@@ -29,6 +29,9 @@ namespace {
 
   constexpr int kMaxRetries = 3;
   constexpr auto kRetryDelay = std::chrono::milliseconds(250);
+  // logind may announce resume before the user's session becomes active. Give polkit
+  // time to authorize it, but do not poll indefinitely if access really is denied.
+  constexpr int kMaxAuthorizationRetries = 20;
 
   enum class MatchResult {
     Invalid,
@@ -58,8 +61,8 @@ namespace {
   }
 
   bool isRecoverableVerifyStartError(const sdbus::Error& error) {
-    // Suspend/resume can drop the claim while the proxy survives; only that case is worth
-    // recreating+reclaiming. Other VerifyStart failures are permanent for this lock attempt.
+    // Suspend/resume can drop the claim while the proxy survives; only that case needs
+    // recreating+reclaiming. PermissionDenied is retried separately without dropping ownership.
     return error.getName() == sdbus::Error::Name{"net.reactivated.Fprint.Error.ClaimDevice"};
   }
 } // namespace
@@ -79,6 +82,7 @@ FingerprintAuthenticator::FingerprintAuthenticator(SystemBus& bus) : m_bus(bus) 
         m_retryTimer.stop();
         m_verifying = false;
       } else if (m_active && !m_abort) {
+        m_authorizationRetries = 0;
         startVerify(false);
       }
     });
@@ -104,6 +108,7 @@ void FingerprintAuthenticator::start() {
   m_active = true;
   m_abort = false;
   m_retries = 0;
+  m_authorizationRetries = 0;
   m_reclaimAttempted = false;
   if (m_sleeping) {
     return;
@@ -184,13 +189,39 @@ void FingerprintAuthenticator::claimDevice() {
         if (e.has_value()) {
           kLog.info("could not claim fingerprint device: {}", e->what());
           m_verifying = false;
+          if (e->getName() == sdbus::Error::Name{"net.reactivated.Fprint.Error.PermissionDenied"}
+              && scheduleAuthorizationRetry(true, false)) {
+            return;
+          }
+          emitStatus({}, false);
           return;
         }
         kLog.info("claimed fingerprint device");
-        if (m_active && !m_sleeping) {
+        if (m_active && !m_sleeping && !m_abort) {
           startVerify(false);
         }
       });
+}
+
+bool FingerprintAuthenticator::scheduleAuthorizationRetry(bool claiming, bool isRetry) {
+  if (!m_active || m_sleeping || m_abort || m_authorizationRetries >= kMaxAuthorizationRetries) {
+    return false;
+  }
+  ++m_authorizationRetries;
+  // Reuse the proxy: a denied Claim must be retried as Claim, while a denied
+  // VerifyStart does not mean we lost ownership of the device. Defer all calls
+  // until after the async reply handler returns.
+  m_retryTimer.start(kRetryDelay, [this, claiming, isRetry]() {
+    if (!m_active || m_sleeping || m_abort) {
+      return;
+    }
+    if (claiming) {
+      claimDevice();
+    } else {
+      startVerify(isRetry);
+    }
+  });
+  return true;
 }
 
 void FingerprintAuthenticator::startVerify(bool isRetry) {
@@ -220,6 +251,10 @@ void FingerprintAuthenticator::startVerify(bool isRetry) {
         if (e.has_value()) {
           kLog.info("could not start fingerprint verification: {}", e->what());
           m_verifying = false;
+          if (e->getName() == sdbus::Error::Name{"net.reactivated.Fprint.Error.PermissionDenied"}
+              && scheduleAuthorizationRetry(false, isRetry)) {
+            return;
+          }
           // A claim dropped across suspend/resume makes VerifyStart fail with ClaimDevice; drop the
           // stale proxy and recreate+reclaim once. Destroying the proxy here would use-after-free
           // the async reply handler, so defer the reset until after it returns.

--- a/src/auth/fingerprint_authenticator.h
+++ b/src/auth/fingerprint_authenticator.h
@@ -30,7 +30,10 @@ public:
   void stop();
 
 private:
+  friend class FingerprintAuthenticatorTestAccess;
+
   bool createDeviceProxy();
+  bool scheduleAuthorizationRetry(bool claiming, bool isRetry);
   void claimDevice();
   void startVerify(bool isRetry);
   void stopVerify();
@@ -54,4 +57,5 @@ private:
   bool m_abort = false;
   bool m_reclaimAttempted = false;
   int m_retries = 0;
+  int m_authorizationRetries = 0;
 };

--- a/tests/fingerprint_authenticator_integration_test.cpp
+++ b/tests/fingerprint_authenticator_integration_test.cpp
@@ -1,3 +1,31 @@
+// Regression tests for the fingerprint authorization race reported in #3602:
+// logind can emit PrepareForSleep(false) before the user's session becomes active,
+// causing fprintd to deny Claim or VerifyStart. Previously, the authenticator did
+// not retry those denials, leaving the reader idle even after activation.
+//
+// These tests run the real FingerprintAuthenticator, SystemBus, and TimerManager
+// against fake fprintd/logind services on a private D-Bus. The fake services hold
+// asynchronous replies until the test explicitly returns PermissionDenied or
+// success. This imposes the wake/denial/recovery ordering deterministically;
+// timer dispatch is controlled by the test, but delays use the real clock.
+// No actual suspend, session activation, polkit policy, or fingerprint hardware
+// is exercised: the tests simulate the authorization results of that race.
+//
+// Specifically, they verify that:
+// - Repeated Claim and VerifyStart denials after wake recover once allowed.
+// - A denied Claim is retried before verification, and a retained claim is reused.
+// - Permanent denial stops after 20 retries, clears the status, and does not
+//   consume match attempts; a later lock activation gets a fresh retry budget.
+// - Stop and suspend cancel scheduled retries; a denial delivered afterward does
+//   not schedule new work (stop cancels the proxy callback, suspend guards it).
+// - AlreadyInUse is not retried, while ClaimDevice still triggers reacquisition.
+// - Authorization retries preserve the failed-match count and the pending
+//   match-retry increment, so repeated mismatches still reach the match limit.
+//
+// On the unpatched implementation, the first denied Claim fails the assertion
+// that a retry is pending. Meson runs this test through dbus-run-session with
+// DBUS_SYSTEM_BUS_ADDRESS redirected to the private session bus.
+
 #include "auth/fingerprint_authenticator.h"
 #include "core/timer_manager.h"
 #include "dbus/system_bus.h"

--- a/tests/fingerprint_authenticator_integration_test.cpp
+++ b/tests/fingerprint_authenticator_integration_test.cpp
@@ -1,0 +1,379 @@
+#include "auth/fingerprint_authenticator.h"
+#include "core/timer_manager.h"
+#include "dbus/system_bus.h"
+#include "i18n/i18n.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <print>
+#include <sdbus-c++/sdbus-c++.h>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+class FingerprintAuthenticatorTestAccess {
+public:
+  static bool sleeping(const FingerprintAuthenticator& auth) { return auth.m_sleeping; }
+  static bool idle(const FingerprintAuthenticator& auth) { return !auth.m_claiming && !auth.m_verifying; }
+  static bool retryPending(const FingerprintAuthenticator& auth) { return auth.m_retryTimer.active(); }
+  static int matchRetries(const FingerprintAuthenticator& auth) { return auth.m_retries; }
+  static int authorizationRetries(const FingerprintAuthenticator& auth) { return auth.m_authorizationRetries; }
+};
+
+namespace {
+  using Access = FingerprintAuthenticatorTestAccess;
+  using namespace std::chrono_literals;
+
+  constexpr auto kDeviceInterface = "net.reactivated.Fprint.Device";
+  constexpr auto kLoginInterface = "org.freedesktop.login1.Manager";
+  const sdbus::ObjectPath kDevicePath{"/net/reactivated/Fprint/Device/0"};
+  const sdbus::Error kPermissionDenied{
+      sdbus::Error::Name{"net.reactivated.Fprint.Error.PermissionDenied"}, "Session is inactive"
+  };
+
+  enum class Method { Claim, VerifyStart };
+
+  // Only the fake service runs on a worker thread. Replies are held until the test
+  // explicitly completes them, so the race is an imposed ordering, not a timing bet.
+  class FakeServices {
+  public:
+    FakeServices()
+        : m_connection(sdbus::createSessionBusConnection(sdbus::ServiceName{"net.reactivated.Fprint"})),
+          m_manager(sdbus::createObject(*m_connection, sdbus::ObjectPath{"/net/reactivated/Fprint/Manager"})),
+          m_device(sdbus::createObject(*m_connection, kDevicePath)),
+          m_logind(sdbus::createObject(*m_connection, sdbus::ObjectPath{"/org/freedesktop/login1"})) {
+      m_connection->requestName(sdbus::ServiceName{"org.freedesktop.login1"});
+      m_manager->addVTable(
+                   sdbus::registerMethod("GetDefaultDevice").implementedAs([]() { return kDevicePath; })
+      ).forInterface("net.reactivated.Fprint.Manager");
+      m_device
+          ->addVTable(
+              sdbus::registerMethod("Claim").implementedAs([this](sdbus::Result<>&& result, std::string user) {
+                assert(user.empty());
+                enqueue(Method::Claim, std::move(result));
+              }),
+              sdbus::registerMethod("VerifyStart").implementedAs([this](sdbus::Result<>&& result, std::string finger) {
+                assert(finger == "any");
+                enqueue(Method::VerifyStart, std::move(result));
+              }),
+              sdbus::registerMethod("VerifyStop").implementedAs([]() {}),
+              sdbus::registerMethod("Release").implementedAs([this]() {
+                std::scoped_lock lock(m_mutex);
+                m_claimed = false;
+              }),
+              sdbus::registerSignal("VerifyStatus").withParameters<std::string, bool>()
+          )
+          .forInterface(kDeviceInterface);
+      m_logind->addVTable(sdbus::registerSignal("PrepareForSleep").withParameters<bool>())
+          .forInterface(kLoginInterface);
+      m_connection->enterEventLoopAsync();
+    }
+
+    ~FakeServices() { m_connection->leaveEventLoop(); }
+
+    void sleep(bool sleeping) {
+      m_logind->emitSignal("PrepareForSleep").onInterface(kLoginInterface).withArguments(sleeping);
+    }
+
+    void verifyStatus(const std::string& result) {
+      m_device->emitSignal("VerifyStatus").onInterface(kDeviceInterface).withArguments(result, true);
+    }
+
+    bool pending(Method method) const {
+      std::scoped_lock lock(m_mutex);
+      return m_pending.has_value() && m_method == method;
+    }
+
+    int calls(Method method) const {
+      std::scoped_lock lock(m_mutex);
+      return method == Method::Claim ? m_claimCalls : m_verifyCalls;
+    }
+
+    void reply(Method method, std::optional<sdbus::Error> error = std::nullopt) {
+      std::optional<sdbus::Result<>> result;
+      {
+        std::scoped_lock lock(m_mutex);
+        assert(m_pending.has_value() && m_method == method);
+        result = std::move(m_pending);
+        m_pending.reset();
+        if (!error) {
+          if (method == Method::Claim) {
+            assert(!m_claimed && "must not reclaim a device we still own");
+            m_claimed = true;
+          } else {
+            assert(m_claimed && "must retry Claim before VerifyStart");
+          }
+        }
+      }
+      if (error) {
+        result->returnError(*error);
+      } else {
+        result->returnResults();
+      }
+    }
+
+    void dropClaim() {
+      std::scoped_lock lock(m_mutex);
+      m_claimed = false;
+    }
+
+  private:
+    void enqueue(Method method, sdbus::Result<>&& result) {
+      std::scoped_lock lock(m_mutex);
+      assert(!m_pending.has_value() && "overlapping fingerprint requests");
+      m_method = method;
+      m_pending.emplace(std::move(result));
+      if (method == Method::Claim) {
+        ++m_claimCalls;
+      } else {
+        ++m_verifyCalls;
+      }
+    }
+
+    std::unique_ptr<sdbus::IConnection> m_connection;
+    std::unique_ptr<sdbus::IObject> m_manager;
+    std::unique_ptr<sdbus::IObject> m_device;
+    std::unique_ptr<sdbus::IObject> m_logind;
+    mutable std::mutex m_mutex;
+    std::optional<sdbus::Result<>> m_pending;
+    Method m_method = Method::Claim;
+    bool m_claimed = false;
+    int m_claimCalls = 0;
+    int m_verifyCalls = 0;
+  };
+
+  struct Fixture {
+    FakeServices services;
+    SystemBus bus;
+    FingerprintAuthenticator auth{bus};
+    std::vector<std::string> statuses;
+    int authenticated = 0;
+
+    Fixture() {
+      auth.setStatusCallback([this](const std::string& status, bool) { statuses.push_back(status); });
+      auth.setAuthenticatedCallback([this]() { ++authenticated; });
+    }
+
+    // Timers run only when requested. In particular, assertions after a denied
+    // reply cannot race with the retry firing on a slow CI machine.
+    template <typename Predicate> void until(Predicate predicate, bool tickTimers = false) {
+      const auto deadline = std::chrono::steady_clock::now() + 10s;
+      do {
+        bus.processPendingEvents();
+        if (tickTimers) {
+          TimerManager::instance().tick();
+        }
+        if (std::invoke(predicate)) {
+          return;
+        }
+        std::this_thread::sleep_for(1ms);
+      } while (std::chrono::steady_clock::now() < deadline);
+      std::println(stderr, "fingerprint_authenticator_integration_test: timed out waiting for state");
+      std::abort();
+    }
+
+    void pending(Method method, bool tickTimers = false) {
+      until([&]() { return services.pending(method); }, tickTimers);
+    }
+
+    void sleep(bool sleeping) {
+      services.sleep(sleeping);
+      until([&]() { return Access::sleeping(auth) == sleeping; });
+    }
+
+    void deny(Method method) {
+      services.reply(method, kPermissionDenied);
+      until([&]() { return Access::idle(auth); });
+      assert(authenticated == 0);
+    }
+
+    void verified() {
+      const auto before = statuses.size();
+      services.reply(Method::VerifyStart);
+      until([&]() { return statuses.size() > before; });
+      assert(statuses.back() == i18n::tr("auth.fingerprint.ready"));
+    }
+
+    void startScanning() {
+      auth.start();
+      pending(Method::Claim);
+      services.reply(Method::Claim);
+      pending(Method::VerifyStart);
+      verified();
+    }
+
+    void startAt(Method method) {
+      auth.start();
+      pending(Method::Claim);
+      if (method == Method::VerifyStart) {
+        services.reply(Method::Claim);
+        pending(Method::VerifyStart);
+      }
+    }
+  };
+
+  void claimAndVerifyRecoverAfterWake() {
+    Fixture f;
+    f.sleep(true);
+    f.auth.start();
+    assert(f.services.calls(Method::Claim) == 0);
+    f.sleep(false);
+    f.pending(Method::Claim);
+    for (int attempt = 0; attempt < 3; ++attempt) {
+      f.deny(Method::Claim);
+      assert(Access::retryPending(f.auth));
+      f.pending(Method::Claim, true);
+      assert(f.services.calls(Method::VerifyStart) == 0);
+    }
+    f.services.reply(Method::Claim);
+    f.pending(Method::VerifyStart);
+    for (int attempt = 0; attempt < 2; ++attempt) {
+      f.deny(Method::VerifyStart);
+      f.pending(Method::VerifyStart, true);
+    }
+    f.verified();
+    assert(f.services.calls(Method::Claim) == 4);
+    assert(f.services.calls(Method::VerifyStart) == 3);
+    assert(Access::matchRetries(f.auth) == 0);
+    f.services.verifyStatus("verify-match");
+    f.until([&]() { return f.authenticated == 1; });
+  }
+
+  void retainedClaimRecoversAfterWake() {
+    Fixture f;
+    f.startScanning();
+    f.sleep(true);
+    f.sleep(false);
+    f.pending(Method::VerifyStart);
+    f.deny(Method::VerifyStart);
+    f.pending(Method::VerifyStart, true);
+    f.verified();
+    assert(f.services.calls(Method::Claim) == 1);
+    assert(Access::matchRetries(f.auth) == 0);
+  }
+
+  void permanentDenialIsBounded(Method method) {
+    Fixture f;
+    f.startAt(method);
+    int retries = 0;
+    while (true) {
+      f.deny(method);
+      if (!Access::retryPending(f.auth)) {
+        break;
+      }
+      assert(++retries <= 20 && "permanent permission denial must stop retrying");
+      f.pending(method, true);
+    }
+    assert(retries == 20);
+    assert(Access::matchRetries(f.auth) == 0);
+    assert(f.statuses.back().empty());
+    // A later lock attempt gets a fresh authorization budget.
+    f.auth.stop();
+    f.startScanning();
+    assert(Access::authorizationRetries(f.auth) == 0);
+  }
+
+  void cancellationStopsRetries(Method method, bool suspend, bool replyAfterCancellation) {
+    Fixture f;
+    f.startAt(method);
+    if (!replyAfterCancellation) {
+      f.deny(method);
+      assert(Access::retryPending(f.auth));
+    }
+    if (suspend) {
+      f.sleep(true);
+    } else {
+      f.auth.stop();
+    }
+    if (replyAfterCancellation) {
+      // A reply already in flight must not schedule new work while sleeping or
+      // after stop() has destroyed the proxy and cancelled its callbacks.
+      const auto before = f.statuses.size();
+      f.services.reply(method, kPermissionDenied);
+      if (suspend) {
+        f.until([&]() { return f.statuses.size() > before; });
+      }
+    }
+    assert(!Access::retryPending(f.auth));
+    assert(f.authenticated == 0);
+  }
+
+  void otherErrorsDoNotRetry(Method method) {
+    Fixture f;
+    f.startAt(method);
+    f.services.reply(method, sdbus::Error{sdbus::Error::Name{"net.reactivated.Fprint.Error.AlreadyInUse"}, "Busy"});
+    f.until([&]() { return Access::idle(f.auth); });
+    assert(!Access::retryPending(f.auth));
+  }
+
+  void droppedClaimStillRecovers() {
+    Fixture f;
+    f.startScanning();
+    f.sleep(true);
+    f.services.dropClaim();
+    f.sleep(false);
+    f.pending(Method::VerifyStart);
+    f.services.reply(
+        Method::VerifyStart,
+        sdbus::Error{sdbus::Error::Name{"net.reactivated.Fprint.Error.ClaimDevice"}, "Claim was dropped"}
+    );
+    f.until([&]() { return Access::retryPending(f.auth); });
+    f.pending(Method::Claim, true);
+    f.services.reply(Method::Claim);
+    f.pending(Method::VerifyStart);
+    f.verified();
+    assert(f.services.calls(Method::Claim) == 2);
+  }
+
+  void authorizationRetriesPreserveMatchLimit() {
+    Fixture f;
+    f.startScanning();
+    for (int mismatch = 0; mismatch < 3; ++mismatch) {
+      f.services.verifyStatus("verify-no-match");
+      f.pending(Method::VerifyStart, true);
+      for (int denial = 0; denial < 2; ++denial) {
+        f.deny(Method::VerifyStart);
+        assert(Access::matchRetries(f.auth) == mismatch);
+        f.pending(Method::VerifyStart, true);
+      }
+      f.verified();
+      assert(Access::matchRetries(f.auth) == mismatch + 1);
+    }
+    f.services.verifyStatus("verify-no-match");
+    f.until([&]() { return f.statuses.back() == i18n::tr("auth.fingerprint.too-many-attempts"); });
+    assert(!Access::retryPending(f.auth));
+    assert(f.authenticated == 0);
+  }
+} // namespace
+
+int main() {
+  // Refuse to run against the real system bus, even if invoked outside Meson.
+  const char* systemAddress = std::getenv("DBUS_SYSTEM_BUS_ADDRESS");
+  const char* sessionAddress = std::getenv("DBUS_SESSION_BUS_ADDRESS");
+  if (systemAddress == nullptr || sessionAddress == nullptr || std::string(systemAddress) != sessionAddress) {
+    std::println(stderr, "Run on a private dbus-run-session bus with DBUS_SYSTEM_BUS_ADDRESS redirected to it");
+    return 1;
+  }
+
+  claimAndVerifyRecoverAfterWake();
+  retainedClaimRecoversAfterWake();
+  for (auto method : {Method::Claim, Method::VerifyStart}) {
+    permanentDenialIsBounded(method);
+    otherErrorsDoNotRetry(method);
+    for (bool suspend : {false, true}) {
+      for (bool replyAfterCancellation : {false, true}) {
+        cancellationStopsRetries(method, suspend, replyAfterCancellation);
+      }
+    }
+  }
+  droppedClaimStillRecovers();
+  authorizationRetriesPreserveMatchLimit();
+  std::println("fingerprint_authenticator_integration_test: passed");
+}


### PR DESCRIPTION
## Summary

Retry `PermissionDenied` from fingerprint `Claim` and `VerifyStart` while the lockscreen is active and awake. Retry every 250 ms, with a shared limit of 20 authorization retries per lock activation or resume.

- Retry a denied `Claim` as `Claim`, rather than attempting verification against an unclaimed device.
- Preserve ownership when retrying `VerifyStart`.
- Keep authorization retries separate from failed fingerprint matches, including preserving `isRetry` when verification eventually starts.
- Cancel scheduled retries on stop/suspend and refuse to schedule them from late error replies while sleeping.
- Add a private-D-Bus integration test using the real authenticator and fake fprintd/logind services.

No polkit permissions are broadened.

## Motivation

On NixOS + Niri with a Goodix MOC sensor, fingerprint unlock intermittently fails silently after resume, while fingerprint authentication for sudo works reliably. Noctalia reacts to `PrepareForSleep(false)` before the session has become active again, so fprintd's active-session authorization check denies the request. The existing implementation does not retry permission denials after the session becomes active.

One captured sequence:

```text
11:05:57.977 niri: pausing session
11:05:58.086 noctalia: system resumed; rechecking night light and auto theme schedules
11:05:58.224 noctalia: could not start fingerprint verification:
  [net.reactivated.Fprint.Error.PermissionDenied]
  Not Authorized: net.reactivated.fprint.device.verify
11:05:58.746 niri: resuming session
```

Another wake failed at `Claim` with `Not Authorized: net.reactivated.fprint.device.enroll` during the same inactive interval. Bounded retries allow recovery without treating all permission failures as permanently recoverable.

## Type of Change

- [x] Bug fix

## Related Issue

Related to #3602. Diagnostic evidence and the two journal sequences are in https://github.com/noctalia-dev/noctalia/issues/3602#issuecomment-5611861064. This addresses the resume-related authorization race, not necessarily every cause of that issue's symptoms.

## Testing

The test holds asynchronous D-Bus replies until explicitly completed. It imposes the wake/denial/recovery ordering instead of depending on real suspension or a probabilistic race. No real fingerprint reader, logind, or polkit service is used. Timer dispatch is controlled by the test; retry delays use the production timer implementation.

Coverage:
- Denied Claim and VerifyStart recover after wake, including multiple denials.
- A claim retained across suspend is not unnecessarily reacquired.
- Permanent denial stops after 20 retries; a new lock attempt gets a fresh budget.
- Stop and suspend cancel pending retries, including denials delivered after cancellation.
- Other errors are not retried; existing ClaimDevice recovery still works.
- Authorization retries neither consume nor reset the failed-match budget.

Validation performed in a pinned nix-shell:
- `just format` with clang-format 22.1.8; `git diff --check`.
- Meson setup/reconfigure with `-Dtests=enabled -Dbuildtype=debug` succeeded.
- Built the focused integration executable directly from the test and production sources, then ran it on a private bus. Passed, including three repeated runs.
- Rebuilt and ran the focused executable with `-fsanitize=address,undefined -fno-omit-frame-pointer`: passed without sanitizer reports.
- Rebuilt the same test with the unpatched authenticator implementation from `8fd4399e38704afdb3b34963637b5fd86c52e4f4`, retaining the header's test-access scaffolding. It fails at `claimAndVerifyRecoverAfterWake`, assertion `Access::retryPending(f.auth)`, exit 134.

Focused build/run command (from the repository root inside the development shell):

```sh
c++ -std=c++23 -O1 -g -ffunction-sections -fdata-sections \
  -Wall -Wextra -Wpedantic -Wconversion -Wshadow \
  -Isrc $(pkg-config --cflags sdbus-c++) \
  tests/fingerprint_authenticator_integration_test.cpp \
  src/auth/fingerprint_authenticator.cpp src/dbus/system_bus.cpp \
  src/core/timer_manager.cpp src/core/log.cpp src/i18n/i18n_service.cpp \
  -Wl,--gc-sections $(pkg-config --libs sdbus-c++) -pthread \
  -o build-fingerprint/fingerprint-standalone-test

dbus-run-session -- sh -c \
  'export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"; exec ./build-fingerprint/fingerprint-standalone-test'
```

The Meson-integrated test is registered as `fingerprint_authenticator_integration`. The full shell/core build and full test suite have not been run locally; the focused build avoids compiling unrelated shell sources. Real suspend/resume validation of the patched shell is still pending, so this PR is initially a draft.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
