### PR TITLE
fix(nix/hjem): make systemd service definition conditional

### DIFF
--- a/nix/hjem-module.nix
+++ b/nix/hjem-module.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   pkgs,
   lib,
   ...
@@ -29,6 +30,8 @@ let
   paletteFiles = mapAttrs (
     name: palette: json.generate "${name}-palette.json" palette
   ) cfg.customPalettes;
+
+  hasSystemd = options ? systemd;
 in
 {
   options.programs.noctalia = {
@@ -97,46 +100,54 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    packages = optional (cfg.package != null) cfg.package;
+  config = mkIf cfg.enable (lib.mkMerge [
+    {
+      packages = optional (cfg.package != null) cfg.package;
 
-    systemd.services.noctalia = mkIf (cfg.systemd.enable) {
-      description = "Noctalia - A lightweight Wayland shell and bar";
-      documentation = [ "https://docs.noctalia.dev/noctalia/" ];
-      partOf = [ cfg.systemd.target ];
-      after = [ cfg.systemd.target ];
-      wantedBy = [ cfg.systemd.target ];
-      # without this the service will have the default
-      # Environment="PATH=coreutils:…", clobbering the PATH that the DE
-      # imported into the user manager.
-      enableDefaultPath = false;
-      restartTriggers = [
-        cfg.package
-      ]
-      ++ optional (cfg.settings != { }) configToml
-      ++ attrValues paletteFiles;
-      serviceConfig = {
-        ExecStart = lib.getExe cfg.package;
-        Restart = "on-failure";
+      xdg.config.files = lib.mkMerge [
+        (mkIf (cfg.settings != { }) {
+          "noctalia/config.toml".source = configToml;
+        })
+        (mapAttrs' (
+          name: source: lib.nameValuePair "noctalia/palettes/${name}.json" { inherit source; }
+        ) paletteFiles)
+      ];
+
+      assertions = [
+        {
+          assertion = !cfg.systemd.enable || cfg.package != null;
+          message = "programs.noctalia.package cannot be null when programs.noctalia.systemd.enable is true";
+        }
+        {
+          assertion = !cfg.systemd.enable || hasSystemd;
+          message = "programs.noctalia.systemd.enable is set, but this platform's Hjem module doesn't expose a `systemd` option";
+        }
+      ];
+    }
+
+    (lib.optionalAttrs hasSystemd {
+      systemd.services.noctalia = mkIf cfg.systemd.enable {
+        description = "Noctalia - A lightweight Wayland shell and bar";
+        documentation = [ "https://docs.noctalia.dev/noctalia/" ];
+        partOf = [ cfg.systemd.target ];
+        after = [ cfg.systemd.target ];
+        wantedBy = [ cfg.systemd.target ];
+        # without this the service will have the default
+        # Environment="PATH=coreutils:…", clobbering the PATH that the DE
+        # imported into the user manager.
+        enableDefaultPath = false;
+        restartTriggers = [
+          cfg.package
+        ]
+        ++ optional (cfg.settings != { }) configToml
+        ++ attrValues paletteFiles;
+        serviceConfig = {
+          ExecStart = lib.getExe cfg.package;
+          Restart = "on-failure";
+        };
       };
-    };
-
-    xdg.config.files = lib.mkMerge [
-      (mkIf (cfg.settings != { }) {
-        "noctalia/config.toml".source = configToml;
-      })
-      (mapAttrs' (
-        name: source: lib.nameValuePair "noctalia/palettes/${name}.json" { inherit source; }
-      ) paletteFiles)
-    ];
-
-    assertions = [
-      {
-        assertion = !cfg.systemd.enable || cfg.package != null;
-        message = "programs.noctalia.package cannot be null when programs.noctalia.systemd.enable is true";
-      }
-    ];
-  };
+    })
+  ]);
 
   _class = "hjem";
 }


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Fixes: #4247 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [ ] This PR is ready for review, or it is marked as Draft.
- [ ] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [] I ran the relevant build or test commands, or explained why they were not run.
- [ ] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
