### PR TITLE
network: re-register secret agent after owner changes

### DIFF
--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -1261,13 +1261,11 @@ void Application::initSystemBusServices() {
     }
     m_configService.addReloadCallback([this]() { m_externalIpService.onConfigReload(); });
 
-    if (m_networkService != nullptr && m_networkService->supportsSecretAgent()) {
-      try {
-        m_networkSecretAgent = std::make_unique<NetworkSecretAgent>(*m_systemBus);
-      } catch (const std::exception& e) {
-        kLog.warn("network secret agent disabled: {}", e.what());
-        m_networkSecretAgent.reset();
-      }
+    try {
+      m_networkSecretAgent = std::make_unique<NetworkSecretAgent>(*m_systemBus);
+    } catch (const std::exception& e) {
+      kLog.warn("network secret agent disabled: {}", e.what());
+      m_networkSecretAgent.reset();
     }
 
     // Initialize iwd secret agent if iwd is the active network service

--- a/src/dbus/network/network_secret_agent.cpp
+++ b/src/dbus/network/network_secret_agent.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <sdbus-c++/IConnection.h>
 #include <sdbus-c++/IObject.h>
+#include <sdbus-c++/IProxy.h>
 #include <sdbus-c++/MethodResult.h>
 #include <sdbus-c++/Types.h>
 #include <sdbus-c++/VTableItems.h>
@@ -30,6 +31,9 @@ namespace {
   const sdbus::ServiceName kNmBusName{"org.freedesktop.NetworkManager"};
   const sdbus::ObjectPath kAgentManagerObjectPath{"/org/freedesktop/NetworkManager/AgentManager"};
   constexpr auto kAgentManagerInterface = "org.freedesktop.NetworkManager.AgentManager";
+  const sdbus::ServiceName kDbusBusName{"org.freedesktop.DBus"};
+  const sdbus::ObjectPath kDbusObjectPath{"/org/freedesktop/DBus"};
+  constexpr auto kDbusInterface = "org.freedesktop.DBus";
 
   constexpr std::uint32_t kNmSecretAgentGetSecretsFlagAllowInteraction = 0x1;
 
@@ -61,11 +65,27 @@ namespace {
 struct NetworkSecretAgent::Impl {
   SystemBus& bus;
   std::unique_ptr<sdbus::IObject> object;
+  std::unique_ptr<sdbus::IProxy> nameWatcher;
+  bool registered = false;
   RequestCallback requestCallback;
   std::optional<sdbus::Result<SecretsDict>> pendingResult;
   std::string pendingSettingName;
 
   explicit Impl(SystemBus& b) : bus(b) {}
+
+  void registerAgent() {
+    try {
+      auto agentManager = sdbus::createProxy(bus.connection(), kNmBusName, kAgentManagerObjectPath);
+      agentManager->callMethod("Register")
+          .onInterface(kAgentManagerInterface)
+          .withArguments(std::string(kAgentIdentifier));
+      registered = true;
+      kLog.info("registered NetworkManager secret agent as {}", kAgentIdentifier);
+    } catch (const sdbus::Error& e) {
+      registered = false;
+      kLog.warn("secret agent registration failed: {}", e.what());
+    }
+  }
 
   void onGetSecrets(
       sdbus::Result<SecretsDict>&& result, SecretsDict connection, sdbus::ObjectPath connectionPath,
@@ -176,15 +196,21 @@ NetworkSecretAgent::NetworkSecretAgent(SystemBus& bus) : m_impl(std::make_unique
       )
       .forInterface(kAgentInterface);
 
-  // Register with NM's agent manager.
-  try {
-    auto agentManager = sdbus::createProxy(bus.connection(), kNmBusName, kAgentManagerObjectPath);
-    agentManager->callMethod("Register")
-        .onInterface(kAgentManagerInterface)
-        .withArguments(std::string(kAgentIdentifier));
-    kLog.info("registered NetworkManager secret agent as {}", kAgentIdentifier);
-  } catch (const sdbus::Error& e) {
-    kLog.warn("secret agent registration failed: {}", e.what());
+  m_impl->nameWatcher = sdbus::createProxy(bus.connection(), kDbusBusName, kDbusObjectPath);
+  m_impl->nameWatcher->uponSignal("NameOwnerChanged")
+      .onInterface(kDbusInterface)
+      .call([this](const std::string& name, const std::string& oldOwner, const std::string& newOwner) {
+        if (name != kNmBusName || (oldOwner.empty() && !newOwner.empty() && m_impl->registered)) {
+          return;
+        }
+        m_impl->registered = false;
+        m_impl->cancelPending("NetworkManager owner changed");
+        if (!newOwner.empty()) {
+          m_impl->registerAgent();
+        }
+      });
+  if (bus.nameHasOwner(kNmBusName)) {
+    m_impl->registerAgent();
   }
 }
 
@@ -192,7 +218,11 @@ NetworkSecretAgent::~NetworkSecretAgent() {
   if (m_impl == nullptr) {
     return;
   }
+  m_impl->nameWatcher.reset();
   m_impl->cancelPending("agent shutting down");
+  if (!m_impl->registered) {
+    return;
+  }
   try {
     auto agentManager = sdbus::createProxy(m_impl->bus.connection(), kNmBusName, kAgentManagerObjectPath);
     agentManager->callMethod("Unregister").onInterface(kAgentManagerInterface);

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -940,6 +940,12 @@ void NetworkTab::onClose() {
 }
 
 void NetworkTab::syncPasswordCard() {
+  if (m_hasPendingSecret
+      && !m_pendingAccessPoint.has_value()
+      && m_secrets != nullptr
+      && !m_secrets->hasPendingRequest()) {
+    clearPasswordPrompt();
+  }
   if (m_passwordCard == nullptr) {
     return;
   }


### PR DESCRIPTION
## Summary

Create the NetworkManager secret agent independently of the selected backend, cancel an outstanding request when NetworkManager leaves D-Bus, register again when it returns, and close the canceled prompt.

## Motivation

Starting the shell without NetworkManager left the agent unregistered. A later NetworkManager restart also discarded its registration and left its canceled password card visible.

## Type of Change

- [x] Bug fix

## Testing

- `git diff --check`
- `nix develop path:. -c just format`
- clang-tidy 22.1.8 with warnings as errors on the three changed translation units
- Debugoptimized build and the complete Meson suite on the combined recovery stack: 119 tests passed
- A private-bus ASan and UBSan fixture with the same secret-agent source verifies request cancellation on owner loss, registration after reacquisition, and a reply to a later request
- The canceled-prompt guard was source-reviewed; the fixture does not construct `NetworkTab`

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
