### PR TITLE
fix(launcher): run dmenu listing commands on a worker thread

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -748,6 +748,7 @@
       "unpin-from-dock": "Unpin from Dock"
     },
     "empty": {
+      "loading": "Loading results...",
       "no-results": "No results found",
       "type-to-search": "Type to search…"
     },

--- a/src/launcher/dmenu_provider.cpp
+++ b/src/launcher/dmenu_provider.cpp
@@ -131,6 +131,10 @@ void DmenuProvider::ensureLoaded() const {
                 // Worker thread: `this` may be gone, so only forward state to the
                 // deferred callback below (main loop), which checks m_alive.
                 std::vector<Line> lines = parseLines(result.out);
+                // Partial stdout from a timed-out run is never published.
+                if (result.timedOut) {
+                  lines.clear();
+                }
                 if (result.timedOut || (!result && lines.empty())) {
                   kLog.warn("[{}] command failed (exit {})", entryId, result.exitCode);
                 }

--- a/src/launcher/dmenu_provider.cpp
+++ b/src/launcher/dmenu_provider.cpp
@@ -1,5 +1,6 @@
 #include "launcher/dmenu_provider.h"
 
+#include "core/deferred_call.h"
 #include "core/log.h"
 #include "core/process/process.h"
 #include "util/fuzzy_match.h"
@@ -7,8 +8,12 @@
 #include "wayland/clipboard_service.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -50,51 +55,116 @@ DmenuProvider::Line DmenuProvider::parseLine(std::string&& raw) {
   return line;
 }
 
