### PR TITLE
ipc: report response read failures

### DIFF
--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -92,7 +92,15 @@ int IpcClient::send(const std::string& command) {
   char buf[4096];
   for (;;) {
     const auto n = ::read(fd, buf, sizeof(buf));
-    if (n <= 0) {
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      std::println(stderr, "error: read() failed: {}", std::strerror(errno));
+      ::close(fd);
+      return 1;
+    }
+    if (n == 0) {
       break;
     }
     response.append(buf, static_cast<std::size_t>(n));


### PR DESCRIPTION
## Summary

Report response read failures instead of treating them as EOF. Retry `EINTR`,
preserving normal EOF handling and the existing two-second socket timeout.

## Motivation

The client can otherwise report success after a receive timeout before a
response arrives. A transient signal interruption must be retried, consistent
with the service read loops.

## Type of Change

- [x] Bug fix

## Testing

- Ran `just format` and built Noctalia with `meson compile -C
  build-debugoptimized -j 4 noctalia` in the declared dev shell.
- The private native fixture has 16 assertions: the baseline reproduces the
  erroneous successful timeout and interrupted-read exits, while the candidate
  reports the timeout and retries a real `EINTR` to receive the response.
- A contained Umbriel 0.1.0 headless scenario used three synthetic clients and
  completed three switcher open, second-open cycle, and close sequences through
  nine private IPC replies.

## Manual Coverage

- [x] Tested on another compositor: Umbriel 0.1.0 headless with three synthetic clients

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
