### PR TITLE
Fix wrong media icons, use outlined disc icon

### DIFF
--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -116,7 +116,7 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
       m_lastPlaybackStatus == "Playing" ? widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))
                                         : colorSpecFromRole(ColorRole::OnSurfaceVariant)
   );
-  m_emptyGlyph->setGlyph(m_lastPlaybackStatus.empty() ? "disc-filled" : "music-off");
+  m_emptyGlyph->setGlyph(m_lastPlaybackStatus.empty() ? "music-off" : "disc");
   m_emptyGlyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
   m_emptyGlyph->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant));
   m_emptyGlyph->measure(renderer);

--- a/src/shell/control_center/control_center_panel.h
+++ b/src/shell/control_center/control_center_panel.h
@@ -123,7 +123,7 @@ private:
   static constexpr std::size_t kTabCount = static_cast<std::size_t>(TabId::Count);
   static constexpr std::array<TabMeta, kTabCount> kTabs{{
       {TabId::Home, "home", "control-center.tabs.home", "home"},
-      {TabId::Media, "media", "control-center.tabs.media", "disc-filled"},
+      {TabId::Media, "media", "control-center.tabs.media", "disc"},
       {TabId::Audio, "audio", "control-center.tabs.audio", "volume"},
       {TabId::Monitor, "monitor", "control-center.tabs.monitor", "device-desktop"},
       {TabId::System, "system", "control-center.tabs.system", "activity-heartbeat"},

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -402,7 +402,7 @@ std::unique_ptr<Flex> HomeTab::create() {
            .height = artSize},
           ui::glyph({
               .out = &m_mediaArtFallback,
-              .glyph = "disc-filled",
+              .glyph = "disc",
               .glyphSize = artSize * 0.55F,
               .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
           }),

--- a/src/shell/osd/media_osd.cpp
+++ b/src/shell/osd/media_osd.cpp
@@ -23,7 +23,7 @@ namespace {
     const std::string artist = joinedArtists(player.artists);
     return OsdContent{
         .kind = OsdKind::Media,
-        .icon = "disc-filled",
+        .icon = "disc",
         .value = artist.empty() ? player.title : player.title + " — " + artist,
         .showProgress = false,
     };
@@ -36,7 +36,7 @@ namespace {
     const std::string level = std::to_string(percent) + "%";
     return OsdContent{
         .kind = OsdKind::Media,
-        .icon = "disc-filled",
+        .icon = "disc",
         .value = playerName.empty() ? level : playerName + " — " + level,
         .showProgress = false,
         .overLimit = percent > 100,

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -238,7 +238,7 @@ namespace settings {
         {.type = "keyboard_layout", .labelKey = "settings.widgets.types.keyboard-layout", .glyph = "keyboard"},
         {.type = "launcher", .labelKey = "settings.widgets.types.launcher", .glyph = "search"},
         {.type = "lock_keys", .labelKey = "settings.widgets.types.lock-keys", .glyph = "lock"},
-        {.type = "media", .labelKey = "settings.widgets.types.media", .glyph = "disc-filled"},
+        {.type = "media", .labelKey = "settings.widgets.types.media", .glyph = "disc"},
         {.type = "network", .labelKey = "settings.widgets.types.network", .glyph = "wifi-off"},
         {.type = "nightlight", .labelKey = "settings.widgets.types.nightlight", .glyph = "nightlight-off"},
         {.type = "notifications", .labelKey = "settings.widgets.types.notifications", .glyph = "bell"},


### PR DESCRIPTION
## Summary

Not-playing and playing icons in the media widget were wrong ("disc-filled" if nothing was playing and "music-off" if something was playing):

<img height="34" alt="off" src="https://github.com/user-attachments/assets/662c2a3e-486d-4362-b865-adf9d8eacfd2" />
<img height="34" alt="on" src="https://github.com/user-attachments/assets/c7a81ea0-e6c3-42ff-ab07-bf32bb57251c" />

I swapped them.

In addition, the filled version of the disc icon was used, which was inconsistent with the other icons. I changed it in all places (media widget and control center) to the outlined icon.

## Motivation

Represent playing state correctly and look consistent with other icons.

## Type of Change

- [X] Bug fix

## Testing

Changes were tested by running noctalia and visually checking the results.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [X] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.