### PR TITLE
switcher: retain the icon resolver across window updates

### DIFF
--- a/src/shell/switcher/window_switcher.cpp
+++ b/src/shell/switcher/window_switcher.cpp
@@ -719,10 +719,9 @@ void WindowSwitcher::refreshWindows() {
     }
   }
 
-  IconResolver iconResolver;
   const int iconSize = 96;
   buildWindowEntries(
-      *m_platform, iconResolver, iconSize, m_windows, m_platform->focusedCompositorWindowId(),
+      *m_platform, m_iconResolver, iconSize, m_windows, m_platform->focusedCompositorWindowId(),
       mruEnabled() ? &m_mruKeys : nullptr
   );
 

--- a/src/shell/switcher/window_switcher.h
+++ b/src/shell/switcher/window_switcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "shell/switcher/window_switcher_tile.h"
+#include "system/icon_resolver.h"
 #include "wayland/wayland_seat.h"
 
 #include <cstddef>
@@ -67,6 +68,7 @@ private:
   AsyncTextureCache* m_asyncTextures = nullptr;
 
   Instance* m_instance = nullptr;
+  IconResolver m_iconResolver;
   std::vector<WindowSwitcherEntry> m_windows;
   std::deque<std::string> m_mruKeys;
   std::size_t m_selectedIndex = 0;

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -511,7 +511,10 @@ const std::string& IconResolver::resolve(const std::string& iconName, int target
   const std::string key = iconName + '\x1F' + std::to_string(std::max(0, targetSize));
   auto it = m_cache.find(key);
   if (it != m_cache.end()) {
-    return it->second;
+    if (iconName.front() != '/' || pathExists(it->second)) {
+      return it->second;
+    }
+    m_cache.erase(it);
   }
   const bool canCacheMissing = m_cacheMissing && iconName.front() != '/';
   if (canCacheMissing && m_missingCache.contains(key)) {

--- a/tests/icon_resolver_test.cpp
+++ b/tests/icon_resolver_test.cpp
@@ -134,8 +134,22 @@ int main() {
            "absolute icon misses should not be cached"
        )
       && ok;
-
+  ok = expect(
+           resolver.resolve(absoluteIcon.string(), 32) == absoluteIcon.string(),
+           "absolute icon should be cached while present"
+       )
+      && ok;
   std::error_code ec;
+  fs::remove(absoluteIcon, ec);
+  ok =
+      expect(resolver.resolve(absoluteIcon.string(), 32).empty(), "deleted absolute icon should not stay cached") && ok;
+  std::ofstream(absoluteIcon) << "<svg/>";
+  ok = expect(
+           resolver.resolve(absoluteIcon.string(), 32) == absoluteIcon.string(),
+           "recreated absolute icon should resolve after cache eviction"
+       )
+      && ok;
+
   fs::remove_all(root, ec);
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Retain the window switcher's icon resolver across window metadata updates.

## Motivation

Frequent title updates repeatedly rebuild the resolver and search icon-theme
directories. Reusing the resolver preserves its cache and existing
theme-generation invalidation. Cached absolute icon paths are rechecked before
use, so deleting an icon outside monitored theme directories falls through to
normal resolution instead of retaining a stale result.

## Type of Change

- [x] Bug fix

## Testing

- Ran `just format` in the declared dev shell on the signed commit.
- Built Noctalia and ran `meson test -C build-debugoptimized -j 4
  icon_resolver --print-errorlogs` with tests enabled and native optimizations
  disabled: 1/1 passed.
- The resolver test covers a cached absolute icon that is deleted and then
  recreated. The same test linked against the pre-guard resolver fails the
  deletion assertion; the candidate passes.
- A contained Umbriel 0.1.0 headless scenario used three synthetic clients and
  completed three switcher open, second-open cycle, and close sequences through
  nine private IPC replies.

## Manual Coverage

- [x] Tested on another compositor: Umbriel 0.1.0 headless with three synthetic clients

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
