### PR TITLE
fix(docs): launcher example shows redundant provider prefix symbol

### DIFF
--- a/docs/user/launcher/index.mdx
+++ b/docs/user/launcher/index.mdx
@@ -133,7 +133,7 @@ Each entry lives under `[shell.launcher.dmenu.entry.<id>]`, where `<id>` is the 
 [shell.launcher.dmenu.entry.commands]
 command = "printf 'Open Config\nShow Date\n'"
 label = "Commands"
-prefix = "/cmd"
+prefix = "cmd"
 glyph = "terminal"
 global = false
 exec = "case \"{selection}\" in Open*) xdg-open ~/.config/noctalia ;; Show*) notify-send \"$(date)\" ;; esac"
@@ -146,7 +146,7 @@ candidates. A tab in a candidate splits the display into title and description:
 [shell.launcher.dmenu.entry.commands]
 command = "printf 'DNF Upgrade\tRun dnf upgrade --refresh\n'"
 label = "Commands"
-prefix = "/cmd"
+prefix = "cmd"
 glyph = "terminal"
 global = false
 exec = "foot -e bash -lc 'pkexec dnf upgrade --refresh; read -rp \"Press Enter to close...\"'"
@@ -158,7 +158,7 @@ Fields:
 | --- | --- |
 | `command` | Shell command run through `/bin/sh -lc`; each stdout line becomes a launcher result |
 | `exec` | Optional shell command run when a result is activated; `{selection}` is the selected raw line, `{query}` is the typed text after the prefix |
-| `prefix` | Optional launcher prefix such as `/cmd`; if this is empty, set `global = true` or the entry is unreachable |
+| `prefix` | Optional launcher prefix such as `cmd` (without prefix symbol like `/`, which is configured by `provider_prefix`); if this is empty, set `global = true` or the entry is unreachable |
 | `label` | Provider title shown in the launcher provider overview; defaults to the entry id |
 | `glyph` | Tabler glyph name for results; defaults to `terminal` |
 | `global` | Whether results participate in normal non-prefixed launcher search |
@@ -175,7 +175,7 @@ Set `freeform = true` when the typed text itself should be activatable. The type
 ```toml
 [shell.launcher.dmenu.entry.notify]
 label = "Notify"
-prefix = "/notify"
+prefix = "notify"
 glyph = "bell"
 global = false
 freeform = true


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->


## Summary

When following the example from the docs where the `prefix = "/cmd"` and `prefix = "/notify"` are shown the resulting input in the launcher would be `//cmd` ord `//notify`.
This is probably an artifact from when the `provider_prefix` was not configurable yet.

## Motivation

Correctnes

## Type of Change

Docs corrected

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

Built this little test launcher which can be run by typing `/ls` in the launcher
```toml
[shell.launcher.dmenu.entry.lstest]
command = "ls ~"
label = "Ls Test"
prefix = "ls"
glyph = "terminal"
global = false
exec = "kitty -e bash -c 'ls {selection}; read -rp \"Press Enter to close...\"'"
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
