### PR TITLE
fix(control-center): keep home row height with a single shortcut

### DIFF
--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -849,6 +849,10 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
     const float innerGridW = std::max(1.0F, gridW - m_shortcutsGrid->paddingLeft() - m_shortcutsGrid->paddingRight());
     const std::size_t cols = std::max<std::size_t>(1, std::min(m_shortcutsGrid->columns(), m_shortcutPads.size()));
     const std::size_t rows = (m_shortcutPads.size() + cols - 1) / cols;
+    // A single shortcut is one row, which would collapse the whole bottom row (and with it the
+    // media/weather cards, whose height is derived from gridH below) to one tile tall. Reserve at
+    // least two rows of height so one shortcut looks the same as two. Tile sizing is unaffected.
+    const std::size_t heightRows = std::max<std::size_t>(rows, 2);
     const float cellWidth = std::max(
         1.0F, (innerGridW - static_cast<float>(cols - 1) * m_shortcutsGrid->columnGap()) / static_cast<float>(cols)
     );
@@ -869,8 +873,8 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
     }
 
     const float gridH = std::round(
-        static_cast<float>(rows) * cellSide
-        + static_cast<float>(rows > 0 ? rows - 1 : 0) * m_shortcutsGrid->rowGap()
+        static_cast<float>(heightRows) * cellSide
+        + static_cast<float>(heightRows - 1) * m_shortcutsGrid->rowGap()
         + m_shortcutsGrid->paddingTop()
         + m_shortcutsGrid->paddingBottom()
     );


### PR DESCRIPTION
## Summary

Fix the Control Center home tab collapsing the media player and weather
cards to a thin sliver when exactly one home shortcut is configured.

The bottom row height is derived from the shortcut grid: `HomeTab::doLayout`
computes `gridH` from the shortcut row count and applies it with
`m_bottomRow->setMinHeight(gridH)`. The media and weather card heights are
then derived from that same `gridH`. With a single shortcut the grid is one
row tall, so `gridH` shrinks to a single tile and the cards render too thin.
Two or more shortcuts produce two rows and already look correct.

The fix floors the row count used only for the height computation
(`heightRows = max(rows, 2)`), so one shortcut reserves the same vertical
space as two. Tile sizing still uses the real `rows`, so the shortcut button
itself is unchanged.

## Motivation

With exactly one home shortcut selected, the media/weather widgets in the
Control Center become unusably thin. Adding a second shortcut works around
it, but a single shortcut is a valid configuration and should render the same
row height.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #4374

## Testing

- Traced the layout math in `src/shell/control_center/tabs/home_tab.cpp`:
  for one shortcut, `cols = 1`, `rows = 1`, so `gridH = 1*cellSide + padV`,
  roughly half the two-shortcut height and a third of the six-shortcut
  height, which is the reported collapse. With the fix, `heightRows` is
  floored to 2 and `gridH` matches the two-row case.
- `just format` (clang-format 22.1.8), no changes to the patch.
- `just build` succeeded (exit 0); `home_tab.cpp` compiled and `noctalia`
  linked with no new warnings.

Not visually reproduced on a running instance; the change is a deterministic
one-line height floor and the collapse follows directly from the code path
above.

## Screenshots / Videos

Not captured. Happy to add a before/after if a maintainer wants one.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](../docs/user/) when this PR changes documented behavior or configuration, or this PR does not require documentation changes.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
