### PR TITLE
process: make app service instances portal-compatible

### DIFF
--- a/src/core/process/process.cpp
+++ b/src/core/process/process.cpp
@@ -685,7 +685,8 @@ namespace {
     // limits or env vars.
     // 2. See the app's output and exit code (if it fails) in `systemctl status`.
     if (!appName.empty()) {
-      const std::string uuid = StringUtils::generateUuid();
+      std::string uuid = StringUtils::generateUuid();
+      std::erase(uuid, '-');
       if (!uuid.empty()) {
         systemdArgs.push_back(std::format("--unit=app-{}@{}.service", escapeSystemdUnitName(appName), uuid));
       }


### PR DESCRIPTION
## Summary

Remove separators from the UUID instance suffix of app service names so xdg-desktop-portal extracts the intended desktop app ID.

## Motivation

systemd accepts a hyphenated UUID, but the [xdg-desktop-portal 1.20.4 service-name parser](https://github.com/flatpak/xdg-desktop-portal/blob/f5aec228c9eb0c9a70eadd6424d92c0ca8a78247/src/xdp-app-info-host.c#L115-L160) accepts only an alphanumeric instance suffix. It therefore captures the hyphenated suffix as part of the app ID, while the compact 32-hex suffix leaves the intended ID. [Release 1.22.1 retains the same expression](https://github.com/flatpak/xdg-desktop-portal/blob/1d20fadc304f6601452b5db65ed91197dba77041/src/xdp-app-info-host.c#L115-L160).

## Type of Change

- [x] Bug fix

## Testing

- `git diff --check`
- `nix develop path:. -c just format`
- clang-tidy 22.1.8 with warnings as errors on `process.cpp`
- Debugoptimized build and the complete Meson suite on the combined recovery stack: 119 tests passed, including `process_test`
- A two-unit fixture confirms that systemd runs both UUID forms and xdg-desktop-portal extracts the intended app ID only from the compact suffix

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
