### PR TITLE
network: break refresh completion cycle

### DIFF
--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -88,7 +88,6 @@ namespace {
     std::vector<std::string> capturedWired;
     std::vector<std::string> capturedCellular;
     int pendingOps = 0;
-    std::function<void()> onAllComplete;
   };
 
   struct SavedConnectionsState {
@@ -232,7 +231,7 @@ void NetworkManagerService::refresh() {
   pending->capturedCellular = m_savedCellularConnectionPaths;
   pending->pendingOps = 3;
 
-  pending->onAllComplete = [this, pending, lifetimeToken]() {
+  auto onAllComplete = [this, pending, lifetimeToken]() {
     if (lifetimeToken.expired()) {
       return;
     }
@@ -268,8 +267,6 @@ void NetworkManagerService::refresh() {
           && m_changeCallback) {
         m_changeCallback(m_state, origin);
       }
-      // Break the self-reference cycle: pending->onAllComplete captures pending.
-      pending->onAllComplete = {};
       // Async reply context: safe to drop retired activation proxies here.
       m_retiredApActivations.clear();
 
@@ -281,12 +278,12 @@ void NetworkManagerService::refresh() {
     });
   };
 
-  auto onOpComplete = [pending, lifetimeToken]() {
+  auto onOpComplete = [pending, lifetimeToken, onAllComplete]() {
     if (lifetimeToken.expired()) {
       return;
     }
     if (--pending->pendingOps == 0) {
-      pending->onAllComplete();
+      onAllComplete();
     }
   };
 


### PR DESCRIPTION
## Summary

Keep the refresh completion outside `PendingRefresh`, so the refresh state no longer owns a callback that owns the same state.

## Motivation

An incomplete asynchronous refresh retained `PendingRefresh` through its stored completion callback.

## Type of Change

- [x] Bug fix

## Testing

- `git diff --check`
- `nix develop path:. -c just format`
- clang-tidy 22.1.8 with warnings as errors on `network_manager_service.cpp`
- Debugoptimized build and the complete Meson suite on the combined recovery stack: 119 tests passed, including `network_recovery_integration`
- A private-bus reproducer against Noctalia 5.0.1 reports 3,672 leaked bytes before this ownership change and passes ASan, LSan, and UBSan after it

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
