### PR TITLE
feat(palette): add getColor(role) for theme color retrieval

### DIFF
--- a/docs/plugin-api.json
+++ b/docs/plugin-api.json
@@ -166,5 +166,11 @@
     "noctaliaVersion": null,
     "feature": "panel-layer",
     "introduced": "The `layer` panel entry option for choosing the layer-shell layer of a floating plugin panel."
+  },
+  {
+    "level": 31,
+    "noctaliaVersion": null,
+    "feature": "get-color",
+    "introduced": "`noctalia.getColor(role)` for reading colors from the active theme palette."
   }
 ]

--- a/docs/user/plugins/development/runtime-api.mdx
+++ b/docs/user/plugins/development/runtime-api.mdx
@@ -18,9 +18,13 @@ boolean immediately to say whether the work was accepted, then deliver results t
 | `noctalia.setUpdateInterval(ms)` | nothing | Sets how often this entry's `update()` function runs. Values below 16 ms are clamped. |
 | `noctalia.log(msg)` | nothing | Writes a message to Noctalia's log with this plugin's script context. |
 | `noctalia.isDarkMode()` | bool | Returns whether the palette Noctalia renders with is dark, so it tracks [`[theme].shell_mode`](/noctalia/theming/#shell_mode) when that is pinned. |
+| `noctalia.getColor(role)` | hex string or `nil` | Returns the active theme palette's `#RRGGBB` hex color for a role name (for example `"primary"`, `"surface"`, `"on_surface"`). Returns `nil` for unknown role names. Requires <PluginApiBadge feature="get-color" />. |
 | `noctalia.getSetting(path)` | config value or `nil` | Reads any effective shell config value by TOML dotted path. Tables and arrays become Luau tables; array indices in paths are zero-based. Missing paths log a warning and return `nil`. Requires <PluginApiBadge feature="get-setting" />. |
 | `noctalia.focusedOutputName()` | string or `nil` | Returns the focused output's connector name, falling back to the preferred interactive output when needed. |
 | `noctalia.getConfig(key)` | setting value or `nil` | Reads a declared plugin or entry setting. Undeclared keys log a warning and return `nil`. |
+
+`getColor(role)` reads a color role from Noctalia's current [palette](/noctalia/theming/palette/). For example,
+`noctalia.getColor("primary")` returns the primary accent color as `#RRGGBB`.
 
 `getConfig(key)` reads the calling plugin entry's declared settings. `getSetting(path)` instead reads the shell's
 effective configuration. For example, `noctalia.getSetting("shell.offline_mode")` returns a boolean,

--- a/docs/user/theming/palette.mdx
+++ b/docs/user/theming/palette.mdx
@@ -30,7 +30,7 @@ User-facing color settings reference these 16 roles with lowercase `snake_case` 
 | `hover` | `mHover` | Hover and interactive highlight background. |
 | `on_hover` | `mOnHover` | Text and icons placed on hover surfaces. |
 
-Settings role pickers expose these role names first. Template files access these roles and the full Material token set through the [Template Reference](/noctalia/theming/templates/#available-color-tokens).
+Settings role pickers expose these role names first. Template files access these roles and the full Material token set through the [Template Reference](/noctalia/theming/templates/#available-color-tokens). Plugins can query the active theme's colors at runtime using [`noctalia.getColor(role)`](/noctalia/plugins/development/runtime-api/#runtime-and-settings).
 
 ## Custom Palette Files
 

--- a/src/scripting/luau_host.cpp
+++ b/src/scripting/luau_host.cpp
@@ -25,6 +25,7 @@
 #include "system/terminal_launch.h"
 #include "time/time_format.h"
 #include "ui/dialogs/color_picker_dialog.h"
+#include "ui/palette.h"
 #include "util/file_utils.h"
 #include "util/fuzzy_match.h"
 #include "util/string_utils.h"
@@ -733,6 +734,22 @@ namespace {
   int luau_isDarkMode(lua_State* L) {
     auto* host = hostForState(L);
     lua_pushboolean(L, host != nullptr && host->api().isDarkMode() ? 1 : 0);
+    return 1;
+  }
+
+  // getColor(role) -> "#RRGGBB" or nil.
+  // Resolves a color role (e.g. "primary", "surface", "on_surface") against the
+  // active theme palette. Returns nil for unknown role names.
+  int luau_getColor(lua_State* L) {
+    size_t len = 0;
+    const char* role = luaL_checklstring(L, 1, &len);
+    const auto colorRole = colorRoleFromToken(std::string_view(role, len));
+    if (!colorRole.has_value()) {
+      lua_pushnil(L);
+      return 1;
+    }
+    const std::string hex = formatRgbHex(colorForRoleSnapshot(*colorRole));
+    lua_pushlstring(L, hex.data(), hex.size());
     return 1;
   }
 
@@ -1762,6 +1779,7 @@ namespace {
       {"togglePanel", luau_togglePanel},
       {"openSettings", luau_openSettings},
       {"isDarkMode", luau_isDarkMode},
+      {"getColor", luau_getColor},
       {"wallpaperDirectory", luau_wallpaperDirectory},
       {"notify", luau_notify},
       {"notifyError", luau_notifyError},

--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -30,7 +30,8 @@ namespace scripting {
   inline constexpr std::uint32_t kPanelContextMenuPluginApiVersion = 28;
   inline constexpr std::uint32_t kGraphPointerTrackingPluginApiVersion = 29;
   inline constexpr std::uint32_t kPanelLayerPluginApiVersion = 30;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = kPanelLayerPluginApiVersion;
+  inline constexpr std::uint32_t kGetColorPluginApiVersion = 31;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = kGetColorPluginApiVersion;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/ui/palette.cpp
+++ b/src/ui/palette.cpp
@@ -4,12 +4,15 @@
 #include "theme/builtin_palettes.h"
 #include "util/string_utils.h"
 
+#include <mutex>
 #include <string>
 
 Palette palette = noctalia::theme::findBuiltinPalette("Noctalia")->dark.palette;
 bool g_resolvedThemeLight = false;
 
 namespace {
+
+  std::mutex g_paletteMutex;
 
   std::string normalizedRoleToken(std::string_view token) {
     std::string normalized = StringUtils::trim(token);
@@ -109,11 +112,19 @@ Signal<>& paletteChanged() {
 }
 
 void setPalette(const Palette& p) {
-  if (palette == p) {
-    return;
+  {
+    std::scoped_lock lock(g_paletteMutex);
+    if (palette == p) {
+      return;
+    }
+    palette = p;
   }
-  palette = p;
   paletteChanged().emit();
+}
+
+Color colorForRoleSnapshot(ColorRole role) {
+  std::scoped_lock lock(g_paletteMutex);
+  return colorForRole(role);
 }
 
 Palette lerpPalette(const Palette& a, const Palette& b, float t) {

--- a/src/ui/palette.h
+++ b/src/ui/palette.h
@@ -132,6 +132,9 @@ void setResolvedThemeLight(bool light) noexcept;
 
 void setPalette(const Palette& p);
 
+// Snapshot accessor safe to call from non-main threads (e.g. plugin script workers).
+[[nodiscard]] Color colorForRoleSnapshot(ColorRole role);
+
 [[nodiscard]] inline ColorSpec scrollbarTrackColor() noexcept {
   return colorSpecFromRole(ColorRole::Outline, Style::disabledOutlineAlpha);
 }

--- a/tests/plugin_process_test.cpp
+++ b/tests/plugin_process_test.cpp
@@ -1,7 +1,9 @@
 #include "core/process/process.h"
 #include "core/toml.h"
+#include "render/core/color.h"
 #include "scripting/luau_host.h"
 #include "scripting/script_api_context.h"
+#include "ui/palette.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -52,6 +54,12 @@ assert(noctalia.runAsync(
 assert(noctalia.getSetting("shell.offline_mode"))
 assert(noctalia.wallpaperPath("DP-1") == "/tmp/wallpaper.png")
 assert(noctalia.wallpaperPath("missing") == nil)
+assert(type(noctalia.getColor("primary")) == "string")
+assert(string.len(noctalia.getColor("primary")) == 7)
+assert(string.sub(noctalia.getColor("primary"), 1, 1) == "#")
+assert(noctalia.getColor("surface") ~= nil)
+assert(noctalia.getColor("on_surface") ~= nil)
+assert(noctalia.getColor("missing_role") == nil)
 noctalia.setWallpaperMask("DP-1", {
   path = "/tmp/mask.png",
   wallpaperPath = "/tmp/wallpaper.png",
@@ -83,5 +91,27 @@ noctalia.setWallpaperMask("DP-1", nil)
            "result callback should receive the completed process"
        )
       && ok;
+
+  // getColor tracks active palette updates and returns nil for unknown roles
+  const Palette originalPalette = palette;
+  Palette testPalette = originalPalette;
+  testPalette.primary = rgba(1.0F, 0.0F, 0.0F, 1.0F);
+  setPalette(testPalette);
+  ok = expect(
+           host.exec("=get-color", "assert(noctalia.getColor('primary') == '#FF0000')\n"),
+           "getColor should return updated color from active palette"
+       )
+      && ok;
+  setPalette(originalPalette);
+  ok = expect(
+           host.exec(
+               "=get-color-restored",
+               "assert(noctalia.getColor('primary') ~= '#FF0000')\n"
+               "assert(noctalia.getColor('invalid_role') == nil)\n"
+           ),
+           "getColor should track restored palette and return nil for invalid roles"
+       )
+      && ok;
+
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- Adds `noctalia.getColor(role)` to the plugin runtime API (`luau_getColor`), allowing plugin scripts to retrieve the `#RRGGBB` hex color for any active palette role (e.g. `primary`, `surface`, `on_surface`). Returns `nil` for unknown role names.
- Adds `colorForRoleSnapshot` in `src/ui/palette.cpp` / `src/ui/palette.h` guarded by a mutex against main-thread palette updates, ensuring thread-safe reads from script worker threads.
- Bumps plugin API version to 31 (`kGetColorPluginApiVersion`) and registers the `get-color` feature in `docs/plugin-api.json`.
- Updates documentation in `docs/user/plugins/development/runtime-api.mdx` and `docs/user/theming/palette.mdx`.
- Adds unit tests in `tests/plugin_process_test.cpp` verifying role resolution, missing roles, and dynamic color tracking across palette updates.

## Motivation

Enables plugins (such as launcher providers, canvas widgets, and custom integrations) to query and harmonize with the active Noctalia theme palette dynamically without hardcoding colors.

Closes #4301

## Type of Change

- [x] New feature

## Testing

- Ran unit tests with `just test debug`:
  - `plugin_process`,`plugin_manifest`, `plugin_catalog`, `plugin_i18n`, `plugin_git_export`, `plugin_lifecycle`
- Formatted with `just format`.
- Verified the build with `just build debug` and tested running Noctalia with a sample launcher plugin in an isolated configuration directory.

## Screenshots / Videos

<img width="555" height="492" alt="img-2026-09-11 17 24 13" src="https://github.com/user-attachments/assets/4b1d7ae0-5d94-4544-bedd-a5ba751fd0c8" />

Test plugin used: [colors.zip](https://github.com/user-attachments/files/32116447/colors.zip).


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

---
Assisted with an AI agent.