+std::vector<DmenuProvider::Line> DmenuProvider::parseLines(std::string_view out) {
+  std::vector<Line> lines;
+  std::size_t begin = 0;
+  for (std::size_t i = 0; i <= out.size(); ++i) {
+    if (i < out.size() && out[i] != '\n') {
+      continue;
+    }
+    std::size_t end = i;
+    if (end > begin && out[end - 1] == '\r') {
+      --end;
+    }
+    if (end > begin) {
+      lines.push_back(parseLine(std::string(out.substr(begin, end - begin))));
+    }
+    begin = i + 1;
+  }
+  return lines;
+}
+
 DmenuProvider::DmenuProvider(DmenuEntryConfig entry, ClipboardService* clipboard)
     : m_entry(std::move(entry)), m_clipboard(clipboard) {
   m_id = "dmenu.";
   m_id += m_entry.id;
   m_prefix = m_entry.prefix.value_or("");
   m_glyph = m_entry.glyph.value_or("terminal");
+  m_alive = std::make_shared<std::atomic<bool>>(true);
+  m_cancel = std::make_shared<std::atomic<bool>>(false);
+}
+
+DmenuProvider::~DmenuProvider() {
+  if (m_cancel) {
+    m_cancel->store(true, std::memory_order_relaxed);
+  }
+  if (m_alive) {
+    m_alive->store(false, std::memory_order_relaxed);
+  }
 }
 
 std::string DmenuProvider::displayName() const { return m_entry.label.value_or(m_entry.id); }
 
 void DmenuProvider::ensureLoaded() const {
-  if (m_loaded) {
+  if (m_loaded || m_loading) {
     return;
   }
-  m_loaded = true; // set before run so a failure doesn't retry every keystroke
-  m_lines.clear();
 
   if (m_entry.command.empty()) {
-    return;
-  }
-  const auto result =
-      process::runSyncWithTimeoutAndOutputLimit({"/bin/sh", "-lc", m_entry.command}, kCommandTimeout, kMaxOutputBytes);
-  if (!result) {
-    kLog.warn("[{}] command failed (exit {})", m_entry.id, result.exitCode);
+    m_loaded = true;
     return;
   }
 
-  std::size_t begin = 0;
-  for (std::size_t i = 0; i <= result.out.size(); ++i) {
-    if (i < result.out.size() && result.out[i] != '\n') {
-      continue;
-    }
-    std::size_t end = i;
-    if (end > begin && result.out[end - 1] == '\r') {
-      --end;
-    }
-    if (end > begin) {
-      m_lines.push_back(parseLine(result.out.substr(begin, end - begin)));
-    }
-    begin = i + 1;
+  m_loading = true;
+
+  std::string entryId = m_entry.id;
+  auto alive = m_alive;
+  const auto cancel = m_cancel;
+  if (!cancel) {
+    m_loading = false;
+    m_loaded = true;
+    return;
+  }
+  const std::uint64_t generation = m_generation;
+
+  process::RunOptions options;
+  options.timeout = kCommandTimeout;
+  options.maxOutputBytes = kMaxOutputBytes;
+  options.cancel = cancel;
+
+  const bool launched = process::runAsync(
+      m_entry.command,
+      process::RunCallbacks{
+          .onExit =
+              [this, alive = std::move(alive), generation,
+               entryId = std::move(entryId)](process::RunResult result) mutable {
+                // Worker thread: `this` may be gone, so only forward state to the
+                // deferred callback below (main loop), which checks m_alive.
+                std::vector<Line> lines = parseLines(result.out);
+                if (result.timedOut || (!result && lines.empty())) {
+                  kLog.warn("[{}] command failed (exit {})", entryId, result.exitCode);
+                }
+                DeferredCall::callLater([this, alive = std::move(alive), generation,
+                                         lines = std::move(lines)]() mutable {
+                  if (!alive || !alive->load(std::memory_order_relaxed) || generation != m_generation) {
+                    return;
+                  }
+                  m_lines = std::move(lines);
+                  m_loading = false;
+                  m_loaded = true;
+                  if (m_onResultsChanged) {
+                    m_onResultsChanged();
+                  }
+                });
+              }
+      },
+      options
+  );
+
+  if (!launched) {
+    m_loading = false;
+    m_loaded = true;
   }
 }
 
 void DmenuProvider::reset() {
+  if (m_cancel) {
+    m_cancel->store(true, std::memory_order_relaxed);
+  }
+  m_cancel = std::make_shared<std::atomic<bool>>(false);
+  ++m_generation;
   m_lines.clear();
+  m_loading = false;
   m_loaded = false;
 }
 

--- a/src/launcher/dmenu_provider.h
+++ b/src/launcher/dmenu_provider.h
@@ -3,15 +3,28 @@
 #include "config/config_types.h"
 #include "launcher/launcher_provider.h"
 
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
 class ClipboardService;
 
 // One config-driven dmenu-style launcher entry. Runs `entry.command` once per open
 // session, splits stdout into newline-separated candidates, and fuzzy-filters them.
 // On activate: runs `entry.exec` (with {selection}/{query} substituted) or, when no
 // exec is set, copies the selection to the clipboard.
+//
+// The listing command runs on a worker thread (never the main loop, which would
+// deadlock IPC/DBus commands like `notify-send` or `noctalia msg`). Its stdout is
+// parsed even on non-zero exit, so error messages still show up in the launcher.
 class DmenuProvider : public LauncherProvider {
 public:
   DmenuProvider(DmenuEntryConfig entry, ClipboardService* clipboard);
+  ~DmenuProvider() override;
 
   [[nodiscard]] std::string_view defaultPrefix() const override { return m_prefix; }
   [[nodiscard]] std::string_view id() const override { return m_id; }
@@ -20,6 +33,8 @@ public:
   [[nodiscard]] bool trackUsage() const override { return true; }
   [[nodiscard]] bool supportsAutoPaste() const override { return !m_entry.exec.has_value(); }
   [[nodiscard]] bool defaultIncludeInGlobalSearch() const override { return m_entry.global; }
+
+  void setResultsChangedCallback(std::function<void()> callback) override { m_onResultsChanged = std::move(callback); }
 
   [[nodiscard]] std::vector<LauncherResult> query(std::string_view text) const override;
 
@@ -37,12 +52,21 @@ private:
 
   void ensureLoaded() const;
   static Line parseLine(std::string&& raw);
+  static std::vector<Line> parseLines(std::string_view out);
 
   DmenuEntryConfig m_entry;
   std::string m_id;     // "dmenu." + entry.id
   std::string m_prefix; // entry.prefix value or empty
   std::string m_glyph;  // entry.glyph or "terminal"
   ClipboardService* m_clipboard = nullptr;
+  std::function<void()> m_onResultsChanged;
+  // False once the provider is destroyed, so pending callbacks can bail out.
+  std::shared_ptr<std::atomic<bool>> m_alive;
+  // Cancels an in-flight listing command (and its process group) on reset/destruction.
+  mutable std::shared_ptr<std::atomic<bool>> m_cancel;
   mutable std::vector<Line> m_lines;
   mutable bool m_loaded = false;
+  mutable bool m_loading = false;
+  // Bumped on reset() so a stale run can't publish into a newer session.
+  mutable std::uint64_t m_generation = 0;
 };

--- a/src/launcher/dmenu_provider.h
+++ b/src/launcher/dmenu_provider.h
@@ -33,6 +33,7 @@ public:
   [[nodiscard]] bool trackUsage() const override { return true; }
   [[nodiscard]] bool supportsAutoPaste() const override { return !m_entry.exec.has_value(); }
   [[nodiscard]] bool defaultIncludeInGlobalSearch() const override { return m_entry.global; }
+  [[nodiscard]] bool isLoading() const override { return m_loading && !m_loaded; }
 
   void setResultsChangedCallback(std::function<void()> callback) override { m_onResultsChanged = std::move(callback); }
 

--- a/src/launcher/launcher_provider.h
+++ b/src/launcher/launcher_provider.h
@@ -92,6 +92,10 @@ public:
   // be re-gathered when fresh results land. Synchronous providers ignore it.
   virtual void setResultsChangedCallback(std::function<void()> /*callback*/) {}
 
+  // True while an async provider is still producing results. The launcher uses
+  // it to show a loading state instead of "No results found".
+  [[nodiscard]] virtual bool isLoading() const { return false; }
+
   // Plugin-backed providers can request that the open launcher input be replaced,
   // e.g. to implement autocomplete.
   virtual void setQueryRequestedCallback(std::function<void(std::string)> /*callback*/) {}

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1550,6 +1550,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
 
   std::vector<LauncherCategory> newCategories;
   bool hasRecentlyUsed = false;
+  bool anyProviderLoading = false;
 
   if (!m_scopedProviderId.empty()) {
     for (auto& provider : m_providers) {
@@ -1557,6 +1558,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
         continue;
       }
       m_allResults = provider->query(text);
+      anyProviderLoading = provider->isLoading();
       for (auto& result : m_allResults) {
         result.providerId = provider->id();
       }
@@ -1602,6 +1604,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
 
     if (activeProvider != nullptr) {
       m_allResults = activeProvider->queryPrefixed(queryText);
+      anyProviderLoading = activeProvider->isLoading();
       if (activeProvider->trackUsage()) {
         applyUsageBoost(m_allResults, *activeProvider);
         if (sortByUsage && m_usageTracker.getRecentlyUsedCount(activeProvider->id()) > 0) {
@@ -1627,6 +1630,9 @@ void LauncherPanel::onInputChanged(const std::string& text) {
           continue;
         }
         auto results = provider->query(queryText);
+        if (provider->isLoading()) {
+          anyProviderLoading = true;
+        }
         if (provider->trackUsage()) {
           applyUsageBoost(results, *provider);
           if (sortByUsage && m_usageTracker.getRecentlyUsedCount(provider->id()) > 0) {
@@ -1692,6 +1698,8 @@ void LauncherPanel::onInputChanged(const std::string& text) {
   if (text.empty() && m_scopedProviderId.empty()) {
     applyPinnedApplicationOrder();
   }
+
+  m_anyProviderLoading = anyProviderLoading;
 
   applyActiveCategory();
 }
@@ -1953,9 +1961,13 @@ void LauncherPanel::applyEmptyState() {
   m_emptyLabel->setVisible(empty);
   m_emptyLabel->setParticipatesInLayout(empty);
   if (empty) {
-    m_emptyLabel->setText(
-        m_query.empty() ? i18n::tr("launcher.empty.type-to-search") : i18n::tr("launcher.empty.no-results")
-    );
+    if (m_anyProviderLoading && !m_query.empty()) {
+      m_emptyLabel->setText(i18n::tr("launcher.empty.loading"));
+    } else {
+      m_emptyLabel->setText(
+          m_query.empty() ? i18n::tr("launcher.empty.type-to-search") : i18n::tr("launcher.empty.no-results")
+      );
+    }
   }
 }
 

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -117,6 +117,7 @@ private:
   Label* m_detailSubtitle = nullptr;
   Label* m_detailBody = nullptr;
   Label* m_emptyLabel = nullptr;
+  bool m_anyProviderLoading = false;
   std::unique_ptr<LauncherResultAdapter> m_listAdapter;
   std::unique_ptr<LauncherAppGridAdapter> m_gridAdapter;
 


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->
`ensureLoaded()` ran the entry's `command` synchronously on the main loop, deadlocking any command that talks back to the daemon (notify-send: DBus, `noctalia msg`: IPC socket): the child blocked until the 2s timeout killed it (SIGTERM/exit 143) and the loop stalled (~2s of no Wayland dispatch).

Run the command via `process::runAsync` on a worker thread, publish results back on the main loop through setResultsChangedCallback + DeferredCall, and treat stdout as candidates even on non-zero exit (so an error message printed by the command still appears in the launcher instead of an empty menu).

## Motivation

<!-- What problem does this solve? -->
Allow `noctalia msg` commands in a dmenu entry.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
